### PR TITLE
fix: modifying Error Links in Documents

### DIFF
--- a/docs/design/lock.md
+++ b/docs/design/lock.md
@@ -84,4 +84,4 @@ void RecordMutex::Lock(const std::string &key) {
 }
 
 ```
-完整代码可参考：[slash_mutex.cc](https://github.com/PikaLabs/slash/blob/master/slash/src/slash_mutex.cc) [slash_mutex.h](https://github.com/PikaLabs/slash/blob/master/slash/include/slash_mutex.h)
+完整代码可参考：[pstd_mutex.cc](https://github.com/OpenAtomFoundation/pika/blob/unstable/src/pstd/src/pstd_mutex.cc) [pstd_mutex.h](https://github.com/OpenAtomFoundation/pika/blob/unstable/src/pstd/include/pstd_mutex.h)

--- a/docs/design/lock.md
+++ b/docs/design/lock.md
@@ -84,4 +84,4 @@ void RecordMutex::Lock(const std::string &key) {
 }
 
 ```
-完整代码可参考：[slash_mutex.cc](https://github.com/baotiao/slash/blob/master/src/slash_mutex.cc) [slash_mutex.h](https://github.com/baotiao/slash/blob/master/include/slash_mutex.h)
+完整代码可参考：[slash_mutex.cc](https://github.com/PikaLabs/slash/blob/master/slash/src/slash_mutex.cc) [slash_mutex.h](https://github.com/PikaLabs/slash/blob/master/slash/include/slash_mutex.h)


### PR DESCRIPTION
#拉取/合并请求描述：（PR description）

####为什么提交这份PR（why to submit this PR）
该失效链接为404，我找到了它原来应指向的目的链接，并将其修复。
