### PR TITLE
fix: improved English comments of pika.conf

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -1,39 +1,84 @@
-# Pika port
+# This is Pika configuration file
+#
+# Pika port, the default value is 9221
 port : 9221
-# Thread Number
+
+# The number of threads for running Pika.
+# It's [not recommended] to set this value exceeds
+# the number of CPU cores on the deployment server.
 thread-num : 1
-# Thread Pool Size
+
+# Size of the thread pool, The threads within this pool
+# are dedicated to handling user requests.
 thread-pool-size : 12
-# Sync Thread Number
+
+# The number of threads for Sync, those Sync threads run on slave nodes
+# and are used to execute commands sent from master node.
 sync-thread-num : 6
-# Pika log path
+
+# Directory to store log files of Pika, which contains multiple types of logs,
+# Including: INFO, WARNING, ERROR log, as well as binglog(write2fine) file which
+# is used for synchronization.
 log-path : ./log/
-# Pika db path
+
+# Directory to store the data of Pika
 db-path : ./db/
-# Pika write-buffer-size
-# Supported Units [K|M|G], default unit bytes
+
+# The size of a single RocksDB memtable at the Pika's bottom layer(Pika use RocksDB to store persist data).
+# [Tip] Big write-buffer-size can improve writing performance,
+# but this will generate heavier IO load when flushing from buffer to disk,
+# you should configure it based on you usage scenario.
+# Supported Units [K|M|G], default unit bytes.
 write-buffer-size : 256M
-# size of one block in arena memory allocation.
-# If <= 0, a proper value is automatically calculated
+
+# The size of one block in arena memory allocation.
+# If <= 0, a proper value is automatically calculated.
 # (usually 1/8 of writer-buffer-size, rounded up to a multiple of 4KB)
-# Supported Units [K|M|G], default unit bytes
+# Supported Units [K|M|G], default unit bytes.
 arena-block-size :
-# Pika timeout
+
+# Timeout value of Pika's connection, counting down starts When there are no requests
+# on a connection (it enters sleep state), when the countdown reaches 0, the connection
+# will be closed by Pika.
+# [Tip] The issue of running out of Pika's connections can be avoided if this value
+# is configured properly.
+# [Unit of this value] is second,the default value is 60(s).
 timeout : 60
-# Requirepass
+
+# The [password of administrator], which is empty by default.
+# [NOTICE] If this admin password is the same as user password (including both being empty),
+# the parameter {userpass} will be ignored and all users are considered as administrators,
+# in this scenario, users are not subject to the restrictions imposed by the parameter {userblacklist}.
+# PS: "user password" refers to value of the parameter below: {userpass}.
 requirepass :
-# Masterauth
+
+# Password for synchronization verify, used for authentication when a slave
+# connects to a master to request synchronization.
+# [NOTICE] The value of this parameter must match the "requirepass" setting on the master.
 masterauth :
-# Userpass
+
+# [The password of user], which is empty by default.
+# [NOTICE] If this user password is the same as admin password (including both being empty),
+# the value of this parameter will be ignored and all users are considered as administrators,
+# in this scenario, users are not subject to the restrictions imposed by the parameter {userblacklist}.
+# PS: "admin password" refers to value of the parameter above: {requirepass}.
 userpass :
-# User Blacklist
+
+# The blacklist of orders for users that logged in by {userpass},
+# the orders that added to this list will not be available for those users logged in by {userpass}.
+# [Advice] It's recommended to add high-risk orders to this list.
+# [Format] Orders should be separated by ",". For example: FLUSHALL, SHUTDOWN, KEYS, CONFIG
+# By default, this list is empty.
 userblacklist :
-# if this option is set to 'classic', that means pika support multiple DB, in
-# this mode, option databases enable
+
+# if this option is set to 'classic', that means pika support multiple DB, in this mode,
+# option databases enable.
 # if this option is set to 'sharding', that means pika support multiple Table, you
 # can specify slot num for each table, in this mode, option default-slot-num enable
 # Pika instance mode [classic | sharding]
 instance-mode : classic
+!continue from here!
+
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where
 # dbid is a number between 0 and 'databases' - 1, limited in [1, 8]

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -1,5 +1,7 @@
-# This is Pika configuration file
-#
+###########################
+# Pika configuration file #
+###########################
+
 # Pika port, the default value is 9221
 port : 9221
 
@@ -12,8 +14,8 @@ thread-num : 1
 # are dedicated to handling user requests.
 thread-pool-size : 12
 
-# The number of threads for Sync, those Sync threads run on slave nodes
-# and are used to execute commands sent from master node.
+# The number of Sync threads for Sync, those are the threads work on slave nodes
+# and are used to execute commands sent from master node when synchronizing.
 sync-thread-num : 6
 
 # Directory to store log files of Pika, which contains multiple types of logs,
@@ -21,35 +23,35 @@ sync-thread-num : 6
 # is used for synchronization.
 log-path : ./log/
 
-# Directory to store the data of Pika
+# Directory to store the data of Pika.
 db-path : ./db/
 
 # The size of a single RocksDB memtable at the Pika's bottom layer(Pika use RocksDB to store persist data).
 # [Tip] Big write-buffer-size can improve writing performance,
 # but this will generate heavier IO load when flushing from buffer to disk,
 # you should configure it based on you usage scenario.
