### PR TITLE
Removed a redundant check of ttl in setcmd

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -39,7 +39,7 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
     tmp_ptr->res().SetRes(CmdRes::kErrOther, "unknown command \"" + opt + "\"");
     return tmp_ptr;
   }
-  c_ptr->SetConn(std::dynamic_pointer_cast<PikaClientConn>(shared_from_this()));
+  c_ptr->SetConn(shared_from_this());
   c_ptr->SetResp(resp_ptr);
 
   // Check authed

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -49,9 +49,6 @@ void SetCmd::DoInitial() {
       if (!pstd::string2int(argv_[index].data(), argv_[index].size(), &sec_)) {
         res_.SetRes(CmdRes::kInvalidInt);
         return;
-      } else if (sec_ <= 0) {
-        res_.SetRes(CmdRes::kErrOther, "invalid expire time in set");
-        return;
       }
 
       if (!strcasecmp(opt.data(), "px")) {


### PR DESCRIPTION
（这个pr前面不小心被我操作分支的时候删了，现在再提一下）
1.执行set key value ex/px sec/ms 命令时，会对ttl进行两次非负检查：
第一次：setcmd的Doinitial函数中，如果set命令带了ex/px则会判断ttl是否非负
![image](https://github.com/OpenAtomFoundation/pika/assets/41671101/f7032721-8c24-4d1a-96d8-e71744bd8222)

第二次：在带有ex/px执行set时，setcmd的Do方法最后是调用partition->db()->Setex方法，在这个方法内部会进行ttl非负检查：
![image](https://github.com/OpenAtomFoundation/pika/assets/41671101/a80ddcb8-647f-421a-b035-e903136f3659)
![image](https://github.com/OpenAtomFoundation/pika/assets/41671101/a1ec8c5e-99c6-4a7e-a88f-3b08742935db)
为什么选择移除Doinitial中的非负检查，而不是移除setex函数中的：因为像"setex key seconds value"这样的命令在Doinitial中没有做ttl的非负检查（依赖于Setex方法中的ttl非负检查）

2.在一个被高频执行的函数中（Docmd函数），疑似存在不必要的动态类型转换（先把父类指针转子类传递给SetConn方法，但是SetConn的形参是父类指针的类型，所以又会隐式转换回去，平白多了2次没有意义的转换？）
![image](https://github.com/OpenAtomFoundation/pika/assets/41671101/1e33b27b-b21a-4357-a553-85955dd6f19d)
![image](https://github.com/OpenAtomFoundation/pika/assets/41671101/02b6673b-7eb6-40af-bde0-70e37d67b939)

当然，上面第2点只是我个人的看法，只是我个人没有看出这个转换有别的用处，如有错误，还请指正。
