### PR TITLE
fix: incorrect manner of terminating the rsync process

### DIFF
--- a/src/pstd/src/rsync.cc
+++ b/src/pstd/src/rsync.cc
@@ -114,7 +114,7 @@ int StopRsync(const std::string& raw_path) {
     return 0;
   }
 
-  std::string rsync_stop_cmd = "kill $(ps -o pgid=" + std::to_string(pid) + ")";
+  std::string rsync_stop_cmd = "kill -- -$(ps -o pgid -p" + std::to_string(pid) + " | grep -o '[0-9]*')";
   int ret = system(rsync_stop_cmd.c_str());
   if (ret == 0 || (WIFEXITED(ret) && !WEXITSTATUS(ret))) {
     LOG(INFO) << "Stop rsync success!";


### PR DESCRIPTION
现有代码中 kill rsync 的方法 `kill $(ps -o pgid=" + std::to_string(pid) + ")"` 有问题。

`ps -o pgid=12345` 的含义是列出的活动进程组ID，并把 header "PGID" 改为 12345。

kill 掉这个命令返回结果会 kill 所有当前所有的活动进程。


这个 PR 将其修改为  `kill -- -$(ps -o pgid -p " + std::to_string(pid) + " | grep -o '[0-9]*')"`，

意图为：

列出 pid 为 12345 的进程的进程组 id `ps -o pgid -p 12345`，并过滤掉非数字结果，得到所需的进程组 id 666。

然后 kill 掉进程组 id 为 666 的所有进程 `kill -- -666`。