### PR TITLE
fix: remove RocksDB metrics displayed in Info command

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -727,8 +727,6 @@ void InfoCmd::Do(std::shared_ptr<Slot> slot) {
       InfoReplication(info);
       info.append("\r\n");
       InfoKeyspace(info);
-      info.append("\r\n");
-      InfoRocksDB(info);
       break;
     case kInfoAll:
       InfoServer(info);


### PR DESCRIPTION
Including RocksDB metrics in the Info command will cause the Pika metrics to be masked, removing the RocksDB metrics displayed by Info. pika_exporter itself uses info all to obtain indicators and will not be affected.

Fixes: #1646