### PR TITLE
improve: modify the error message to compatible with go-redis

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -44,7 +44,7 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(
   if (!c_ptr) {
     std::shared_ptr<Cmd> tmp_ptr = std::make_shared<DummyCmd>(DummyCmd());
     tmp_ptr->res().SetRes(CmdRes::kErrOther,
-        "unknown or unsupported command \"" + opt + "\"");
+        "unknown command \"" + opt + "\"");
     return tmp_ptr;
   }
   c_ptr->SetConn(std::dynamic_pointer_cast<PikaClientConn>(shared_from_this()));


### PR DESCRIPTION
go-redis 库在邵兵模式下会检查 hello 命令是否支持，通过“ERR unknown command”判读不支持 hello 命令。
但是 pika 中 不支持的命令报错是“ERR unknown or unsupported command”，故而导致 go-redis 判断错误。
