### PR TITLE
Bug fix : Fix error return when SET NX/XX command fails

### DIFF
--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -94,7 +94,7 @@ void SetCmd::Do(std::shared_ptr<Partition> partition) {
       if (res == 1) {
         res_.SetRes(CmdRes::kOk);
       } else {
-        res_.AppendArrayLen(-1);;
+        res_.AppendStringLen(-1);
       }
     }
   } else {


### PR DESCRIPTION
Fix a bug in the process of executing the SET command. 
When the `SET` command contains parameters: `NX` or `XX` and the execution fails, the wrong RESP information will be written to the i/o buffer: `*-1\r\n` (Null Array), in fact, the correct return format should be: `$-1\r\n` (Null Bulk String), this wrong return will cause some Redis clients to generate some exceptions.
- This PR can fix the problem in this issue: https://github.com/OpenAtomFoundation/pika/issues/1342