-# Supported Units [K|M|G], default unit bytes.
+# Supported Units [K|M|G], write-buffer-size default unit is bytes.
 write-buffer-size : 256M
 
 # The size of one block in arena memory allocation.
 # If <= 0, a proper value is automatically calculated.
 # (usually 1/8 of writer-buffer-size, rounded up to a multiple of 4KB)
-# Supported Units [K|M|G], default unit bytes.
+# Supported Units [K|M|G], arena-block-size default unit is bytes.
 arena-block-size :
 
-# Timeout value of Pika's connection, counting down starts When there are no requests
+# Timeout of Pika's connection, counting down starts When there are no requests
 # on a connection (it enters sleep state), when the countdown reaches 0, the connection
 # will be closed by Pika.
-# [Tip] The issue of running out of Pika's connections can be avoided if this value
+# [Tip] The issue of running out of Pika's connections may be avoided if this value
 # is configured properly.
-# [Unit of this value] is second,the default value is 60(s).
+# Unit of timeout is [seconds] and the default value is 60(s).
 timeout : 60
 
 # The [password of administrator], which is empty by default.
 # [NOTICE] If this admin password is the same as user password (including both being empty),
-# the parameter {userpass} will be ignored and all users are considered as administrators,
-# in this scenario, users are not subject to the restrictions imposed by the parameter {userblacklist}.
-# PS: "user password" refers to value of the parameter below: {userpass}.
+# the value of userpass will be ignored and all users are considered as administrators,
+# in this scenario, users are not subject to the restrictions imposed by the userblacklist.
+# PS: "user password" refers to value of the parameter below: userpass.
 requirepass :
 
 # Password for synchronization verify, used for authentication when a slave
@@ -57,130 +59,222 @@ requirepass :
 # [NOTICE] The value of this parameter must match the "requirepass" setting on the master.
 masterauth :
 
-# [The password of user], which is empty by default.
+# The [password of user], which is empty by default.
 # [NOTICE] If this user password is the same as admin password (including both being empty),
 # the value of this parameter will be ignored and all users are considered as administrators,
-# in this scenario, users are not subject to the restrictions imposed by the parameter {userblacklist}.
-# PS: "admin password" refers to value of the parameter above: {requirepass}.
+# in this scenario, users are not subject to the restrictions imposed by the parameter userblacklist.
+# PS: "admin password" refers to value of the parameter above: requirepass.
 userpass :
 
-# The blacklist of orders for users that logged in by {userpass},
-# the orders that added to this list will not be available for those users logged in by {userpass}.
+# The blacklist of orders for users that logged in by userpass,
+# the orders that added to this list will not be available for users except for administrator.
 # [Advice] It's recommended to add high-risk orders to this list.
 # [Format] Orders should be separated by ",". For example: FLUSHALL, SHUTDOWN, KEYS, CONFIG
 # By default, this list is empty.
 userblacklist :
 
-# if this option is set to 'classic', that means pika support multiple DB, in this mode,
+# Running Mode of Pika.
+# If this mode is set to 'classic', meas Pika support multiple DB, in this mode,
 # option databases enable.
-# if this option is set to 'sharding', that means pika support multiple Table, you
-# can specify slot num for each table, in this mode, option default-slot-num enable
-# Pika instance mode [classic | sharding]
+# If this mode is set to 'sharding', means pika support multiple Table, you can
+# specify slot num for each table, in this mode, option default-slot-num enable.
+# Pika supports two instance modes:  [classic | sharding]
 instance-mode : classic
-!continue from here!
 
-# Set the number of databases. The default database is DB 0, you can select
-# a different one on a per-connection basis using SELECT <dbid> where
-# dbid is a number between 0 and 'databases' - 1, limited in [1, 8]
+# The number of databases when Pika runs in classic mode.
+# The default database is DB 0, you can select a different one on
+# a per-connection basis using SELECT <dbid> where dbid is
+# a number between 0 and 'databases' - 1.
+# the [value range] of this parameter is [1, 8]
 databases : 1
-# default slot number each table in sharding mode
+
+# The default slot number of each table when Pika runs in sharding mode.
 default-slot-num : 1024
-# replication num defines how many followers in a single raft group, only [0, 1, 2, 3, 4] is valid
+
+# The number of  followers in a single raft group, only [0, 1, 2, 3, 4] is valid.
+# By default, this num is set to 0, which means this feature is [not enabled].
 replication-num : 0
-# consensus level defines how many confirms does leader get, before commit this log to client,
-#                 only [0, ...replicaiton-num] is valid
+
+# consensus level defines the num of confirms(ACKs) the leader node needs to receive from
+# follower nodes before returning the result to the client that sent the request.
+# The [value range] of this parameter is: [0, ...replicaiton-num].
+# Default value of consensus-level is 0, means this feature is not enabled.
 consensus-level : 0
-# Dump Prefix
+
+# The Prefix of dump file's name.
+# All the files that generated by order "bgsave" will be name with this prefix.
 dump-prefix :
-# daemonize  [yes | no]
+
+# daemonize  [yes | no].
 #daemonize : yes
-# Dump Path
+
+# The directory to stored dump files that generated by order "bgsave".
 dump-path : ./dump/
