### PR TITLE
Fix memory leaks in HandleBGWorkerWriteDB and HandleMetaSyncResponse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,14 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
+#Sanitizer for testing stage
+#CMAKE_BUILD_TYPE must be "Debug" if you wanna use sanitizer.
+#set(CMAKE_BUILD_TYPE "Debug")
+
+#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
+# [Notice] address sanitizer and thread sanitizer can not be enabled at the same time.
+#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=thread")
+
 execute_process(COMMAND uname -p OUTPUT_VARIABLE HOST_ARCH)
 string(TOLOWER ${HOST_ARCH} HOST_ARCH)
 

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -243,7 +243,7 @@ int PikaReplBgWorker::HandleWriteBinlog(net::RedisParser* parser, const net::Red
 }
 
 void PikaReplBgWorker::HandleBGWorkerWriteDB(void* arg) {
-  auto task_arg = static_cast<ReplClientWriteDBTaskArg*>(arg);
+  std::unique_ptr<ReplClientWriteDBTaskArg> task_arg(static_cast<ReplClientWriteDBTaskArg*>(arg));
   const std::shared_ptr<Cmd> c_ptr = task_arg->cmd_ptr;
   const PikaCmdArgsType& argv = c_ptr->argv();
   LogOffset offset = task_arg->offset;

--- a/src/pika_repl_client_conn.cc
+++ b/src/pika_repl_client_conn.cc
@@ -85,7 +85,7 @@ int PikaReplClientConn::DealMessage() {
 }
 
 void PikaReplClientConn::HandleMetaSyncResponse(void* arg) {
-  auto task_arg = static_cast<ReplClientTaskArg*>(arg);
+  std::unique_ptr<ReplClientTaskArg> task_arg(static_cast<ReplClientTaskArg*>(arg));
   std::shared_ptr<net::PbConn> conn = task_arg->conn;
   std::shared_ptr<InnerMessage::InnerResponse> response = task_arg->res;
 


### PR DESCRIPTION
从节点消费binlog的流程中，有两个异步任务传进去的参数对象是new出来的，但是用完以后没有delete，内存泄露了。

<img width="1646" alt="image" src="https://github.com/OpenAtomFoundation/pika/assets/41671101/7410e2a2-0e9e-4f47-b7e4-f8986c12e3e0">
