### PR TITLE
fix: occasional failure of operator build

### DIFF
--- a/operator/test/e2e/utils/cmd.go
+++ b/operator/test/e2e/utils/cmd.go
@@ -3,41 +3,37 @@ package utils
 import (
 	"io"
 	"os/exec"
-	"sync"
 )
 
 // ExecCmdWithOutput executes a command and returns the output.
 // return stdoutHas,stderrHas,err
 func ExecCmdWithOutput(cmd string, args ...string) (string, string, error) {
 	cmdSt := exec.Command(cmd, args...)
+
 	stdoutReader, err := cmdSt.StdoutPipe()
 	if err != nil {
-		panic(err)
+		return "", "", err
 	}
 	stderrReader, err := cmdSt.StderrPipe()
 	if err != nil {
-		panic(err)
+		return "", "", err
 	}
-	wg := &sync.WaitGroup{}
-	wg.Add(2)
 
-	var stdout, stderr []byte
-	go func() {
-		defer wg.Done()
-		stdout, err = io.ReadAll(stdoutReader)
-		if err != nil {
-			return
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		stderr, err = io.ReadAll(stderrReader)
-		if err != nil {
-			return
-		}
-	}()
+	err = cmdSt.Start()
+	if err != nil {
+		return "", "", err
+	}
 
-	err = cmdSt.Run()
-	wg.Wait()
+	stdout, err := io.ReadAll(stdoutReader)
+	if err != nil {
+		return "", "", err
+	}
+
+	stderr, err := io.ReadAll(stderrReader)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = cmdSt.Wait()
 	return string(stdout), string(stderr), err
 }

--- a/operator/test/e2e/utils/cmd_test.go
+++ b/operator/test/e2e/utils/cmd_test.go
@@ -53,6 +53,29 @@ func TestExecCmdWithOutput(t *testing.T) {
 			stderrHas: "No such file or directory",
 			wantErr:   true,
 		},
+		{
+			name: "test sleep 3",
+			args: args{
+				cmd: "bash",
+				args: []string{
+					"-c",
+					"for i in {1..3}; do echo $i; sleep 1; done",
+				},
+			},
+			stdoutHas: "1\n2\n3",
+			stderrHas: "",
+			wantErr:   false,
+		},
+		{
+			name: "test unknow command",
+			args: args{
+				cmd:  "no_this_command",
+				args: []string{},
+			},
+			stdoutHas: "",
+			stderrHas: "",
+			wantErr:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fix occasional failure of operator build.

The reason for this is mistakenly using the "exec" command, 
leading to unstable errors when reading data.

Also added tests for such errors.