### PR TITLE
fix: modify invalid link

### DIFF
--- a/codis/cmd/fe/assets/node_modules/bootstrap/README.md
+++ b/codis/cmd/fe/assets/node_modules/bootstrap/README.md
@@ -95,7 +95,7 @@ Documentation for v2.3.2 has been made available for the time being at <http://g
 
 ## Contributing
 
-Please read through our [contributing guidelines](https://github.com/twbs/bootstrap/blob/master/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
+Please read through our [contributing guidelines](https://github.com/twbs/bootstrap/blob/master/.github/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
 
 Moreover, if your pull request contains JavaScript patches or features, you must include [relevant unit tests](https://github.com/twbs/bootstrap/tree/master/js/tests). All HTML and CSS should conform to the [Code Guide](https://github.com/mdo/code-guide), maintained by [Mark Otto](https://github.com/mdo).
 


### PR DESCRIPTION
…ING.md 改为 https://github.com/twbs/bootstrap/blob/master/.github/CONTRIBUTING.md

这个贡献者的链接错误无法打开