-# Expire-dump-days
+
+# Expire-time of dump files that generated by order "bgsave".
+# Any dump files that exceed this expire time will be cleaned up.
+# Unit of dump-expire is [days] and the default value is 0(days),
+# which means dump files never expire.
 dump-expire : 0
-# pidfile Path
+
+# Pid file Path of Pika.
 pidfile : ./pika.pid
-# Max Connection
+
+# The Maximum number of Pika's Connection.
 maxclients : 20000
-# the per file size of sst to compact, default is 20M
-# Supported Units [K|M|G], default unit bytes
+
+# The size of sst file in rocksDB(Pika is based on rocksDB).
+# sst files are hierarchical, the smaller the sst file size, the faster of performance and the lower merge cost,
+# the price is the number of sst files could be huge. On the contrary, when the size of sst file is bigger,
+# the number of files is fewer, but the merge cost is higher and the performance slower.
+# Supported Units [K|M|G], target-file-size-base default unit is bytes and the default value is 20M.
 target-file-size-base : 20M
-# Expire-logs-days
+
+# Expire-time of binlog(write2file) files that stored within log-path.
+# Any binlog(write2file) files that exceed this expire time will be cleaned up.
+# Unit of expire-logs-days is [days] and the default value is 7(days).
+# The [Minimum value] of this parameter is 1(day).
 expire-logs-days : 7
-# Expire-logs-nums
+
+# The maximum number of binlog(write2file) files.
+# Once the total number of binlog files exceed this value,
+# automatic cleaning will start to ensure the maximum number
+# of binlog files is equal to expire-logs-nums.
+# The [Minimum value] of this parameter is 10.
 expire-logs-nums : 10
-# Root-connection-num
+
+# The number of guaranteed connections for root user.
+# This parameter guarantees that there are 2(By default) connections available
+# for root user to log in Pika from 127.0.0.1, even if the maximum connection limit is reached.
+# PS: The maximum connection refers to the parameter above: maxclients.
+# root-connection-num default value is 2.
 root-connection-num : 2
+
 # Slowlog-write-errorlog
 slowlog-write-errorlog : no
-# Slowlog-log-slower-than
+
+# The time threshold for slow log recording.
+# Any command whose execution time exceeds this threshold will be recorded in pika-ERROR.log,
+# which is stored in log-path.
+# The unit of slowlog-log-slower-than is [microseconds(μs)] and the default value is 10000 μs / 10 ms.
 slowlog-log-slower-than : 10000
+
 # Slowlog-max-len
 slowlog-max-len : 128
+
 # Pika db sync path
 db-sync-path : ./dbsync/
-# db sync speed(MB) max is set to 1024MB, min is set to 0, and if below 0 or above 1024, the value will be adjust to 1024
+
+# The maximum Transmission speed during full synchronization.
+# The Exhaustion of network resources can be prevented by setting this parameter properly.
+# The value range of this parameter is [1,1024], with unit of MB/s.
+# [NOTICE] If this parameter is set to an invalid value(smaller than 0 or bigger than 1024),
+# it will be automatically reset to 1024.
+# db-sync-speed default value is -1 (1024MB/s).
 db-sync-speed : -1
-# The slave priority
+
+# The priority of slave node when electing new master node.
+# The slave node with [lower] value of slave-priority will have [higher priority] to be elected as the new master node.
+# This parameter is only used in conjunction with sentinel and serves no other purpose.
+# slave-priority default value is 100.
 slave-priority : 100
-# network interface
+
+# Specify network interface that work with Pika.
 #network-interface : eth1
-# replication
+
+# The IP and port of the master node are specified by this parameter for
+# synchronization between master and slaves.
+# [Format] is "ip:port" , for example: "192.168.1.2:6666" indicates that
+# the slave instances that configured with this value will automatically send
+# synchronization requests to port 6666 of 192.168.1.2 after startup.
+# This parameter should be configured on slave nodes.
 #slaveof : master-ip:master-port
 
-# CronTask, format 1: start-end/ratio, like 02-04/60, pika will check to schedule compaction between 2 to 4 o'clock everyday
-#                   if the freesize/disksize > 60%.
-#           format 2: week/start-end/ratio, like 3/02-04/60, pika will check to schedule compaction between 2 to 4 o'clock
-#                   every wednesday, if the freesize/disksize > 60%.
-#           NOTICE: if compact-interval is set, compact-cron will be mask and disable.
+
+# Daily/Weekly Automatic full compaction task is configured by compact-cron.
+#
+#  [Format-daily]: start time(hour)-end time(hour)/disk-free-space-ratio,
+#  example: with value of "02-04/60", Pika will perform full compaction task between 2:00-4:00 AM everyday if
+#  the disk-free-size / disk-size > 60%.
+#
+#  [Format-weekly]: week/start time(hour)-end time(hour)/disk-free-space-ratio,
+#  example: with value of "3/02-04/60", Pika will perform full compaction task between 2:00-4:00 AM every Wednesday if
+#  the disk-free-size / disk-size > 60%.
+#
+#  [Tip] Automatic full compaction is suitable for scenarios with multiple data structures
+#  and lots of items are expired or deleted, or key names are frequently reused.
+#
+#  [NOTICE]: If compact-interval is set, compact-cron will be masked and disabled.
 #
 #compact-cron : 3/02-04/60
 
