### PR TITLE
fix: slove the coredump for monitor

### DIFF
--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1108,13 +1108,11 @@ void PikaServer::AddMonitorMessage(const std::string& monitor_message) {
       it = pika_monitor_clients_.erase(it);
     }
   }
-
-  lock.unlock(); // SendReply without lock
-
   for (const auto& cli : clients) {
     cli->WriteResp(msg);
     cli->SendReply();
   }
+  lock.unlock(); // SendReply without lock
 }
 
 void PikaServer::AddMonitorClient(const std::shared_ptr<PikaClientConn>& client_ptr) {


### PR DESCRIPTION
fix #1689 

<img width="602" alt="截屏2023-07-24 13 08 27" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/321c305c-b936-4fca-b4c0-ec6df239cccd">

把原先处于上面的解锁步骤改到了下面，防止多并发情况下对reply消息的组装导致协议返回错误
pika/src/pika_server.cc +1111
<img width="814" alt="截屏2023-07-24 13 10 18" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/80dab370-a79f-4613-9146-16b9e6388cac">
