### PR TITLE
fix: libfmt debug build name error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,10 +342,16 @@ ExternalProject_Add(fmt
   make -j${CPU_CORE}
 )
 
-if(${OS_VERSION} MATCHES "CentOS")
-  set(FMT_LIBRARY ${INSTALL_LIBDIR_64}/libfmt.a)
+if(${LIB_BUILD_TYPE} STREQUAL DEBUG)
+  set(LIB_FMT libfmtd.a)
 else()
-  set(FMT_LIBRARY ${INSTALL_LIBDIR}/libfmt.a)
+  set(LIB_FMT libfmt.a)
+endif()
+
+if(${OS_VERSION} MATCHES "CentOS")
+  set(FMT_LIBRARY ${INSTALL_LIBDIR_64}/${LIB_FMT})
+else()
+  set(FMT_LIBRARY ${INSTALL_LIBDIR}/${LIB_FMT})
 endif()
 
 set(FMT_INCLUDE_DIR ${INSTALL_INCLUDEDIR})
@@ -677,7 +683,7 @@ target_link_libraries(${PROJECT_NAME}
   librocksdb.a
   ${LIB_PROTOBUF}
   ${LIB_GFLAGS}
-  libfmt.a
+  ${LIB_FMT}
   libsnappy.a
   libzstd.a
   liblz4.a


### PR DESCRIPTION
修复 fmt库在debug模式下库名字和release模式下不同导致的链接错误