### PR TITLE
build in linux with clang toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
    add_definitions(-DOS_MACOSX)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-     set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -ldl -pthread")
+     set(CMAKE_EXE_LINKER_FLAGS "-stdlib=libc++ -fuse-ld=lld -lc++ -lc++abi ${CMAKE_EXE_LINKER_FLAGS}")
+     set(CMAKE_CXX_FLAGS "-stdlib=libc++ -pthread ${CMAKE_CXX_FLAGS}")
    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
      set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
      set(CMAKE_CXX_FLAGS "-pthread -Wl,--no-as-needed -ldl")
@@ -223,7 +224,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     LOG_INSTALL
     1
     CONFIGURE_COMMAND
-    <SOURCE_DIR>/configure --prefix=${STAGED_INSTALL_PREFIX} --enable-minidebuginfo=no --enable-zlibdebuginfo=no
+    <SOURCE_DIR>/configure --prefix=${STAGED_INSTALL_PREFIX} --enable-minidebuginfo=no --enable-zlibdebuginfo=no --enable-shared=no
     BUILD_IN_SOURCE
     1
     BUILD_COMMAND
@@ -487,6 +488,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
     -DGPERFTOOLS_BUILD_STATIC=ON
     -DEFAULT_BUILD_MINIMAL=ON
+    -Dgperftools_build_benchmark=OFF
     BUILD_COMMAND
     make -j${CPU_CORE}
   )


### PR DESCRIPTION
Like #1783 mentioned, build under macos will produce more expressive sanitize log. But not  everyone use mac, so it's better to make pika could build using same toolchain like macos do.