### PR TITLE
fix readme about #usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Then compile pika.
 ## Usage
 
 ```
-./output/bin/pika -c ./conf/pika.conf
+./output/pika -c ./conf/pika.conf
 ```
 
 ## Performance


### PR DESCRIPTION
Exec build.sh, which generate binary file is `output/pika` while README told me `output/bin/pika`, thus I try to make them consistent