### PR TITLE
Resolve the abnormal output of the keys command

### DIFF
--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -426,22 +426,7 @@ void KeysCmd::DoInitial() {
     return;
   }
   pattern_ = argv_[1];
-  if (argv_.size() == 3) {
-    std::string opt = argv_[2];
-    if (strcasecmp(opt.data(), "string") == 0) {
-      type_ = storage::DataType::kStrings;
-    } else if (strcasecmp(opt.data(), "zset") == 0) {
-      type_ = storage::DataType::kZSets;
-    } else if (strcasecmp(opt.data(), "set") == 0) {
-      type_ = storage::DataType::kSets;
-    } else if (strcasecmp(opt.data(), "list") == 0) {
-      type_ = storage::DataType::kLists;
-    } else if (strcasecmp(opt.data(), "hash") == 0) {
-      type_ = storage::DataType::kHashes;
-    } else {
-      res_.SetRes(CmdRes::kSyntaxErr);
-    }
-  } else if (argv_.size() > 3) {
+  if (argv_.size() > 2) {
     res_.SetRes(CmdRes::kSyntaxErr);
   }
 }


### PR DESCRIPTION
fix #1688 keys命令只接受两个参数，所以对多于2个参数的应该报错
修改前：
<img width="260" alt="截屏2023-07-10 09 50 25" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/e5d37c29-2bd0-4f17-ac0f-a4de2661acef">
修改后：
<img width="573" alt="截屏2023-07-10 10 30 04" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/632dc979-56ed-4aa7-81b0-6c29e5390a87">
