### PR TITLE
build: disable rocksdb io_uring compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,7 @@ ExternalProject_Add(rocksdb
   -DWITH_ZSTD=ON
   -DWITH_GFLAGS=ON
   -DFAIL_ON_WARNINGS=OFF
+  -DWITH_LIBURING=OFF
   BUILD_COMMAND
   make -j${CPU_CORE}
 )


### PR DESCRIPTION
fix #1457 
关闭rocksdb 使用io_uring, 防止在链接时报错