-# Compact-interval, format: interval/ratio, like 6/60, pika will check to schedule compaction every 6 hours,
-#                           if the freesize/disksize > 60%. NOTICE:compact-interval is prior than compact-cron;
+
+# Automatic full synchronization task between a time interval is configured by compact-interval.
+# [Format]: time interval(hour)/disk-free-space-ratio, example: "6/60", Pika will perform full compaction every 6 hours,
+# if the disk-free-size / disk-size > 60%.
+# [NOTICE]: compact-interval is prior than compact-cron.
 #compact-interval :
 
-# the size of flow control window while sync binlog between master and slave.Default is 9000 and the maximum is 90000.
+# The size of flow control windows while sync binlog between master and slave.
+# This window-size determines the amount of data that can be transmitted in a single synchronization process.
+# [Tip] In the scenario of high network latency, Increasing this size can improve synchronization efficiency.
+# sync-window-size Default is 9000 and the [maximum] value is 90000.
 sync-window-size : 9000
-# max value of connection read buffer size: configurable value 67108864(64MB) or 268435456(256MB) or 536870912(512MB)
-#                                           default value is 268435456(256MB)
-#                                           NOTICE: master and slave should share exactly the same value
-# Supported Units [K|M|G], default unit bytes
+
+# Maximum buffer size of a client connection.
+# Only three values are valid here: [67108864(64MB) | 268435456(256MB) | 536870912(512MB)].
+# [NOTICE] Master and slaves must have exactly the same value for the max-conn-rbuf-size.
+# Supported Units [K|M|G], max-conn-rbuf-size default unit is bytes and the default value is 268435456(256MB).
 max-conn-rbuf-size : 268435456
 
 
-###################
-## Critical Settings
-###################
+#######################
+#! Critical Settings !#
+#######################
 # write_binlog  [yes | no]
 write-binlog : yes
-# binlog file size: default is 100M,  limited in [1K, 2G]
-# slave binlog file size must be the same with master's
-# Supported Units [K|M|G], default unit bytes
+
+# The size of binlog file, which can not be modified once Pika instance started.
+# [NOTICE] Master and slaves must have exactly the same value for the binlog-file-size.
+# The [value range] of binlog-file-size is [1K, 2G].
+# Supported Units [K|M|G], binlog-file-size default unit is bytes and the default value is 100M.
 binlog-file-size : 104857600
-# Automatically triggers a small compaction according statistics
+
+# Automatically triggers a small compaction according to statistics
 # Use the cache to store up to 'max-cache-statistic-keys' keys
-# if 'max-cache-statistic-keys' set to '0', that means turn off the statistics function
-# it also doesn't automatically trigger a small compact feature
+# If 'max-cache-statistic-keys' set to '0', that means turn off the statistics function
+# and this automatic small compaction feature is disabled.
 max-cache-statistic-keys : 0
+
 # When 'delete' or 'overwrite' a specific multi-data structure key 'small-compaction-threshold' times,
-# a small compact is triggered automatically, default is 5000, limited in [1, 100000]
+# a small compact is triggered automatically if the small compaction feature is enabled.
+# small-compaction-threshold default value is 5000 and the value range is [1, 100000].
 small-compaction-threshold : 5000
-# If the total size of all live memtables of all the DBs exceeds
-# the limit, a flush will be triggered in the next DB to which the next write
-# is issued.
-# Supported Units [K|M|G], default unit bytes
+
+# The maximum total size of all live memtables of the rocksDB instance that owned by Pika.
+# Flushing from memtable to disk will be triggered if the actual memory usage of rocksDB
+# exceeds max-write-buffer-size when next write operation is issued.
+# [Rocksdb-Basic-Tuning](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning)
+# Supported Units [K|M|G], max-write-buffer-size default unit is bytes.
 max-write-buffer-size : 10737418240
+
 # The maximum number of write buffers that are built up in memory for one ColumnFamily in DB.
 # The default and the minimum number is 2, so that when 1 write buffer
 # is being flushed to storage, new writes can continue to the other write buffer.
 # If max-write-buffer-num > 3, writing will be slowed down
 # if we are writing to the last write buffer allowed.
 max-write-buffer-num : 2
-# Limit some command response size, like Scan, Keys*
-# Supported Units [K|M|G], default unit bytes
+
+# The limit of response size,
+# which can prevent memory exhaustion caused by commands like 'keys *' and 'Scan' that can generate huge response.
+# Supported Units [K|M|G], max-client-response-size default unit is bytes.
 max-client-response-size : 1073741824
-# Compression type supported [snappy, zlib, lz4, zstd], if not compression required, set `none`
+
+# The Compression type Pika to use,
+# which can not be modified once Pika instance started.
+# Supported types: [snappy, zlib, lz4, zstd], if compression is not required, set to `none`.
+# [NOTICE] The official binary release of Pika provides static linking with the default Snappy compression.
+# If other compression methods are needed, please download the corresponding static library and compile it yourself.
 compression : snappy
 
 # if the vector size is smaller than the level number, the undefined lower level uses the
@@ -191,16 +285,24 @@ compression : snappy
 # When this configurable is enabled, compression is ignored,
 # default l0 l1 noCompression, l2 and more use `compression` option
 # https://github.com/facebook/rocksdb/wiki/Compression
