### PR TITLE
fix: fix pika coredump when process exit

### DIFF
--- a/src/net/src/holy_thread.h
+++ b/src/net/src/holy_thread.h
@@ -52,6 +52,7 @@ class HolyThread : public ServerThread {
   virtual std::shared_ptr<NetConn> get_conn(int fd);
 
   void ProcessNotifyEvents(const net::NetFiredEvent* pfe) override;
+  void Cleanup();
 
  private:
   mutable pstd::RWMutex rwlock_; /* For external statistics */
@@ -72,7 +73,6 @@ class HolyThread : public ServerThread {
   void HandleConnEvent(NetFiredEvent* pfe) override;
 
   void CloseFd(const std::shared_ptr<NetConn>& conn);
-  void Cleanup();
 };  // class HolyThread
 
 }  // namespace net

--- a/src/pika_repl_server.cc
+++ b/src/pika_repl_server.cc
@@ -46,6 +46,7 @@ int PikaReplServer::Start() {
 int PikaReplServer::Stop() {
   server_tp_->stop_thread_pool();
   pika_repl_server_thread_->StopThread();
+  pika_repl_server_thread_->Cleanup();
   return 0;
 }
 


### PR DESCRIPTION
修复pika进程退出时的coredump。 #1819 

出现问题的原因是pika_repl_server在执行FdClosedHandle时会用到pika_server，pika_server已经析构了，所以coredump.
修复方式是pika_repl_server在stop时，关闭掉连接。