### PR TITLE
fix lpop/rpop response

### DIFF
--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -333,7 +333,9 @@ void LPopCmd::Do(std::shared_ptr<Slot> slot) {
   rocksdb::Status s = slot->db()->LPop(key_, count_, &elements);
 
   if (s.ok()) {
-    res_.AppendArrayLenUint64(elements.size());
+    if(elements.size() > 1) {
+      res_.AppendArrayLenUint64(elements.size());
+    }
     for (const auto& element : elements) {
       res_.AppendString(element);
     }
@@ -561,7 +563,9 @@ void RPopCmd::Do(std::shared_ptr<Slot> slot) {
   std::vector<std::string> elements;
   rocksdb::Status s = slot->db()->RPop(key_, count_, &elements);
   if (s.ok()) {
+    if(elements.size() > 1){
     res_.AppendArrayLenUint64(elements.size());
+    }
     for (const auto& element : elements) {
       res_.AppendString(element);
     }

--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -560,13 +560,13 @@ void RPopCmd::DoInitial() {
   }
 }
 void RPopCmd::Do(std::shared_ptr<Slot> slot) {
-  std::vector<std::string> elements;
+  std::vector <std::string> elements;
   rocksdb::Status s = slot->db()->RPop(key_, count_, &elements);
   if (s.ok()) {
-    if (elements.size() > 1){
-    res_.AppendArrayLenUint64(elements.size());
+    if (elements.size() > 1) {
+      res_.AppendArrayLenUint64(elements.size());
     }
-    for (const auto& element : elements) {
+    for (const auto &element: elements) {
       res_.AppendString(element);
     }
   } else if (s.IsNotFound()) {

--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -333,7 +333,7 @@ void LPopCmd::Do(std::shared_ptr<Slot> slot) {
   rocksdb::Status s = slot->db()->LPop(key_, count_, &elements);
 
   if (s.ok()) {
-    if(elements.size() > 1) {
+    if (elements.size() > 1) {
       res_.AppendArrayLenUint64(elements.size());
     }
     for (const auto& element : elements) {
@@ -563,7 +563,7 @@ void RPopCmd::Do(std::shared_ptr<Slot> slot) {
   std::vector<std::string> elements;
   rocksdb::Status s = slot->db()->RPop(key_, count_, &elements);
   if (s.ok()) {
-    if(elements.size() > 1){
+    if (elements.size() > 1){
     res_.AppendArrayLenUint64(elements.size());
     }
     for (const auto& element : elements) {


### PR DESCRIPTION
fix #1894 

**Problem**:
For current code, Lpop/Rpop's responses are always start with *n, but according to redis protocal, a single line response should not start with *n, which is used to indicate how many lines there are when the response contains multiple lines.

**Use Case**:
![image](https://github.com/OpenAtomFoundation/pika/assets/41671101/fe699b61-1d1d-44e7-9526-0ca02e8513d4)


At this use case, 
When the **server is Pika**, tcp package of lpop's response: (containing a *1, which is invalid)
![85bc4f87d45d97f3ba11adb463be506](https://github.com/OpenAtomFoundation/pika/assets/41671101/8842768c-9dc3-4298-b3f4-ad11fbd15284)

When the **server is Redis**,  tcp package of lpop's response: (single line format, no *n at the start)
![8cc779733dd043b43bfbd6fbb6c02af](https://github.com/OpenAtomFoundation/pika/assets/41671101/a17f6b99-80d7-4f77-868d-d9d041c9ea76)


**Consequence**:
For most of the implementation of redis client, the response still could be parsed.
But for some other client, parsing error will occur:
![3440c5109f3fb364bb91536575c1b83](https://github.com/OpenAtomFoundation/pika/assets/41671101/061f559c-2841-48ca-865f-a9164f77301e)
 