### PR TITLE
fix: remove instantaneous_metric and collect network metrics every 5 seconds

### DIFF
--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -508,7 +508,7 @@ class PikaServer : public pstd::noncopyable {
   void AutoPurge();
   void AutoDeleteExpiredDump();
   void AutoKeepAliveRSync();
-  void AutoInstantaneousMetric();
+  void AutoUpdateNetworkMetric();
 
   std::string host_;
   int port_ = 0;

--- a/src/pika_instant.cc
+++ b/src/pika_instant.cc
@@ -17,7 +17,7 @@ double Instant::getInstantaneousMetric(std::string metric) {
   return sum / STATS_METRIC_SAMPLES;
 }
 
-/* ======================= Cron: called every 100 ms ======================== */
+/* ======================= Cron: called every 5 s ======================== */
 
 /* Add a sample to the instantaneous metric. This function computes the quotient
  * of the increment of value and base, which is useful to record operation count

--- a/tools/pika_exporter/exporter/metrics/stats.go
+++ b/tools/pika_exporter/exporter/metrics/stats.go
@@ -81,7 +81,7 @@ var collectStatsMetrics = map[string]MetricConfig{
         Parser: &normalParser{},
         MetricMeta: &MetaData{
             Name:      "instantaneous_input_kbps",
-            Help:      "the network's read rate per second in KB/sec",
+            Help:      "the network's read rate per second in KB/sec, calculated as an average of 16 samples collected every 5 seconds.",
             Type:      metricTypeCounter,
             Labels:    []string{LabelNameAddr, LabelNameAlias},
             ValueName: "instantaneous_input_kbps",
@@ -91,7 +91,7 @@ var collectStatsMetrics = map[string]MetricConfig{
         Parser: &normalParser{},
         MetricMeta: &MetaData{
             Name:      "instantaneous_output_kbps",
-            Help:      "the network's write rate per second in KB/sec",
+            Help:      "the network's write rate per second in KB/sec, calculated as an average of 16 samples collected every 5 seconds.",
             Type:      metricTypeCounter,
             Labels:    []string{LabelNameAddr, LabelNameAlias},
             ValueName: "instantaneous_output_kbps",
@@ -101,7 +101,7 @@ var collectStatsMetrics = map[string]MetricConfig{
         Parser: &normalParser{},
         MetricMeta: &MetaData{
             Name:      "instantaneous_input_repl_kbps",
-            Help:      "the network's read rate per second in KB/sec for replication purposes",
+            Help:      "the network's read rate per second in KB/sec for replication purposes, calculated as an average of 16 samples collected every 5 seconds.",
             Type:      metricTypeCounter,
             Labels:    []string{LabelNameAddr, LabelNameAlias},
             ValueName: "instantaneous_input_repl_kbps",
@@ -111,7 +111,7 @@ var collectStatsMetrics = map[string]MetricConfig{
         Parser: &normalParser{},
         MetricMeta: &MetaData{
             Name:      "instantaneous_output_repl_kbps",
-            Help:      "the network's write rate per second in KB/sec for replication purposes",
+            Help:      "the network's write rate per second in KB/sec for replication purposes, calculated as an average of 16 samples collected every 5 seconds.",
             Type:      metricTypeCounter,
             Labels:    []string{LabelNameAddr, LabelNameAlias},
             ValueName: "instantaneous_output_repl_kbps",


### PR DESCRIPTION
Using the instantaneous_metric thread to collect every 0.1s will consume cpu resources, and it is only used for collecting network traffic, which is not very worthwhile. Remove the instantaneous_metric thread and use DoTimingTask() to collect network traffic every 5 seconds.

Fixes: #1756