### PR TITLE
Turn off the TRACE output by default

### DIFF
--- a/src/storage/src/debug.h
+++ b/src/storage/src/debug.h
@@ -5,7 +5,7 @@
 
 #ifndef SRC_DEBUG_H_
 #define SRC_DEBUG_H_
-
+#define NDEBUG
 #ifndef NDEBUG
 #  define TRACE(M, ...) fprintf(stderr, "[TRACE] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 #  define DEBUG(M, ...) fprintf(stderr, "[Debug] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)

--- a/src/storage/src/debug.h
+++ b/src/storage/src/debug.h
@@ -5,13 +5,17 @@
 
 #ifndef SRC_DEBUG_H_
 #define SRC_DEBUG_H_
-#define NDEBUG
+
 #ifndef NDEBUG
-#  define TRACE(M, ...) fprintf(stderr, "[TRACE] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 #  define DEBUG(M, ...) fprintf(stderr, "[Debug] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 #else
-#  define TRACE(M, ...) {}
 #  define DEBUG(M, ...) {}
 #endif  // NDEBUG
+
+#ifdef TRACE_ON
+#  define TRACE(M, ...) fprintf(stderr, "[TRACE] (%s:%d) " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#else
+#  define TRACE(M, ...) {}
+#endif
 
 #endif  // SRC_DEBUG_H_


### PR DESCRIPTION
Turning off this output can speed up the compaction process, it should not be turned on unless you are debuging relevant code.

![Screenshot 2023-07-25 093809](https://github.com/OpenAtomFoundation/pika/assets/41671101/3e07e443-3152-466c-bb5c-bca6817f67e6)
