### PR TITLE
feat: add clang-format shell script

### DIFF
--- a/format_code.sh
+++ b/format_code.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+find include src pika-tools -regex '.*\.\(cpp\|hpp\|c\|h\)' | xargs clang-format -i
+
+
+# If you want to automatically format your code before git commit
+# append the code to .git/hooks/pre-commit
+#
+# for FILE in $(git diff --cached --name-only | grep -E '.*\.(cpp|hpp|c|h)')
+# do
+#    if [[ "$FILE" =~ .*.(cpp|hpp|c|h)$ ]];then
+#      clang-format -i $FILE
+#    fi
+# done

--- a/format_code.sh
+++ b/format_code.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-find include src pika-tools -regex '.*\.\(cpp\|hpp\|c\|h\)' | xargs clang-format -i
+find include src pika-tools -regex '.*\.\(cpp\|hpp\|c\|h\|cc\)' | xargs clang-format -i
 
 
 # If you want to automatically format your code before git commit
 # append the code to .git/hooks/pre-commit
 #
-# for FILE in $(git diff --cached --name-only | grep -E '.*\.(cpp|hpp|c|h)')
+# for FILE in $(git diff --cached --name-only | grep -E '.*\.(cpp|hpp|c|h|cc)')
 # do
 #    if [[ "$FILE" =~ .*.(cpp|hpp|c|h)$ ]];then
 #      clang-format -i $FILE


### PR DESCRIPTION
加了自动格式化代码的脚本,原来想把格式化的代码加入到 .git/hooks/pre-commit 中, 在实际操作中,
1. 发现自动添加的功能不好实现
2. 如果用户电脑上没有 `clang-format`程序,会导致提交报错

现在在脚本的注释中有添加到 pre-commit的方法,可以自己手动添加