### PR TITLE
ci: add nightly and release image build action

### DIFF
--- a/.github/workflows/codis.yml
+++ b/.github/workflows/codis.yml
@@ -46,6 +46,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./codis
+          platforms: linux/amd64,linux/arm64
           file: ./codis/Dockerfile
           push: false
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/codis.yml
+++ b/.github/workflows/codis.yml
@@ -52,7 +52,6 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./codis
-          platforms: linux/amd64,linux/arm64
           file: ./codis/Dockerfile
           push: false
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/codis.yml
+++ b/.github/workflows/codis.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7

--- a/.github/workflows/codis.yml
+++ b/.github/workflows/codis.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           images: pikadb/codis
       
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./codis

--- a/.github/workflows/codis.yml
+++ b/.github/workflows/codis.yml
@@ -27,4 +27,26 @@ jobs:
 
     - name: Test
       run: |
-        cd codis && make -j
+       cd codis && make -j
+
+  build_codis_image:
+    name: Build Codis Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: pikadb/codis
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./codis
+          file: ./codis/Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -229,7 +229,6 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: false
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -225,7 +225,7 @@ jobs:
         with:
           images: pikadb/pika
       
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -223,6 +223,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: false
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -205,3 +205,26 @@ jobs:
           cd ../tests/integration/
           chmod +x integrate_test.sh 
           sh integrate_test.sh
+
+  build_pika_image:
+    name: Build Pika Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: pikadb/pika
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -213,6 +213,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7

--- a/.github/workflows/publish_nightly_docker_image.yml
+++ b/.github/workflows/publish_nightly_docker_image.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -60,6 +61,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./codis
+          platforms: linux/amd64,linux/arm64
           file: ./codis/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish_nightly_docker_image.yml
+++ b/.github/workflows/publish_nightly_docker_image.yml
@@ -1,0 +1,67 @@
+name: Publish Docker image Nightly
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+jobs:
+  push_pika_to_registry:
+    name: Push Pika Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: pikadb/pika-dev-nightly
+          tags: |
+            type=schedule,prefix={{branch}},pattern={{date 'YYYYMMDD'}}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  push_codis_to_registry:
+    name: Push Codis Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: pikadb/codis-dev-nightly
+          tags: |
+            type=schedule,prefix={{branch}},pattern={{date 'YYYYMMDD'}}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./codis
+          file: ./codis/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/publish_nightly_docker_image.yml
+++ b/.github/workflows/publish_nightly_docker_image.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -42,6 +48,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/publish_release_docker_image.yml
+++ b/.github/workflows/publish_release_docker_image.yml
@@ -28,6 +28,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -56,6 +57,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: ./codis
+          platforms: linux/amd64,linux/arm64
           file: ./codis/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish_release_docker_image.yml
+++ b/.github/workflows/publish_release_docker_image.yml
@@ -12,6 +12,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
       
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -40,6 +46,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/publish_release_docker_image.yml
+++ b/.github/workflows/publish_release_docker_image.yml
@@ -1,0 +1,63 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_pika_to_registry:
+    name: Push Pika Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: pikadb/pika
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  push_codis_to_registry:
+    name: Push Codis Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: pikadb/codis
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./codis
+          file: ./codis/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/codis/Dockerfile
+++ b/codis/Dockerfile
@@ -1,9 +1,15 @@
 FROM golang:1.20 AS builder
 
+ARG ENABLE_PROXY=false
+
+RUN if [ "$ENABLE_PROXY" = "true" ] ; \
+    then go env -w GOPROXY=https://goproxy.io,direct; \
+    fi 
+
 WORKDIR /codis
 COPY . /codis
 
-RUN make build-all
+RUN go env && make build-all
 
 FROM ubuntu:22.04
 

--- a/codis/Dockerfile
+++ b/codis/Dockerfile
@@ -1,14 +1,26 @@
-FROM golang:1.8
+FROM golang:1.20 AS builder
 
-RUN apt-get update
-RUN apt-get install -y autoconf
+WORKDIR /codis
+COPY . /codis
 
-ENV GOPATH /gopath
-ENV CODIS  ${GOPATH}/src/github.com/CodisLabs/codis
-ENV PATH   ${GOPATH}/bin:${PATH}:${CODIS}/bin
-COPY . ${CODIS}
+RUN make build-all
 
-RUN make -C ${CODIS} distclean
-RUN make -C ${CODIS} build-all
+FROM ubuntu:22.04
+
+ARG ENABLE_PROXY=false
+
+RUN if [ "$ENABLE_PROXY" = "true" ] ; \
+    then sed -i 's/http:\/\/archive.ubuntu.com/http:\/\/mirrors.aliyun.com/g' /etc/apt/sources.list ; \
+         sed -i 's/http:\/\/ports.ubuntu.com/http:\/\/mirrors.aliyun.com/g' /etc/apt/sources.list ; \
+    fi 
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /codis/bin /codis/bin
+COPY --from=builder /codis/config /codis/config
+COPY --from=builder /codis/scripts /codis/scripts
+COPY --from=builder /codis/admin /codis/admin
 
 WORKDIR /codis


### PR DESCRIPTION
This PR has 3 changes.
1. add nightly & release image publish github action
2. fix codis and pika dockerfile
3. add codis and pika docker build on pr open

nightly build image will be like 
- `pikadb/pika-dev-nightly:unstable20230805`
- `pikadb/codis-dev-nightly:unstable20230805`

nightly build time is 2AM UTC, which is 10:00 AM in China.

release build will triggered when new release is set, and image will be like
- `pikadb/pika-dev-nightly:v3.5.0-alpha`
- `pikadb/codis-dev-nightly:v3.5.0-alpha`

NOTE:
publish need add fellow action secrets on github setting.

- DOCKER_USERNAME
- DOCKER_PASSWORD

fix #1163

