### PR TITLE
fix: aof_reader c++17 build fail

### DIFF
--- a/pika-tools/aof_to_pika/src/aof_reader.cc
+++ b/pika-tools/aof_to_pika/src/aof_reader.cc
@@ -58,7 +58,7 @@ static int file_read(const std::string& path) {
   LOG_INFO("Begin reading.... ");
   print_cur_time();
 
-  std::ios::streampos gpos = ifs.tellg();
+  std::streampos gpos = ifs.tellg();
   std::string line;
   bool dirty = false;
   while (true) {


### PR DESCRIPTION
fix aof_reader c++17 build fail