### PR TITLE
fix: modify command info keyspace response data

### DIFF
--- a/include/pika_partition.h
+++ b/include/pika_partition.h
@@ -25,7 +25,7 @@ struct KeyScanInfo {
   bool key_scaning_ = false;
   KeyScanInfo()
       : start_time(0),
-        s_start_time("1970-01-01 08:00:00"),
+        s_start_time("0"),
         duration(-3),
         key_infos({{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}),
         key_scaning_(false) {}

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1067,10 +1067,10 @@ void InfoCmd::InfoKeyspace(std::string& info) {
   std::stringstream tmp_stream;
   tmp_stream << "# Keyspace\r\n";
 
-  if (argv_.size() == 3) {//command => `info keyspace 1`
+  if (argv_.size() == 3) {  // command => `info keyspace 1`
     tmp_stream << "# Start async statistics"
                << "\r\n";
-  } else {//command => `info keyspace` or `info`
+  } else {  // command => `info keyspace` or `info`
     tmp_stream << "# Use `info keyspace 1` do async statistics"
                << "\r\n";
   }

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1066,6 +1066,15 @@ void InfoCmd::InfoKeyspace(std::string& info) {
   std::vector<storage::KeyInfo> key_infos;
   std::stringstream tmp_stream;
   tmp_stream << "# Keyspace\r\n";
+
+  if (argv_.size() == 3) {//command => `info keyspace 1`
+    tmp_stream << "# Start async statistics"
+               << "\r\n";
+  } else {//command => `info keyspace` or `info`
+    tmp_stream << "# Use `info keyspace 1` do async statistics"
+               << "\r\n";
+  }
+
   pstd::RWLock rwl(&g_pika_server->tables_rw_, false);
   for (const auto& table_item : g_pika_server->tables_) {
     if (keyspace_scan_tables_.empty() || keyspace_scan_tables_.find(table_item.first) != keyspace_scan_tables_.end()) {


### PR DESCRIPTION
修改 `info keyspace` 命令返回数据格式
当使用  `info keyspace`  时,提示 使用 `info keyspace 1` 异步统计
当使用  `info keyspace 1`  时,提示 开始 异步统计