### PR TITLE
fix: Added requirepass judgment on empty and error passwords when starting the server

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -202,7 +202,11 @@ proc start_server {options {code undefined}} {
             puts -nonewline $fp "$directive : "
             puts $fp [dict get $config $directive]
         } elseif {$directive == "requirepass"} {
-            puts $fp "$directive :"
+            if {[dict get $config $directive] eq ":"} {
+                puts $fp "$directive: "
+            } else {
+                puts $fp "$directive: [dict get $config $directive]"
+            }
         } elseif {$directive == "dump_prefix"} {
             puts $fp "$directive :"
         } else {


### PR DESCRIPTION
Redis Server started twice in auth.tcl, and the second script contains Overrides Frequirepass Foobar). Its role is to modify the configuration file and set the password.

Found that
https://github.com/OpenAtomFoundation/pika/blob/dcddb0cc8a88fd27fb5e45587199430e091ad1b7/tests/support/server.tcl#L204-L205
there is no handling of receiving foobar in the branch of the requirepass, just need to add a judgment

Fixes: #1622