### PR TITLE
doc: add pika-operator guide on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,33 @@ Here is an example usage of the script:
 ```bash
 ./build_docker.sh -p linux/amd64 -t private_registry/pika:latest
 ```
+### Use pika-operator to deploy
+
+You can use the `pika-operator` to easily deploy `pika` in a Kubernetes environment. 
+
+Please note that this operator is **NOT** recommended for use in a production environment.
+
+Local Deploy：
+
+1. install [MiniKube](https://minikube.sigs.k8s.io/docs/start/)
+2. deploy pika-operator
+```bash
+cd tools/pika_operator
+make minikube-up # run this if you don't have a minikube cluster
+make local-deploy
+```
+3. create pika instance
+```
+cd tools/pika_operator
+kubectl apply -f examples/pika-sample/
+
+# check pika status
+kubectl get pika pika-sample
+
+# get pika instance info
+kubectl run pika-sample-test --image redis -it --rm --restart=Never \
+  -- /usr/local/bin/redis-cli -h pika-sample -p 9221 info
+```
 
 ## Performance
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -159,6 +159,33 @@ redis-cli -p 9221 "info"
 ./build_docker.sh -p linux/amd64 -t private_registry/pika:latest
 ```
 
+### 使用 pika-operator 部署
+
+使用 pika-operator 可以在简单的在 Kubernetes 环境中部署 pika 单实例。
+请勿在生产环境中使用此功能。
+
+本地安装：
+
+1. 安装 [MiniKube](https://minikube.sigs.k8s.io/docs/start/)
+2. 部署 pika-operator
+```bash
+cd tools/pika_operator
+make minikube-up # run this if you don't have a minikube cluster
+make local-deploy
+```
+3. 创建 pika 实例
+```
+cd tools/pika_operator
+kubectl apply -f examples/pika-sample/
+
+# check pika status
+kubectl get pika pika-sample
+
+# get pika instance info
+kubectl run pika-sample-test --image redis -it --rm --restart=Never \
+  -- /usr/local/bin/redis-cli -h pika-sample -p 9221 info
+```
+
 ## 性能 (感谢[deep011](https://github.com/deep011)提供性能测试结果)
 ### 注!!!
 本测试结果是在特定环境特定场景下得出的，不能够代表所有环境及场景下的表现，__仅供参考__。

--- a/README_CN.md
+++ b/README_CN.md
@@ -161,7 +161,7 @@ redis-cli -p 9221 "info"
 
 ### 使用 pika-operator 部署
 
-使用 pika-operator 可以在简单的在 Kubernetes 环境中部署 pika 单实例。
+使用 `pika-operator` 可以简单的在 Kubernetes 环境中部署单实例 `pika` 。
 请勿在生产环境中使用此功能。
 
 本地安装：


### PR DESCRIPTION
This PR add some guide for pika-operator on readme, which will help people to use pika-operator deploy pika on kubernetes envirment.

Because the pika-operator is still relatively simple and not suitable for use in a production environment, a disclaimer has also been added to the guide.