### PR TITLE
fix: access null pointer in src/net

### DIFF
--- a/src/net/src/worker_thread.cc
+++ b/src/net/src/worker_thread.cc
@@ -105,7 +105,10 @@ void* WorkerThread::ThreadMain() {
 
     for (int i = 0; i < nfds; i++) {
       pfe = (net_multiplexer_->FiredEvents()) + i;
-      if (pfe->fd == net_multiplexer_->NotifyReceiveFd()) {
+      if (pfe == nullptr) {
+          continue;
+      }
+      else if (pfe->fd == net_multiplexer_->NotifyReceiveFd()) {
         if (pfe->mask & kReadable) {
           int32_t nread = read(net_multiplexer_->NotifyReceiveFd(), bb, 2048);
           if (nread == 0) {
@@ -153,9 +156,6 @@ void* WorkerThread::ThreadMain() {
       } else {
         in_conn = nullptr;
         int should_close = 0;
-        if (pfe == nullptr) {
-          continue;
-        }
 
         {
           pstd::ReadLock l(&rwlock_);

--- a/src/net/src/worker_thread.cc
+++ b/src/net/src/worker_thread.cc
@@ -108,7 +108,7 @@ void* WorkerThread::ThreadMain() {
       if (pfe == nullptr) {
           continue;
       }
-      else if (pfe->fd == net_multiplexer_->NotifyReceiveFd()) {
+      if (pfe->fd == net_multiplexer_->NotifyReceiveFd()) {
         if (pfe->mask & kReadable) {
           int32_t nread = read(net_multiplexer_->NotifyReceiveFd(), bb, 2048);
           if (nread == 0) {


### PR DESCRIPTION
在原来的代码中，第153行的对pfe是否为空指针的判断应当提前，因为在第108行中的if判断中已经使用了指针pfe。
为防止空指针引用，应将第153行的空指针判断放在整个if判断的最前面