### PR TITLE
Fix: resend msgs when client_thread send failed

### DIFF
--- a/src/net/src/client_thread.cc
+++ b/src/net/src/client_thread.cc
@@ -346,13 +346,11 @@ void ClientThread::ProcessNotifyEvents(const NetFiredEvent* pfe) {
               send_failed_msgs.push_back(msg);
             }
           }
-          {
-            std::lock_guard l(mu_);
-            if (!send_failed_msgs.empty()) {
-              send_failed_msgs.insert(send_failed_msgs.end(), to_send_[ip_port].begin(),
-                                      to_send_[ip_port].end());
-              send_failed_msgs.swap(to_send_[ip_port]);
-            }
+          std::lock_guard l(mu_);
+          if (!send_failed_msgs.empty()) {
+            send_failed_msgs.insert(send_failed_msgs.end(), to_send_[ip_port].begin(),
+                                    to_send_[ip_port].end());
+            send_failed_msgs.swap(to_send_[ip_port]);
             NotifyWrite(ip_port);
           }
         } else if (ti.notify_type() == kNotiClose) {

--- a/src/net/src/client_thread.cc
+++ b/src/net/src/client_thread.cc
@@ -29,7 +29,7 @@ ClientThread::ClientThread(ConnFactory* conn_factory, int cron_interval, int kee
     : keepalive_timeout_(keepalive_timeout),
       cron_interval_(cron_interval),
       handle_(handle),
-      
+
       private_data_(private_data),
       conn_factory_(conn_factory) {
   net_multiplexer_.reset(CreateNetMultiplexer());
@@ -339,14 +339,12 @@ void ClientThread::ProcessNotifyEvents(const NetFiredEvent* pfe) {
               continue;
             }
             msgs.swap(iter->second);
-            to_send_.erase(iter);
           }
           // get msg from to_send_
           std::vector<std::string> send_failed_msgs;
-          for (auto& msg : msgs) {
+          for (const auto& msg : msgs) {
             if (ipport_conns_[ip_port]->WriteResp(msg)) {
               send_failed_msgs.push_back(msg);
-              NotifyWrite(ip_port);
             }
           }
           {
@@ -355,6 +353,7 @@ void ClientThread::ProcessNotifyEvents(const NetFiredEvent* pfe) {
               send_failed_msgs.insert(send_failed_msgs.end(), to_send_[ip_port].begin(),
                                       to_send_[ip_port].end());
               send_failed_msgs.swap(to_send_[ip_port]);
+              NotifyWrite(ip_port);
             }
           }
         } else if (ti.notify_type() == kNotiClose) {

--- a/src/net/src/client_thread.cc
+++ b/src/net/src/client_thread.cc
@@ -331,21 +331,31 @@ void ClientThread::ProcessNotifyEvents(const NetFiredEvent* pfe) {
             // connection exist
             net_multiplexer_->NetModEvent(ipport_conns_[ip_port]->fd(), 0, kReadable | kWritable);
           }
+          std::vector<std::string> msgs;
           {
             std::lock_guard l(mu_);
             auto iter = to_send_.find(ip_port);
             if (iter == to_send_.end()) {
               continue;
             }
-            // get msg from to_send_
-            std::vector<std::string>& msgs = iter->second;
-            for (auto& msg : msgs) {
-              if (ipport_conns_[ip_port]->WriteResp(msg)) {
-                to_send_[ip_port].push_back(msg);
-                NotifyWrite(ip_port);
-              }
-            }
+            msgs.swap(iter->second);
             to_send_.erase(iter);
+          }
+          // get msg from to_send_
+          std::vector<std::string> send_failed_msgs;
+          for (auto& msg : msgs) {
+            if (ipport_conns_[ip_port]->WriteResp(msg)) {
+              send_failed_msgs.push_back(msg);
+              NotifyWrite(ip_port);
+            }
+          }
+          {
+            std::lock_guard l(mu_);
+            if (!send_failed_msgs.empty()) {
+              send_failed_msgs.insert(send_failed_msgs.end(), to_send_[ip_port].begin(),
+                                      to_send_[ip_port].end());
+              send_failed_msgs.swap(to_send_[ip_port]);
+            }
           }
         } else if (ti.notify_type() == kNotiClose) {
           LOG(INFO) << "received kNotiClose";


### PR DESCRIPTION
resend msgs when client_thread send failed and narrow down critical section 

Fixes: #1815