-# compression_per_level : [none:none:snappy:lz4:lz4]
+#compression_per_level : [none:none:snappy:lz4:lz4]
 
-# max-background-flushes: default is 1, limited in [1, 4]
+# The number of background flushing threads.
+# max-background-flushes default value is 1, value range is [1, 4].
 max-background-flushes : 1
-# max-background-compactions: default is 2, limited in [1, 8]
+
+# The number of background compacting threads.
+# max-background-compactions default value is 2, value range is [1, 8].
 max-background-compactions : 2
+
 # maximum value of Rocksdb cached open file descriptors
 max-cache-files : 5000
-# max_bytes_for_level_multiplier: default is 10, you can change it to 5
+
+# The Factor used in Pika engine to control the multiplier relationship between each level
+# and the total capacity of the previous level.
+# max_bytes_for_level_multiplier default value is 10(x), another valid value is 5(x).
 max-bytes-for-level-multiplier : 10
+
 # BlockBasedTable block_size, default 4k
 # block-size: 4096
 # block LRU cache, default 8M, 0 to disable

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -2,11 +2,12 @@
 # Pika configuration file #
 ###########################
 
-# Pika port, the default value is 9221
+# Pika port, the default value is 9221.
+# If it's still valid, +100/+200 magic offsets could be applied.
 port : 9221
 
 # The number of threads for running Pika.
-# It's [not recommended] to set this value exceeds
+# It's not recommended to set this value exceeds
 # the number of CPU cores on the deployment server.
 thread-num : 1
 
@@ -14,8 +15,8 @@ thread-num : 1
 # are dedicated to handling user requests.
 thread-pool-size : 12
 
-# The number of Sync threads for Sync, those are the threads work on slave nodes
-# and are used to execute commands sent from master node when synchronizing.
+# The number of sync-thread for data replication from master, those are the threads work on slave nodes
+# and are used to execute commands sent from master node when replicating.
 sync-thread-num : 6
 
 # Directory to store log files of Pika, which contains multiple types of logs,
@@ -30,13 +31,13 @@ db-path : ./db/
 # [Tip] Big write-buffer-size can improve writing performance,
 # but this will generate heavier IO load when flushing from buffer to disk,
 # you should configure it based on you usage scenario.
-# Supported Units [K|M|G], write-buffer-size default unit is bytes.
+# Supported Units [K|M|G], write-buffer-size default unit is in [bytes].
 write-buffer-size : 256M
 
 # The size of one block in arena memory allocation.
 # If <= 0, a proper value is automatically calculated.
 # (usually 1/8 of writer-buffer-size, rounded up to a multiple of 4KB)
-# Supported Units [K|M|G], arena-block-size default unit is bytes.
+# Supported Units [K|M|G], arena-block-size default unit is in [bytes].
 arena-block-size :
 
 # Timeout of Pika's connection, counting down starts When there are no requests
@@ -44,7 +45,7 @@ arena-block-size :
 # will be closed by Pika.
 # [Tip] The issue of running out of Pika's connections may be avoided if this value
 # is configured properly.
-# Unit of timeout is [seconds] and the default value is 60(s).
+# The Unit of timeout is in [seconds] and its default value is 60(s).
 timeout : 60
 
 # The [password of administrator], which is empty by default.
@@ -54,66 +55,66 @@ timeout : 60
 # PS: "user password" refers to value of the parameter below: userpass.
 requirepass :
 
-# Password for synchronization verify, used for authentication when a slave
-# connects to a master to request synchronization.
+# Password for replication verify, used for authentication when a slave
+# connects to a master to request replication.
 # [NOTICE] The value of this parameter must match the "requirepass" setting on the master.
 masterauth :
 
 # The [password of user], which is empty by default.
 # [NOTICE] If this user password is the same as admin password (including both being empty),
 # the value of this parameter will be ignored and all users are considered as administrators,
-# in this scenario, users are not subject to the restrictions imposed by the parameter userblacklist.
+# in this scenario, users are not subject to the restrictions imposed by the userblacklist.
 # PS: "admin password" refers to value of the parameter above: requirepass.
 userpass :
 
-# The blacklist of orders for users that logged in by userpass,
-# the orders that added to this list will not be available for users except for administrator.
-# [Advice] It's recommended to add high-risk orders to this list.
-# [Format] Orders should be separated by ",". For example: FLUSHALL, SHUTDOWN, KEYS, CONFIG
+# The blacklist of commands for users that logged in by userpass,
+# the commands that added to this list will not be available for users except for administrator.
+# [Advice] It's recommended to add high-risk commands to this list.
+# [Format] Commands should be separated by ",". For example: FLUSHALL, SHUTDOWN, KEYS, CONFIG
 # By default, this list is empty.
 userblacklist :
 
 # Running Mode of Pika.
-# If this mode is set to 'classic', meas Pika support multiple DB, in this mode,
-# option databases enable.
-# If this mode is set to 'sharding', means pika support multiple Table, you can
-# specify slot num for each table, in this mode, option default-slot-num enable.
+# If set to 'classic', Pika will create multiple DBs whose number is the value of configure item "databases".
+# Meanwhile the following configure item "databases" is valid and the "default-slot-num" is disabled.
+# If set to 'sharding', Pika will create multiple Tables whose number is the value of configure item "default-slot-num".
+# Meanwhile the following configure item "default-slot-num" is valid and the "databases" is disabled.
 # Pika supports two instance modes:  [classic | sharding]
 instance-mode : classic
 
