### PR TITLE
fix issue#1597: add rocksdb dependency to pstd

### DIFF
--- a/include/pika_data_distribution.h
+++ b/include/pika_data_distribution.h
@@ -6,6 +6,7 @@
 #ifndef PIKA_DATA_DISTRIBUTION_H_
 #define PIKA_DATA_DISTRIBUTION_H_
 
+#include <cstdint>
 #include "pstd/include/pstd_status.h"
 
 // polynomial reserved Crc32 magic num

--- a/src/pstd/CMakeLists.txt
+++ b/src/pstd/CMakeLists.txt
@@ -31,6 +31,7 @@ aux_source_directory(./src  DIR_SRCS)
 add_library(pstd STATIC ${DIR_SRCS})
 
 add_dependencies(pstd
+  rocksdb
   glog
   gflags
   fmt

--- a/src/pstd/include/random.h
+++ b/src/pstd/include/random.h
@@ -2,6 +2,7 @@
 #define __PSTD_INCLUDE_RANDOM_H__
 
 #include <ctime>
+#include <cstdint>
 
 namespace pstd {
 

--- a/src/pstd/src/pstd_status.cc
+++ b/src/pstd/src/pstd_status.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "pstd/include/pstd_status.h"
+#include <cstdint>  
 #include <cstdio>
 
 namespace pstd {

--- a/src/pstd/src/pstd_string.cc
+++ b/src/pstd/src/pstd_string.cc
@@ -43,6 +43,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <sstream>
+#include <cstdint>  
 
 #include <algorithm>
 

--- a/src/storage/src/redis_hyperloglog.h
+++ b/src/storage/src/redis_hyperloglog.h
@@ -6,9 +6,10 @@
 #ifndef SRC_REDIS_HYPERLOGLOG_H_
 #define SRC_REDIS_HYPERLOGLOG_H_
 
+#include <cstdint>
 #include <iostream>
-#include <string>
 #include <memory>
+#include <string>
 
 namespace storage {
 


### PR DESCRIPTION
pstd使用了rocksdb/slice.h里面的纯头文件的类， 但是pstd里的CmakeLists.txt没有对rocksdb的依赖， 导致在rocksdb没下载的情况下开始编译pstd
https://github.com/OpenAtomFoundation/pika/issues/1597