### PR TITLE
fix: the unit test of type/set

### DIFF
--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -900,6 +900,7 @@ rocksdb::Status RedisSets::SRandmember(const Slice& key, int32_t count, std::vec
       if (count > 0) {
         count = count <= size ? count : size;
         while (targets.size() < static_cast<size_t>(count)) {
+          engine.seed(last_seed);
           last_seed = engine();
           uint32_t pos = last_seed % size;
           if (unique.find(pos) == unique.end()) {
@@ -910,6 +911,7 @@ rocksdb::Status RedisSets::SRandmember(const Slice& key, int32_t count, std::vec
       } else {
         count = -count;
         while (targets.size() < static_cast<size_t>(count)) {
+          engine.seed(last_seed);
           last_seed = engine();
           targets.push_back(last_seed % size);
         }

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -878,7 +878,7 @@ rocksdb::Status RedisSets::SRandmember(const Slice& key, int32_t count, std::vec
   }
 
   members->clear();
-  int32_t last_seed = time(nullptr);
+  int64_t last_seed = pstd::NowMicros();
   std::default_random_engine engine;
 
   std::string meta_value;
@@ -900,7 +900,6 @@ rocksdb::Status RedisSets::SRandmember(const Slice& key, int32_t count, std::vec
       if (count > 0) {
         count = count <= size ? count : size;
         while (targets.size() < static_cast<size_t>(count)) {
-          engine.seed(last_seed);
           last_seed = engine();
           uint32_t pos = last_seed % size;
           if (unique.find(pos) == unique.end()) {
@@ -911,7 +910,6 @@ rocksdb::Status RedisSets::SRandmember(const Slice& key, int32_t count, std::vec
       } else {
         count = -count;
         while (targets.size() < static_cast<size_t>(count)) {
-          engine.seed(last_seed);
           last_seed = engine();
           targets.push_back(last_seed % size);
         }

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -129,17 +129,3 @@ proc test {name code {okpattern undefined}} {
     }
 }
 
- proc uniqkey { } {
-     set key   [ expr { [ expr { 1 << 31 } ] + [ clock clicks ] } ]
-     set key   [ string range $key end-8 end-3 ]
-     set key   [ clock seconds ]$key
-     return $key
- }
-
- proc sleep { ms } {
-     set uniq [ uniqkey ]
-     set ::__sleep__tmp__$uniq 0
-     after $ms set ::__sleep__tmp__$uniq 1
-     vwait ::__sleep__tmp__$uniq
-     unset ::__sleep__tmp__$uniq
- }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -20,7 +20,7 @@ set ::all_tests {
     # unit/type/list
     unit/type/list-2
     unit/type/list-3
-    # unit/type/set
+    unit/type/set
     unit/type/zset
     # unit/type/hash
     # unit/sort

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -297,8 +297,7 @@ start_server {
             create_set myset $contents
             unset -nocomplain myset
             array set myset {}
-            for {set i 0} {$i < 500} {incr i} {
-                sleep 10
+            for {set i 0} {$i < 100} {incr i} {
                 set myset([r srandmember myset]) 1
             }
             assert_equal $contents [lsort [array names myset]]
@@ -359,7 +358,7 @@ start_server {
             set iterations 1000
             while {$iterations != 0} {
                 incr iterations -1
-                set res [r srandmember myset -20]
+                set res [r srandmember myset -10]
                 foreach ele $res {
                     set auxset($ele) 1
                 }
@@ -367,7 +366,6 @@ start_server {
                     [lsort [array names auxset]]} {
                     break;
                 }
-                sleep 15
             }
             assert {$iterations != 0}
 
@@ -404,7 +402,7 @@ start_server {
                 set iterations 1000
                 while {$iterations != 0} {
                     incr iterations -1
-                    set res [r srandmember myset -20]
+                    set res [r srandmember myset -10]
                     foreach ele $res {
                         set auxset($ele) 1
                     }
@@ -412,7 +410,6 @@ start_server {
                         [lsort [array names auxset]]} {
                         break;
                     }
-                    sleep 15
                 }
                 assert {$iterations != 0}
             }


### PR DESCRIPTION
The results generated by srandmember are very close within the same second, causing random failures in `type/set` unit testing. 

```
[err]: SRANDMEMBER with <count> - hashtable in tests/unit/type/set.tcl
Expected condition '$iterations != 0' to be true (0 != 0)
```

This PR optimizes this process by using microseconds to generate more reasonable results. 

Related Issues: #1605 #1253