+
 # The number of databases when Pika runs in classic mode.
-# The default database is DB 0, you can select a different one on
-# a per-connection basis using SELECT <dbid> where dbid is
-# a number between 0 and 'databases' - 1.
-# the [value range] of this parameter is [1, 8]
+# The default database id is DB 0. You can select a different one on
+# a per-connection by using SELECT. The db id range is [0, 'databases' value -1].
+# The value range of this parameter is [1, 8].
 databases : 1
 
 # The default slot number of each table when Pika runs in sharding mode.
 default-slot-num : 1024
 
-# The number of  followers in a single raft group, only [0, 1, 2, 3, 4] is valid.
+# The number of followers of a master. Only [0, 1, 2, 3, 4] is valid at present.
 # By default, this num is set to 0, which means this feature is [not enabled].
 replication-num : 0
 
 # consensus level defines the num of confirms(ACKs) the leader node needs to receive from
 # follower nodes before returning the result to the client that sent the request.
 # The [value range] of this parameter is: [0, ...replicaiton-num].
-# Default value of consensus-level is 0, means this feature is not enabled.
+# Default value of consensus-level is 0, which means this feature is not enabled.
 consensus-level : 0
 
 # The Prefix of dump file's name.
-# All the files that generated by order "bgsave" will be name with this prefix.
+# All the files that generated by command "bgsave" will be name with this prefix.
 dump-prefix :
 
 # daemonize  [yes | no].
 #daemonize : yes
 
-# The directory to stored dump files that generated by order "bgsave".
+# The directory to stored dump files that generated by command "bgsave".
 dump-path : ./dump/
 
-# Expire-time of dump files that generated by order "bgsave".
-# Any dump files that exceed this expire time will be cleaned up.
-# Unit of dump-expire is [days] and the default value is 0(days),
+# TTL of dump files that generated by command "bgsave".
+# Any dump files which exceed this TTL will be deleted.
+# Unit of dump-expire is in [days] and the default value is 0(day),
 # which means dump files never expire.
 dump-expire : 0
 
@@ -123,16 +124,16 @@ pidfile : ./pika.pid
 # The Maximum number of Pika's Connection.
 maxclients : 20000
 
-# The size of sst file in rocksDB(Pika is based on rocksDB).
-# sst files are hierarchical, the smaller the sst file size, the faster of performance and the lower merge cost,
-# the price is the number of sst files could be huge. On the contrary, when the size of sst file is bigger,
-# the number of files is fewer, but the merge cost is higher and the performance slower.
-# Supported Units [K|M|G], target-file-size-base default unit is bytes and the default value is 20M.
+# The size of sst file in RocksDB(Pika is based on RocksDB).
+# sst files are hierarchical, the smaller the sst file size, the higher the performance and the lower the merge cost,
+# the price is that the number of sst files could be huge. On the contrary, the bigger the sst file size, the lower
+# the performance and the higher the merge cost, while the number of files is fewer.
+# Supported Units [K|M|G], target-file-size-base default unit is in [bytes] and the default value is 20M.
 target-file-size-base : 20M
 
 # Expire-time of binlog(write2file) files that stored within log-path.
 # Any binlog(write2file) files that exceed this expire time will be cleaned up.
-# Unit of expire-logs-days is [days] and the default value is 7(days).
+# The unit of expire-logs-days is in [days] and the default value is 7(days).
 # The [Minimum value] of this parameter is 1(day).
 expire-logs-days : 7
 
@@ -156,7 +157,7 @@ slowlog-write-errorlog : no
 # The time threshold for slow log recording.
 # Any command whose execution time exceeds this threshold will be recorded in pika-ERROR.log,
 # which is stored in log-path.
-# The unit of slowlog-log-slower-than is [microseconds(μs)] and the default value is 10000 μs / 10 ms.
+# The unit of slowlog-log-slower-than is in [microseconds(μs)] and the default value is 10000 μs / 10 ms.
 slowlog-log-slower-than : 10000
 
 # Slowlog-max-len
@@ -166,11 +167,11 @@ slowlog-max-len : 128
 db-sync-path : ./dbsync/
 
 # The maximum Transmission speed during full synchronization.
-# The Exhaustion of network resources can be prevented by setting this parameter properly.
-# The value range of this parameter is [1,1024], with unit of MB/s.
+# The exhaustion of network can be prevented by setting this parameter properly.
+# The value range of this parameter is [1,1024] with unit in [MB/s].
 # [NOTICE] If this parameter is set to an invalid value(smaller than 0 or bigger than 1024),
 # it will be automatically reset to 1024.
-# db-sync-speed default value is -1 (1024MB/s).
+# Its value is -1 (1024MB/s).
 db-sync-speed : -1
 
 # The priority of slave node when electing new master node.
@@ -215,16 +216,15 @@ slave-priority : 100
 # [NOTICE]: compact-interval is prior than compact-cron.
 #compact-interval :
 
-# The size of flow control windows while sync binlog between master and slave.
 # This window-size determines the amount of data that can be transmitted in a single synchronization process.
