### PR TITLE
Removed a redundant check of ttl in setcmd

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -39,7 +39,7 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
     tmp_ptr->res().SetRes(CmdRes::kErrOther, "unknown command \"" + opt + "\"");
     return tmp_ptr;
   }
-  c_ptr->SetConn(std::dynamic_pointer_cast<PikaClientConn>(shared_from_this()));
+  c_ptr->SetConn(shared_from_this());
   c_ptr->SetResp(resp_ptr);
 
   // Check authed

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -49,9 +49,6 @@ void SetCmd::DoInitial() {
       if (!pstd::string2int(argv_[index].data(), argv_[index].size(), &sec_)) {
         res_.SetRes(CmdRes::kInvalidInt);
         return;
-      } else if (sec_ <= 0) {
-        res_.SetRes(CmdRes::kErrOther, "invalid expire time in set");
-        return;
       }
 
       if (!strcasecmp(opt.data(), "px")) {


### PR DESCRIPTION
1.执行set key value ex/px sec/ms 命令时，会对ttl进行两次非负检查：
第一次：setcmd的Doinitial函数中，如果set命令带了ex/px则会判断ttl是否非负
<img width="523" alt="image" src="https://github.com/OpenAtomFoundation/pika/assets/41671101/9065d113-dd33-462f-a4cd-4097cbcd0456">

第二次：在带有ex/px执行set时，setcmd的Do方法最后是调用partition->db()->Setex方法，在这个方法内部会进行ttl非负检查：
<img width="494" alt="image" src="https://github.com/OpenAtomFoundation/pika/assets/41671101/5d4730ff-2459-4213-ba42-02353142437b">
<img width="563" alt="image" src="https://github.com/OpenAtomFoundation/pika/assets/41671101/8add0066-b6e6-4bc2-a8b3-fdc1fbb83048">


为什么选择移除Doinitial中的非负检查，而不是移除setex函数中的：因为像"setex key seconds value"这样的命令在Doinitial中没有做ttl的非负检查（依赖于Setex方法中的ttl非负检查）

2.在一个被高频执行的函数中（Docmd函数），疑似存在不必要的动态类型转换（先把父类指针转子类传递给SetConn方法，但是SetConn的形参是父类指针的类型，所以又会隐式转换回去，平白多了2次没有意义的转换？）
<img width="631" alt="image" src="https://github.com/OpenAtomFoundation/pika/assets/41671101/6a330b95-f3ab-4e92-a4c3-e8e3df1d974b">
<img width="508" alt="image" src="https://github.com/OpenAtomFoundation/pika/assets/41671101/859af8cc-d56f-4994-b182-3a74f8fd002f">



当然，上面第2点只是我个人的看法，只是我个人没有看出这个转换有别的用处，如有错误，还请指正。