### PR TITLE
fix: access null pointer

### DIFF
--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -962,13 +962,13 @@ void PikaServer::TryDBSync(const std::string& ip, int port, const std::string& t
                            int32_t top) {
   std::shared_ptr<Partition> partition = GetTablePartitionById(table_name, partition_id);
   if (!partition) {
-    LOG(WARNING) << "Partition: " << partition->GetPartitionName() << " Not Found, TryDBSync Failed";
+    LOG(WARNING) << "Partition_id: " << partition_id << " or Table_name: " << table_name << " Not Found, TryDBSync Failed";
     return;
   }
   std::shared_ptr<SyncMasterPartition> sync_partition =
       g_pika_rm->GetSyncMasterPartitionByName(PartitionInfo(table_name, partition_id));
   if (!sync_partition) {
-    LOG(WARNING) << "Partition: " << sync_partition->SyncPartitionInfo().ToString() << " Not Found, TryDBSync Failed";
+    LOG(WARNING) << "Partition_id: " << partition_id << " or Table_name: " << table_name << " Not Found, TryDBSync Failed";
     return;
   }
   BgSaveInfo bgsave_info = partition->bgsave_info();
@@ -985,7 +985,7 @@ void PikaServer::TryDBSync(const std::string& ip, int port, const std::string& t
 void PikaServer::DbSyncSendFile(const std::string& ip, int port, const std::string& table_name, uint32_t partition_id) {
   std::shared_ptr<Partition> partition = GetTablePartitionById(table_name, partition_id);
   if (!partition) {
-    LOG(WARNING) << "Partition: " << partition->GetPartitionName() << " Not Found, DbSync send file Failed";
+    LOG(WARNING) << "Partition_id: " << partition_id << " or Table_name: " << table_name << " Not Found, DbSync send file Failed";
     return;
   }
 

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -962,13 +962,13 @@ void PikaServer::TryDBSync(const std::string& ip, int port, const std::string& t
                            int32_t top) {
   std::shared_ptr<Partition> partition = GetTablePartitionById(table_name, partition_id);
   if (!partition) {
-    LOG(WARNING) << "Partition_id: " << partition_id << " or Table_name: " << table_name << " Not Found, TryDBSync Failed";
+    LOG(WARNING) << "can not find Partition whose id is " << partition_id << " in table " << table_name << ", TryDBSync Failed";
     return;
   }
   std::shared_ptr<SyncMasterPartition> sync_partition =
       g_pika_rm->GetSyncMasterPartitionByName(PartitionInfo(table_name, partition_id));
   if (!sync_partition) {
-    LOG(WARNING) << "Partition_id: " << partition_id << " or Table_name: " << table_name << " Not Found, TryDBSync Failed";
+    LOG(WARNING) << "can not find Partition whose id is " << partition_id << " in table " << table_name << ", TryDBSync Failed";
     return;
   }
   BgSaveInfo bgsave_info = partition->bgsave_info();
@@ -985,7 +985,7 @@ void PikaServer::TryDBSync(const std::string& ip, int port, const std::string& t
 void PikaServer::DbSyncSendFile(const std::string& ip, int port, const std::string& table_name, uint32_t partition_id) {
   std::shared_ptr<Partition> partition = GetTablePartitionById(table_name, partition_id);
   if (!partition) {
-    LOG(WARNING) << "Partition_id: " << partition_id << " or Table_name: " << table_name << " Not Found, DbSync send file Failed";
+    LOG(WARNING) << "can not find Partition whose id is " << partition_id << " in table " << table_name << ", DbSync send file Failed";
     return;
   }
 


### PR DESCRIPTION
修复了 #1410 中访问空指针的问题，将报错信息修改成 记录table_name 和 partition_id。
同时深入到初始化变量的函数，如`GetTablePartitionById`中发现，初始化返回为NULL时可能是table_name找不到，也可能是partition_id不在table中，因此将报错输出设置成`LOG(WARNING) << "Partition_id: " << partition_id << " or Table_name: " << table_name << " Not Found";` 这样的形式。