-# [Tip] In the scenario of high network latency, Increasing this size can improve synchronization efficiency.
-# sync-window-size Default is 9000 and the [maximum] value is 90000.
+# [Tip] In the scenario of high network latency. Increasing this size can improve synchronization efficiency.
+# Its default value is 9000. the [maximum] value is 90000.
 sync-window-size : 9000
 
 # Maximum buffer size of a client connection.
 # Only three values are valid here: [67108864(64MB) | 268435456(256MB) | 536870912(512MB)].
 # [NOTICE] Master and slaves must have exactly the same value for the max-conn-rbuf-size.
-# Supported Units [K|M|G], max-conn-rbuf-size default unit is bytes and the default value is 268435456(256MB).
+# Supported Units [K|M|G]. Its default unit is in [bytes] and its default value is 268435456(256MB).
 max-conn-rbuf-size : 268435456
 
 
@@ -237,7 +237,7 @@ write-binlog : yes
 # The size of binlog file, which can not be modified once Pika instance started.
 # [NOTICE] Master and slaves must have exactly the same value for the binlog-file-size.
 # The [value range] of binlog-file-size is [1K, 2G].
-# Supported Units [K|M|G], binlog-file-size default unit is bytes and the default value is 100M.
+# Supported Units [K|M|G], binlog-file-size default unit is in [bytes] and the default value is 100M.
 binlog-file-size : 104857600
 
 # Automatically triggers a small compaction according to statistics
@@ -251,30 +251,28 @@ max-cache-statistic-keys : 0
 # small-compaction-threshold default value is 5000 and the value range is [1, 100000].
 small-compaction-threshold : 5000
 
-# The maximum total size of all live memtables of the rocksDB instance that owned by Pika.
-# Flushing from memtable to disk will be triggered if the actual memory usage of rocksDB
+# The maximum total size of all live memtables of the RocksDB instance that owned by Pika.
+# Flushing from memtable to disk will be triggered if the actual memory usage of RocksDB
 # exceeds max-write-buffer-size when next write operation is issued.
 # [Rocksdb-Basic-Tuning](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning)
-# Supported Units [K|M|G], max-write-buffer-size default unit is bytes.
+# Supported Units [K|M|G], max-write-buffer-size default unit is in [bytes].
 max-write-buffer-size : 10737418240
 
-# The maximum number of write buffers that are built up in memory for one ColumnFamily in DB.
-# The default and the minimum number is 2, so that when 1 write buffer
-# is being flushed to storage, new writes can continue to the other write buffer.
-# If max-write-buffer-num > 3, writing will be slowed down
-# if we are writing to the last write buffer allowed.
+# The maximum number of write buffers(memtables) that are built up in memory for one ColumnFamily in DB.
+# The default and the minimum number is 2. It means that Pika(RocksDB) will write to a write buffer
+# when it flushes the data of another write buffer to storage.
+# If max-write-buffer-num > 3, writing will be slowed down.
 max-write-buffer-num : 2
 
-# The limit of response size,
-# which can prevent memory exhaustion caused by commands like 'keys *' and 'Scan' that can generate huge response.
-# Supported Units [K|M|G], max-client-response-size default unit is bytes.
+# The maximum size of the response package to client to prevent memory
+# exhaustion caused by commands like 'keys *' and 'Scan' which can generate huge response.
+# Supported Units [K|M|G]. The default unit is in [bytes].
 max-client-response-size : 1073741824
 
-# The Compression type Pika to use,
-# which can not be modified once Pika instance started.
-# Supported types: [snappy, zlib, lz4, zstd], if compression is not required, set to `none`.
-# [NOTICE] The official binary release of Pika provides static linking with the default Snappy compression.
-# If other compression methods are needed, please download the corresponding static library and compile it yourself.
+# The compression algorithm. You can not change it when Pika started.
+# Supported types: [snappy, zlib, lz4, zstd]. If you do not wanna compress the SST file, please set its value as none.
+# [NOTICE] The Pika official binary release just linking the snappy library statically, which means that
+# you should compile the Pika from the source code and then link it with other compression algorithm library statically by yourself.
 compression : snappy
 
 # if the vector size is smaller than the level number, the undefined lower level uses the
@@ -298,15 +296,14 @@ max-background-compactions : 2
 # maximum value of Rocksdb cached open file descriptors
 max-cache-files : 5000
 
-# The Factor used in Pika engine to control the multiplier relationship between each level
-# and the total capacity of the previous level.
-# max_bytes_for_level_multiplier default value is 10(x), another valid value is 5(x).
+# The ratio between the total size of RocksDB level-(L+1) files and the total size of RocksDB level-L files for all L.
+# Its default value is 10(x). You can also change it to 5(x).
 max-bytes-for-level-multiplier : 10
 
 # BlockBasedTable block_size, default 4k
 # block-size: 4096
 # block LRU cache, default 8M, 0 to disable
-# Supported Units [K|M|G], default unit bytes
+# Supported Units [K|M|G], default unit [bytes]
 # block-cache: 8388608
 # num-shard-bits default -1, the number of bits from cache keys to be use as shard id.
 # The cache will be sharded into 2^num_shard_bits shards.

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -94,7 +94,8 @@ databases : 1
 default-slot-num : 1024
 
 # The number of followers of a master. Only [0, 1, 2, 3, 4] is valid at present.
