### PR TITLE
fix: access null pointer

### DIFF
--- a/src/net/src/worker_thread.cc
+++ b/src/net/src/worker_thread.cc
@@ -105,6 +105,9 @@ void* WorkerThread::ThreadMain() {
 
     for (int i = 0; i < nfds; i++) {
       pfe = (net_multiplexer_->FiredEvents()) + i;
+      if (pfe == nullptr) {
+          continue;
+      }
       if (pfe->fd == net_multiplexer_->NotifyReceiveFd()) {
         if (pfe->mask & kReadable) {
           int32_t nread = read(net_multiplexer_->NotifyReceiveFd(), bb, 2048);
@@ -153,9 +156,6 @@ void* WorkerThread::ThreadMain() {
       } else {
         in_conn = nullptr;
         int should_close = 0;
-        if (pfe == nullptr) {
-          continue;
-        }
 
         {
           pstd::ReadLock l(&rwlock_);


### PR DESCRIPTION
之前对pfe是否为空指针的判断在后面的else中，为防止if中使用的pfe为空指针，应将判断提前