### PR TITLE
test: add function mock debug populate

### DIFF
--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -369,3 +369,10 @@ proc start_write_load {host port seconds} {
 proc stop_write_load {handle} {
     catch {exec /bin/kill -9 $handle}
 }
+
+# Mock debug populate
+proc populate {size} {
+    for {set counter 0} {$counter < $size} {incr counter} {
+        r set "key:$counter" "key:$counter"
+    }
+}

--- a/tests/unit/scan.tcl
+++ b/tests/unit/scan.tcl
@@ -1,7 +1,8 @@
 start_server {tags {"scan"}} {
     test "SCAN basic" {
         r flushdb
-        r debug populate 1000
+        populate 1000
+        #populate 1000
 
         set cur 0
         set keys {}
@@ -19,7 +20,7 @@ start_server {tags {"scan"}} {
 
     test "SCAN COUNT" {
         r flushdb
-        r debug populate 1000
+        populate 1000
 
         set cur 0
         set keys {}
@@ -37,7 +38,7 @@ start_server {tags {"scan"}} {
 
     test "SCAN MATCH" {
         r flushdb
-        r debug populate 1000
+        populate 1000
 
         set cur 0
         set keys {}
@@ -56,7 +57,7 @@ start_server {tags {"scan"}} {
     test "SCAN TYPE" {
         r flushdb
         # populate only creates strings
-        r debug populate 1000
+        populate 1000
 
         # Check non-strings are excluded
         set cur 0
@@ -214,7 +215,7 @@ start_server {tags {"scan"}} {
 
     test "SCAN guarantees check under write load" {
         r flushdb
-        r debug populate 100
+        populate 100
 
         # We start scanning here, so keys from 0 to 99 should all be
         # reported at the end of the iteration.


### PR DESCRIPTION
在 tcl 脚本中增加 populate 方法模拟 redis  debug populate 方法，用以填充测试数据。
同时修复 scan 中相关的测试。