-# By default, this num is set to 0, which means this feature is [not enabled].
+# By default, this num is set to 0, which means this feature is [not enabled]
+# and the Pika runs in standalone mode.
 replication-num : 0
 
 # consensus level defines the num of confirms(ACKs) the leader node needs to receive from

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -3,7 +3,8 @@
 ###########################
 
 # Pika port, the default value is 9221.
-# If it's still valid, +100/+200 magic offsets could be applied.
+# [NOTICE] Port Magic offsets of port+1000 / port+2000 are used by Pika at present,
+# Port 10221 is used for Rsync, and port 11221 is used for Replication, while the listening port is 9221.
 port : 9221
 
 # The number of threads for running Pika.
@@ -21,7 +22,7 @@ sync-thread-num : 6
 
 # Directory to store log files of Pika, which contains multiple types of logs,
 # Including: INFO, WARNING, ERROR log, as well as binglog(write2fine) file which
-# is used for synchronization.
+# is used for replication.
 log-path : ./log/
 
 # Directory to store the data of Pika.
@@ -99,7 +100,7 @@ replication-num : 0
 # consensus level defines the num of confirms(ACKs) the leader node needs to receive from
 # follower nodes before returning the result to the client that sent the request.
 # The [value range] of this parameter is: [0, ...replicaiton-num].
-# Default value of consensus-level is 0, which means this feature is not enabled.
+# The default value of consensus-level is 0, which means this feature is not enabled.
 consensus-level : 0
 
 # The Prefix of dump file's name.
@@ -148,7 +149,7 @@ expire-logs-nums : 10
 # This parameter guarantees that there are 2(By default) connections available
 # for root user to log in Pika from 127.0.0.1, even if the maximum connection limit is reached.
 # PS: The maximum connection refers to the parameter above: maxclients.
-# root-connection-num default value is 2.
+# The default value of root-connection-num is 2.
 root-connection-num : 2
 
 # Slowlog-write-errorlog
@@ -171,23 +172,23 @@ db-sync-path : ./dbsync/
 # The value range of this parameter is [1,1024] with unit in [MB/s].
 # [NOTICE] If this parameter is set to an invalid value(smaller than 0 or bigger than 1024),
 # it will be automatically reset to 1024.
-# Its value is -1 (1024MB/s).
+# The default value of db-sync-speed is -1 (1024MB/s).
 db-sync-speed : -1
 
 # The priority of slave node when electing new master node.
 # The slave node with [lower] value of slave-priority will have [higher priority] to be elected as the new master node.
 # This parameter is only used in conjunction with sentinel and serves no other purpose.
-# slave-priority default value is 100.
+# The default value of slave-priority is 100.
 slave-priority : 100
 
 # Specify network interface that work with Pika.
 #network-interface : eth1
 
 # The IP and port of the master node are specified by this parameter for
-# synchronization between master and slaves.
+# replication between master and slaves.
 # [Format] is "ip:port" , for example: "192.168.1.2:6666" indicates that
 # the slave instances that configured with this value will automatically send
-# synchronization requests to port 6666 of 192.168.1.2 after startup.
+# SLAVEOF command to port 6666 of 192.168.1.2 after startup.
 # This parameter should be configured on slave nodes.
 #slaveof : master-ip:master-port
 
@@ -254,7 +255,7 @@ small-compaction-threshold : 5000
 # The maximum total size of all live memtables of the RocksDB instance that owned by Pika.
 # Flushing from memtable to disk will be triggered if the actual memory usage of RocksDB
 # exceeds max-write-buffer-size when next write operation is issued.
-# [Rocksdb-Basic-Tuning](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning)
+# [RocksDB-Basic-Tuning](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning)
 # Supported Units [K|M|G], max-write-buffer-size default unit is in [bytes].
 max-write-buffer-size : 10737418240
 
@@ -286,14 +287,14 @@ compression : snappy
 #compression_per_level : [none:none:snappy:lz4:lz4]
 
 # The number of background flushing threads.
-# max-background-flushes default value is 1, value range is [1, 4].
+# max-background-flushes default value is 1 and the value range is [1, 4].
 max-background-flushes : 1
 
 # The number of background compacting threads.
-# max-background-compactions default value is 2, value range is [1, 8].
+# max-background-compactions default value is 2 and the value range is [1, 8].
 max-background-compactions : 2
 
-# maximum value of Rocksdb cached open file descriptors
+# maximum value of RocksDB cached open file descriptors
 max-cache-files : 5000
 
 # The ratio between the total size of RocksDB level-(L+1) files and the total size of RocksDB level-L files for all L.

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -3,7 +3,7 @@
 ###########################
 
 # Pika port, the default value is 9221.
-# [NOTICE] Port Magic offsets of port+1000 / port+2000 are used by Pika at present,
+# [NOTICE] Port Magic offsets of port+1000 / port+2000 are used by Pika at present.
 # Port 10221 is used for Rsync, and port 11221 is used for Replication, while the listening port is 9221.
 port : 9221
 


### PR DESCRIPTION
Revised most of the English comments of pika.conf, based on its [Chinese Description](https://github.com/OpenAtomFoundation/pika/wiki/pika-%E9%85%8D%E7%BD%AE%E6%96%87%E4%BB%B6%E8%AF%B4%E6%98%8E).

PS: For the parameters that has shown in pika.conf but can not be found in its Chinese Description, keep them as they were.