### PR TITLE
[WIP] fix: heartbeat oacket sending logic issue in master node

### DIFF
--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -123,6 +123,8 @@ class SyncMasterSlot : public SyncSlot {
   int32_t session_id_ = 0;
 
   ConsensusCoordinator coordinator_;
+
+  std::atomic<uint32_t> sent_acked_mismatch_count_ = 0;
 };
 
 class SyncSlaveSlot : public SyncSlot {

--- a/tests/integration/pika_replication_test.py
+++ b/tests/integration/pika_replication_test.py
@@ -22,6 +22,12 @@ def test_del_replication():
     # 创建Redis客户端
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -118,6 +124,12 @@ def test_msetnx_replication():
     print("start test_msetnx_replication")
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -187,6 +199,12 @@ def test_mset_replication():
     print("start test_mset_replication")
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -254,6 +272,11 @@ def test_smove_replication():
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
 
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -303,6 +326,12 @@ def test_rpoplpush_replication():
     print("start test_rpoplpush_replication")
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -386,6 +415,12 @@ def test_sdiffstore_replication():
 
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -451,6 +486,12 @@ def test_sinterstore_replication():
 
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -513,6 +554,12 @@ def test_zunionstore_replication():
 
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -567,6 +614,12 @@ def test_zinterstore_replication():
 
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -629,6 +682,12 @@ def test_sunionstore_replication():
 
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -684,6 +743,12 @@ def test_bitop_replication():
 
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -737,6 +802,12 @@ def test_pfmerge_replication():
 
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
+
     if delay_slave_of:
         slave.slaveof("no", "one")
     else:
@@ -785,6 +856,11 @@ def test_migrateslot_replication():
     print("start test_migrateslot_replication")
     master = redis.Redis(host=master_ip, port=int(master_port), db=0)
     slave = redis.Redis(host=slave_ip, port=int(slave_port), db=0)
+
+    slave.slaveof("no", "one")
+    time.sleep(5)
+    master.flushdb()
+    slave.flushdb()
 
     # open slot migrate
     master.config_set("slotmigrate", "yes")


### PR DESCRIPTION
Increase the counter sent_acked_mismatch_count_ to record the counts of sent_offset != acked_offset to avoid blocking the sending of heartbeat packets. When there is still no equality after ten heartbeats, the slave will be deleted.

Fixes: #1856