### PR TITLE
fix:improve the clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,21 +45,23 @@ Checks:     '
             -clang-diagnostic-ignored-optimization-argument,
             -readability-implicit-bool-conversion,
             '
-# CheckOptions:
-#   - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
-#   - { key: readability-identifier-naming.EnumCase,            value: CamelCase  }
-#   - { key: readability-identifier-naming.FunctionCase,        value: CamelCase  }
-#   - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
-#   - { key: readability-identifier-naming.MemberCase,          value: lower_case }
-#   - { key: readability-identifier-naming.MemberSuffix,        value: _          }
-#   - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
-#   - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
-#   - { key: readability-identifier-naming.UnionCase,           value: CamelCase  }
-#   - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+# naming check
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.EnumCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,        value: CamelCase  }
+  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
+  - { key: readability-identifier-naming.MemberCase,          value: lower_case }
+  - { key: readability-identifier-naming.MemberSuffix,        value: _          }
+  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+  - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
+  - { key: readability-identifier-naming.UnionCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+  - { key: readability-identifier-naming.GlobalVariableCase,  value: lower_case }
+  - { key: readability-identifier-naming.GlobalVariablePrefix,value: g_pika     }
 
 WarningsAsErrors: '*'
-# HeaderFilterRegex: '(|/src|/src/net|/src/pstd|/src/storage)/include'
-# HeaderFilterRegex: '/src/(net|storage|pstd)/include'
+HeaderFilterRegex: '(src/net/..|src/storage/include|src/pstd/..|src/pstd/include|src/net/..)'
 AnalyzeTemporaryDtors: true
 
 #### Disabled checks and why: #####

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -33,6 +33,7 @@ jobs:
         if: ${{ steps.cache.output.cache-hit != 'true' }}
         run: |
           sudo apt install autoconf libprotobuf-dev protobuf-compiler -y
+          sudo apt-get install -y clang-tidy-12
           sudo apt-get install -y python3-pip
           python3 -m pip install --upgrade pip
           python3 -m pip install redis
@@ -45,6 +46,10 @@ jobs:
       - name: Build
         # Build your program with the given configuration
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Clang-tidy Check
+        working-directory: ${{github.workspace}}/build
+        run: make clang-tidy
 
       - name: Test
         working-directory: ${{github.workspace}}/build
@@ -85,6 +90,8 @@ jobs:
         run: |
           yum install -y wget git autoconf centos-release-scl
           yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util
+          yum install -y llvm-toolset-7
+          yum install -y llvm-toolset-7-clang
           source /opt/rh/devtoolset-10/enable
           gcc --version
           make --version
@@ -117,6 +124,10 @@ jobs:
           cd ${{github.workspace}}
           source /opt/rh/devtoolset-10/enable
           cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Clang-tidy Check
+        working-directory: ${{github.workspace}}/build
+        run: make clang-tidy
 
       - name: Test
         # Execute tests defined by the CMake configuration.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ if (${AUTOCONF} MATCHES AUTOCONF-NOTFOUND)
   message(FATAL_ERROR "not find autoconf on localhost")
 endif()
 
+set(CLANG_SEARCH_PATH "/usr/local/bin" "/usr/bin" "/usr/local/opt/llvm/bin"
+                      "/usr/local/opt/llvm@12/bin")
 find_program(CLANG_TIDY_BIN
         NAMES clang-tidy clang-tidy-12
         HINTS ${CLANG_SEARCH_PATH})
@@ -782,7 +784,6 @@ add_custom_target(
         clang-tidy
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/run_clang_tidy.py
         -clang-tidy-binary ${CLANG_TIDY_BIN}
-        -header-filter='${PROJECT_SOURCE_DIR}(/include|/tools|/src)/.*'
         -p ${CMAKE_BINARY_DIR}
         -quiet
     )
@@ -791,7 +792,6 @@ add_custom_target(clang-tidy-fix
     ${CMAKE_CURRENT_SOURCE_DIR}/run_clang_tidy.py
     -clang-tidy-binary ${CLANG_TIDY_BIN}
     -p ${CMAKE_BINARY_DIR}
-    -header-filter='${PROJECT_SOURCE_DIR}(/include|/tools|/src)/.*'
     -clang-apply-replacements-binary ${CLANG_APPLY_REPLACEMENTS_BIN}
     -fix
 )


### PR DESCRIPTION
#1627 

- [x]  增加命名检测(naming check)
- [x] 将clang-tidy检测头文件的范围设置从cmake文件中移动到clang-tidy文件中
- [x] 将clang-tidy检测添加到github ci之中

- [ ] naming check部分，命名规则需要统一，需要统一一个命名规则，并且将规则应用到pika之中