### PR TITLE
fix: remove new/delete in net

### DIFF
--- a/src/net/examples/bg_thread.cc
+++ b/src/net/examples/bg_thread.cc
@@ -14,12 +14,12 @@ using namespace std;
 static pstd::Mutex print_lock;
 
 void task(void* arg) {
+  std::unique_ptr<int> int_arg(static_cast<int*>(arg));
   {
     std::lock_guard l(print_lock);
-    std::cout << " task : " << *((int*)arg) << std::endl;
+    std::cout << " task : " << *int_arg << std::endl;
   }
   sleep(1);
-  delete (int*)arg;
 }
 
 struct TimerItem {

--- a/src/net/examples/binlog_parser_test.cc
+++ b/src/net/examples/binlog_parser_test.cc
@@ -16,7 +16,7 @@ int main(int argc, char* argv[]) {
   std::string ip(argv[1]);
   int port = atoi(argv[2]);
 
-  NetCli* rcli = NewRedisCli();
+  std::unique_ptr<NetCli> rcli(NewRedisCli());
   rcli->set_connect_timeout(3000);
 
   Status s = rcli->Connect(ip, port, "127.0.0.1");

--- a/src/net/examples/http_server.cc
+++ b/src/net/examples/http_server.cc
@@ -96,8 +96,8 @@ int main(int argc, char* argv[]) {
 
   SignalSetup();
 
-  ConnFactory* my_conn_factory = new MyConnFactory();
-  ServerThread* st = NewDispatchThread(port, 4, my_conn_factory, 1000);
+  std::unique_ptr<ConnFactory> my_conn_factory = std::make_unique<MyConnFactory>();
+  std::unique_ptr<ServerThread> st(NewDispatchThread(port, 4, my_conn_factory.get(), 1000));
 
   if (st->StartThread() != 0) {
     printf("StartThread error happened!\n");
@@ -108,9 +108,6 @@ int main(int argc, char* argv[]) {
     sleep(1);
   }
   st->StopThread();
-
-  delete st;
-  delete my_conn_factory;
 
   return 0;
 }

--- a/src/net/examples/https_server.cc
+++ b/src/net/examples/https_server.cc
@@ -97,8 +97,8 @@ int main(int argc, char* argv[]) {
 
   SignalSetup();
 
-  ConnFactory* my_conn_factory = new MyConnFactory();
-  ServerThread* st = NewDispatchThread(port, 4, my_conn_factory, 1000);
+  std::unique_ptr<ConnFactory> my_conn_factory = std::make_unique<MyConnFactory>();
+  std::unique_ptr<ServerThread> st(NewDispatchThread(port, 4, my_conn_factory.get(), 1000));
 
 #if __ENABLE_SSL
   if (st->EnableSecurity("/complete_path_to/host.crt", "/complete_path_to/host.key") != 0) {
@@ -116,9 +116,6 @@ int main(int argc, char* argv[]) {
     sleep(1);
   }
   st->StopThread();
-
-  delete st;
-  delete my_conn_factory;
 
   return 0;
 }

--- a/src/net/examples/mydispatch_srv.cc
+++ b/src/net/examples/mydispatch_srv.cc
@@ -75,8 +75,8 @@ static void SignalSetup() {
 
 int main() {
   SignalSetup();
-  ConnFactory* my_conn_factory = new MyConnFactory();
-  ServerThread* st = NewDispatchThread(9211, 10, my_conn_factory, 1000);
+  std::unique_ptr<ConnFactory> my_conn_factory = std::make_unique<MyConnFactory>();
+  std::unique_ptr<ServerThread> st(NewDispatchThread(9211, 10, my_conn_factory.get(), 1000));
 
   if (st->StartThread() != 0) {
     printf("StartThread error happened!\n");
@@ -87,9 +87,6 @@ int main() {
     sleep(1);
   }
   st->StopThread();
-
-  delete st;
-  delete my_conn_factory;
 
   return 0;
 }

--- a/src/net/examples/myholy_srv.cc
+++ b/src/net/examples/myholy_srv.cc
@@ -80,9 +80,9 @@ int main(int argc, char* argv[]) {
 
   SignalSetup();
 
-  ConnFactory* conn_factory = new MyConnFactory();
+  std::unique_ptr<ConnFactory> conn_factory = std::make_unique<MyConnFactory>();
 
-  ServerThread* my_thread = NewHolyThread(my_port, conn_factory);
+  std::unique_ptr<ServerThread> my_thread(NewHolyThread(my_port, conn_factory.get()));
   if (my_thread->StartThread() != 0) {
     printf("StartThread error happened!\n");
     exit(-1);
@@ -92,9 +92,6 @@ int main(int argc, char* argv[]) {
     sleep(1);
   }
   my_thread->StopThread();
-
-  delete my_thread;
-  delete conn_factory;
 
   return 0;
 }

--- a/src/net/examples/myholy_srv_chandle.cc
+++ b/src/net/examples/myholy_srv_chandle.cc
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
   MyConnFactory conn_factory;
   MyServerHandle handle;
 
-  ServerThread* my_thread = NewHolyThread(my_port, &conn_factory, 1000, &handle);
+  std::unique_ptr<ServerThread> my_thread(NewHolyThread(my_port, &conn_factory, 1000, &handle));
   if (my_thread->StartThread() != 0) {
     printf("StartThread error happened!\n");
     exit(-1);
@@ -117,8 +117,6 @@ int main(int argc, char* argv[]) {
     sleep(1);
   }
   my_thread->StopThread();
-
-  delete my_thread;
 
   return 0;
 }

--- a/src/net/examples/myproto_cli.cc
+++ b/src/net/examples/myproto_cli.cc
@@ -2,6 +2,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <memory>
 
 #include "myproto.pb.h"
 #include "net/include/net_cli.h"
@@ -18,7 +19,7 @@ int main(int argc, char* argv[]) {
   std::string ip(argv[1]);
   int port = atoi(argv[2]);
 
-  NetCli* cli = NewPbCli();
+  std::unique_ptr<NetCli> cli(NewPbCli());
 
   Status s = cli->Connect(ip, port);
   if (!s.ok()) {
@@ -48,6 +49,5 @@ int main(int argc, char* argv[]) {
   }
   cli->Close();
 
-  delete cli;
   return 0;
 }

--- a/src/net/examples/myredis_srv.cc
+++ b/src/net/examples/myredis_srv.cc
@@ -96,9 +96,10 @@ int main(int argc, char* argv[]) {
 
   SignalSetup();
 
-  ConnFactory* conn_factory = new MyConnFactory();
+  std::unique_ptr<ConnFactory> conn_factory = std::make_unique<MyConnFactory>();
 
-  ServerThread* my_thread = new HolyThread(my_port, conn_factory, 1000, nullptr, false);
+  std::unique_ptr<ServerThread> my_thread =
+      std::make_unique<HolyThread>(my_port, conn_factory.get(), 1000, nullptr, false);
   if (my_thread->StartThread() != 0) {
     printf("StartThread error happened!\n");
     exit(-1);
@@ -108,9 +109,6 @@ int main(int argc, char* argv[]) {
     sleep(1);
   }
   my_thread->StopThread();
-
-  delete my_thread;
-  delete conn_factory;
 
   return 0;
 }

--- a/src/net/examples/performance/client.cc
+++ b/src/net/examples/performance/client.cc
@@ -18,7 +18,7 @@ int main(int argc, char* argv[]) {
   std::string ip(argv[1]);
   int port = atoi(argv[2]);
 
-  NetCli* cli = NewPbCli();
+  std::unique_ptr<NetCli> cli(NewPbCli());
 
   Status s = cli->Connect(ip, port);
   if (!s.ok()) {
@@ -44,6 +44,5 @@ int main(int argc, char* argv[]) {
   }
   cli->Close();
 
-  delete cli;
   return 0;
 }

--- a/src/net/examples/performance/server.cc
+++ b/src/net/examples/performance/server.cc
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]) {
 
   SignalSetup();
 
-  ServerThread* st_thread = NewDispatchThread(ip, port, 24, &conn_factory, 1000);
+  std::unique_ptr<ServerThread> st_thread(NewDispatchThread(ip, port, 24, &conn_factory, 1000));
   st_thread->StartThread();
   uint64_t st, ed;
 
@@ -98,8 +98,6 @@ int main(int argc, char* argv[]) {
     printf("average qps %lf\n", (double)(num.load() - prv) / ((double)(ed - st) / 1000000));
   }
   st_thread->StopThread();
-
-  delete st_thread;
 
   return 0;
 }

--- a/src/net/examples/redis_cli_test.cc
+++ b/src/net/examples/redis_cli_test.cc
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
   ret = net::SerializeRedisCommand(vec, &str);
   printf("   2. Serialize by vec return %d, (%s)\n", ret, str.c_str());
 
-  NetCli* rcli = NewRedisCli();
+  std::unique_ptr<NetCli> rcli(NewRedisCli());
   rcli->set_connect_timeout(3000);
 
   // redis v3.2+ protect mode will block other ip

--- a/src/net/examples/redis_parser_test.cc
+++ b/src/net/examples/redis_parser_test.cc
@@ -15,7 +15,7 @@ int main(int argc, char* argv[]) {
   std::string ip(argv[1]);
   int port = atoi(argv[2]);
 
-  NetCli* rcli = NewRedisCli();
+  std::unique_ptr<NetCli> rcli(NewRedisCli());
   rcli->set_connect_timeout(3000);
 
   Status s = rcli->Connect(ip, port, "127.0.0.1");

--- a/src/net/examples/simple_http_server.cc
+++ b/src/net/examples/simple_http_server.cc
@@ -76,8 +76,8 @@ int main(int argc, char* argv[]) {
 
   SignalSetup();
 
-  ConnFactory* my_conn_factory = new MyConnFactory();
-  ServerThread* st = NewDispatchThread(port, 4, my_conn_factory, 1000);
+  std::unique_ptr<ConnFactory> my_conn_factory = std::make_unique<MyConnFactory>();
+  std::unique_ptr<ServerThread> st(NewDispatchThread(port, 4, my_conn_factory.get(), 1000));
 
   if (st->StartThread() != 0) {
     printf("StartThread error happened!\n");
@@ -88,9 +88,6 @@ int main(int argc, char* argv[]) {
     sleep(1);
   }
   st->StopThread();
-
-  delete st;
-  delete my_conn_factory;
 
   return 0;
 }

--- a/src/net/examples/thread_pool_test.cc
+++ b/src/net/examples/thread_pool_test.cc
@@ -24,13 +24,13 @@ uint64_t NowMicros() {
 static pstd::Mutex print_lock;
 
 void task(void* arg) {
+  std::unique_ptr<int> int_arg(static_cast<int*>(arg));
   {
     std::lock_guard l(print_lock);
-    std::cout << " task : " << *((int*)arg) << " time(micros) " << NowMicros() << "   thread id: " << pthread_self()
+    std::cout << " task : " << *int_arg << " time(micros) " << NowMicros() << "   thread id: " << pthread_self()
               << std::endl;
   }
   sleep(1);
-  delete (int*)arg;
 }
 
 int main() {

--- a/src/net/include/net_cli.h
+++ b/src/net/include/net_cli.h
@@ -47,7 +47,7 @@ class NetCli {
 
  private:
   struct Rep;
-  std::shared_ptr<Rep> rep_;
+  std::unique_ptr<Rep> rep_;
   int set_tcp_nodelay();
 
   NetCli(const NetCli&);

--- a/src/net/include/net_cli.h
+++ b/src/net/include/net_cli.h
@@ -6,8 +6,8 @@
 #ifndef NET_INCLUDE_NET_CLI_H_
 #define NET_INCLUDE_NET_CLI_H_
 
+#include <memory>
 #include <string>
-
 #include "pstd/include/pstd_status.h"
 
 using pstd::Status;
@@ -47,7 +47,7 @@ class NetCli {
 
  private:
   struct Rep;
-  Rep* rep_;
+  std::shared_ptr<Rep> rep_;
   int set_tcp_nodelay();
 
   NetCli(const NetCli&);

--- a/src/net/include/server_thread.h
+++ b/src/net/include/server_thread.h
@@ -188,7 +188,7 @@ class ServerThread : public Thread {
    */
   int port_ = -1;
   std::set<std::string> ips_;
-  std::vector<ServerSocket*> server_sockets_;
+  std::vector<std::shared_ptr<ServerSocket>> server_sockets_;
   std::set<int32_t> server_fds_;
 
   virtual int InitHandle();

--- a/src/net/src/dispatch_thread.cc
+++ b/src/net/src/dispatch_thread.cc
@@ -20,9 +20,8 @@ DispatchThread::DispatchThread(int port, int work_num, ConnFactory* conn_factory
       last_thread_(0),
       work_num_(work_num),
       queue_limit_(queue_limit) {
-  worker_thread_ = new WorkerThread*[work_num_];
   for (int i = 0; i < work_num_; i++) {
-    worker_thread_[i] = new WorkerThread(conn_factory, this, queue_limit, cron_interval);
+    worker_thread_.emplace_back(std::make_shared<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
   }
 }
 
@@ -32,9 +31,9 @@ DispatchThread::DispatchThread(const std::string& ip, int port, int work_num, Co
       last_thread_(0),
       work_num_(work_num),
       queue_limit_(queue_limit) {
-  worker_thread_ = new WorkerThread*[work_num_];
+
   for (int i = 0; i < work_num_; i++) {
-    worker_thread_[i] = new WorkerThread(conn_factory, this, queue_limit, cron_interval);
+    worker_thread_.emplace_back(std::make_shared<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
   }
 }
 
@@ -44,17 +43,15 @@ DispatchThread::DispatchThread(const std::set<std::string>& ips, int port, int w
       last_thread_(0),
       work_num_(work_num),
       queue_limit_(queue_limit) {
-  worker_thread_ = new WorkerThread*[work_num_];
+
   for (int i = 0; i < work_num_; i++) {
-    worker_thread_[i] = new WorkerThread(conn_factory, this, queue_limit, cron_interval);
+    worker_thread_.emplace_back(std::make_shared<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
+
   }
 }
 
 DispatchThread::~DispatchThread() {
-  for (int i = 0; i < work_num_; i++) {
-    delete worker_thread_[i];
-  }
-  delete[] worker_thread_;
+
 }
 
 int DispatchThread::StartThread() {
@@ -129,7 +126,7 @@ std::shared_ptr<NetConn> DispatchThread::MoveConnOut(int fd) {
 }
 
 void DispatchThread::MoveConnIn(std::shared_ptr<NetConn> conn, const NotifyType& type) {
-  WorkerThread* worker_thread = worker_thread_[last_thread_];
+  std::shared_ptr<WorkerThread> worker_thread = worker_thread_[last_thread_];
   bool success = worker_thread->MoveConnIn(conn, type, true);
   if (success) {
     last_thread_ = (last_thread_ + 1) % work_num_;
@@ -155,7 +152,7 @@ void DispatchThread::HandleNewConn(const int connfd, const std::string& ip_port)
   int next_thread = last_thread_;
   bool find = false;
   for (int cnt = 0; cnt < work_num_; cnt++) {
-    WorkerThread* worker_thread = worker_thread_[next_thread];
+    std::shared_ptr<WorkerThread> worker_thread = worker_thread_[next_thread];
     find = worker_thread->MoveConnIn(ti, false);
     if (find) {
       last_thread_ = (next_thread + 1) % work_num_;

--- a/src/net/src/dispatch_thread.cc
+++ b/src/net/src/dispatch_thread.cc
@@ -21,7 +21,7 @@ DispatchThread::DispatchThread(int port, int work_num, ConnFactory* conn_factory
       work_num_(work_num),
       queue_limit_(queue_limit) {
   for (int i = 0; i < work_num_; i++) {
-    worker_thread_.emplace_back(std::make_shared<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
+    worker_thread_.emplace_back(std::make_unique<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
   }
 }
 
@@ -33,7 +33,7 @@ DispatchThread::DispatchThread(const std::string& ip, int port, int work_num, Co
       queue_limit_(queue_limit) {
 
   for (int i = 0; i < work_num_; i++) {
-    worker_thread_.emplace_back(std::make_shared<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
+    worker_thread_.emplace_back(std::make_unique<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
   }
 }
 
@@ -45,7 +45,7 @@ DispatchThread::DispatchThread(const std::set<std::string>& ips, int port, int w
       queue_limit_(queue_limit) {
 
   for (int i = 0; i < work_num_; i++) {
-    worker_thread_.emplace_back(std::make_shared<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
+    worker_thread_.emplace_back(std::make_unique<WorkerThread>(conn_factory, this, queue_limit, cron_interval));
 
   }
 }
@@ -126,7 +126,7 @@ std::shared_ptr<NetConn> DispatchThread::MoveConnOut(int fd) {
 }
 
 void DispatchThread::MoveConnIn(std::shared_ptr<NetConn> conn, const NotifyType& type) {
-  std::shared_ptr<WorkerThread> worker_thread = worker_thread_[last_thread_];
+  std::unique_ptr<WorkerThread>& worker_thread = worker_thread_[last_thread_];
   bool success = worker_thread->MoveConnIn(conn, type, true);
   if (success) {
     last_thread_ = (last_thread_ + 1) % work_num_;
@@ -152,7 +152,7 @@ void DispatchThread::HandleNewConn(const int connfd, const std::string& ip_port)
   int next_thread = last_thread_;
   bool find = false;
   for (int cnt = 0; cnt < work_num_; cnt++) {
-    std::shared_ptr<WorkerThread> worker_thread = worker_thread_[next_thread];
+    std::unique_ptr<WorkerThread>& worker_thread = worker_thread_[next_thread];
     find = worker_thread->MoveConnIn(ti, false);
     if (find) {
       last_thread_ = (next_thread + 1) % work_num_;

--- a/src/net/src/dispatch_thread.h
+++ b/src/net/src/dispatch_thread.h
@@ -65,7 +65,7 @@ class DispatchThread : public ServerThread {
   /*
    * This is the work threads
    */
-  std::vector<std::shared_ptr<WorkerThread>> worker_thread_;
+  std::vector<std::unique_ptr<WorkerThread>> worker_thread_;
   int queue_limit_;
   std::map<WorkerThread*, void*> localdata_;
 

--- a/src/net/src/dispatch_thread.h
+++ b/src/net/src/dispatch_thread.h
@@ -65,7 +65,7 @@ class DispatchThread : public ServerThread {
   /*
    * This is the work threads
    */
-  WorkerThread** worker_thread_;
+  std::vector<std::shared_ptr<WorkerThread>> worker_thread_;
   int queue_limit_;
   std::map<WorkerThread*, void*> localdata_;
 

--- a/src/net/src/net_cli.cc
+++ b/src/net/src/net_cli.cc
@@ -48,19 +48,16 @@ struct NetCli::Rep {
         available(false) {}
 };
 
-NetCli::NetCli(const std::string& ip, const int port) : rep_(new Rep(ip, port)) {}
+NetCli::NetCli(const std::string& ip, const int port) : rep_(std::make_shared<Rep>(ip, port)) {}
 
-NetCli::~NetCli() {
-  Close();
-  delete rep_;
-}
+NetCli::~NetCli() { Close(); }
 
 bool NetCli::Available() const { return rep_->available; }
 
 Status NetCli::Connect(const std::string& bind_ip) { return Connect(rep_->peer_ip, rep_->peer_port, bind_ip); }
 
 Status NetCli::Connect(const std::string& ip, const int port, const std::string& bind_ip) {
-  Rep* r = rep_;
+  std::shared_ptr<Rep> r = rep_;
   Status s;
   int rv;
   char cport[6];
@@ -246,7 +243,7 @@ Status NetCli::SendRaw(void* buf, size_t count) {
 }
 
 Status NetCli::RecvRaw(void* buf, size_t* count) {
-  Rep* r = rep_;
+  std::shared_ptr<Rep> r = rep_;
   char* rbuf = reinterpret_cast<char*>(buf);
   size_t nleft = *count;
   size_t pos = 0;
@@ -285,7 +282,7 @@ void NetCli::Close() {
 void NetCli::set_connect_timeout(int connect_timeout) { rep_->connect_timeout = connect_timeout; }
 
 int NetCli::set_send_timeout(int send_timeout) {
-  Rep* r = rep_;
+  std::shared_ptr<Rep> r = rep_;
   int ret = 0;
   if (send_timeout > 0) {
     r->send_timeout = send_timeout;
@@ -296,7 +293,7 @@ int NetCli::set_send_timeout(int send_timeout) {
 }
 
 int NetCli::set_recv_timeout(int recv_timeout) {
-  Rep* r = rep_;
+  std::shared_ptr<Rep> r = rep_;
   int ret = 0;
   if (recv_timeout > 0) {
     r->recv_timeout = recv_timeout;
@@ -307,7 +304,7 @@ int NetCli::set_recv_timeout(int recv_timeout) {
 }
 
 int NetCli::set_tcp_nodelay() {
-  Rep* r = rep_;
+  std::shared_ptr<Rep> r = rep_;
   int val = 1;
   int ret = 0;
   ret = setsockopt(r->sockfd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));

--- a/src/net/src/net_cli.cc
+++ b/src/net/src/net_cli.cc
@@ -48,7 +48,7 @@ struct NetCli::Rep {
         available(false) {}
 };
 
-NetCli::NetCli(const std::string& ip, const int port) : rep_(std::make_shared<Rep>(ip, port)) {}
+NetCli::NetCli(const std::string& ip, const int port) : rep_(std::make_unique<Rep>(ip, port)) {}
 
 NetCli::~NetCli() { Close(); }
 
@@ -57,7 +57,7 @@ bool NetCli::Available() const { return rep_->available; }
 Status NetCli::Connect(const std::string& bind_ip) { return Connect(rep_->peer_ip, rep_->peer_port, bind_ip); }
 
 Status NetCli::Connect(const std::string& ip, const int port, const std::string& bind_ip) {
-  std::shared_ptr<Rep> r = rep_;
+  std::unique_ptr<Rep>& r = rep_;
   Status s;
   int rv;
   char cport[6];
@@ -243,7 +243,7 @@ Status NetCli::SendRaw(void* buf, size_t count) {
 }
 
 Status NetCli::RecvRaw(void* buf, size_t* count) {
-  std::shared_ptr<Rep> r = rep_;
+  std::unique_ptr<Rep>& r = rep_;
   char* rbuf = reinterpret_cast<char*>(buf);
   size_t nleft = *count;
   size_t pos = 0;
@@ -282,7 +282,7 @@ void NetCli::Close() {
 void NetCli::set_connect_timeout(int connect_timeout) { rep_->connect_timeout = connect_timeout; }
 
 int NetCli::set_send_timeout(int send_timeout) {
-  std::shared_ptr<Rep> r = rep_;
+  std::unique_ptr<Rep>& r = rep_;
   int ret = 0;
   if (send_timeout > 0) {
     r->send_timeout = send_timeout;
@@ -293,7 +293,7 @@ int NetCli::set_send_timeout(int send_timeout) {
 }
 
 int NetCli::set_recv_timeout(int recv_timeout) {
-  std::shared_ptr<Rep> r = rep_;
+  std::unique_ptr<Rep>& r = rep_;
   int ret = 0;
   if (recv_timeout > 0) {
     r->recv_timeout = recv_timeout;
@@ -304,7 +304,7 @@ int NetCli::set_recv_timeout(int recv_timeout) {
 }
 
 int NetCli::set_tcp_nodelay() {
-  std::shared_ptr<Rep> r = rep_;
+  std::unique_ptr<Rep>& r = rep_;
   int val = 1;
   int ret = 0;
   ret = setsockopt(r->sockfd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));


### PR DESCRIPTION
fix #1477
removed new/delete operation in /src/net/* and use smart ptr instead.
Ps:not all new/delete are removed, for the variable that has flexible life circle, I choose to keep them as they were.