### PR TITLE
operator: automatic registration for the Pika service

### DIFF
--- a/codis/Dockerfile
+++ b/codis/Dockerfile
@@ -21,7 +21,10 @@ RUN if [ "$ENABLE_PROXY" = "true" ] ; \
     fi 
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates && \
+    apt-get install -y ca-certificates  \
+    jq \
+    netcat \
+    && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /codis/bin /codis/bin

--- a/tools/kubeblocks_helm/pika-cluster/templates/cluster.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/templates/cluster.yaml
@@ -37,11 +37,12 @@ spec:
       volumeClaimTemplates:
         - name: data # ref clusterdefinition components.containers.volumeMounts.name
           spec:
+            storageClassName: {{ .Values.persistence.pikaData.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ $.Values.persistence.data.size }}
+                storage: {{ $.Values.persistence.pikaData.size }}
       {{- end }}
     {{- end }}
     - name: etcd # user-defined
@@ -65,12 +66,12 @@ spec:
       volumeClaimTemplates:
         - name: data # ref clusterdefinition components.containers.volumeMounts.name
           spec:
-            storageClassName: {{ .Values.persistence.data.storageClassName }}
+            storageClassName: {{ .Values.persistence.etcdData.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ .Values.persistence.data.size }}
+                storage: {{ .Values.persistence.etcdData.size }}
       {{- end }}
     - name: codis-proxy
       componentDefRef: codis-proxy # ref clusterDefinition componentDefs.name
@@ -84,16 +85,6 @@ spec:
           cpu: {{ .requests.cpu | quote }}
           memory: {{ .requests.memory | quote }}
       {{- end }}
-      {{- if .Values.persistence.enabled }}
-      volumeClaimTemplates:
-        - name: data # ref clusterdefinition components.containers.volumeMounts.name
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ .Values.persistence.data.size }}
-      {{- end }}
     - name: codis-fe
       componentDefRef: codis-fe # ref clusterDefinition componentDefs.name
       replicas: {{ .Values.codisFeReplicaCount | default 1 }}
@@ -106,16 +97,6 @@ spec:
           cpu: {{ .requests.cpu | quote }}
           memory: {{ .requests.memory | quote }}
       {{- end }}
-      {{- if .Values.persistence.enabled }}
-      volumeClaimTemplates:
-        - name: data # ref clusterdefinition components.containers.volumeMounts.name
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ .Values.persistence.data.size }}
-      {{- end }}
     - name: codis-dashboard
       componentDefRef: codis-dashboard # ref clusterDefinition componentDefs.name
       replicas: 1
@@ -127,14 +108,4 @@ spec:
         requests:
           cpu: {{ .requests.cpu | quote }}
           memory: {{ .requests.memory | quote }}
-    {{- end }}
-    {{- if .Values.persistence.enabled }}
-      volumeClaimTemplates:
-        - name: data # ref clusterdefinition components.containers.volumeMounts.name
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ .Values.persistence.data.size }}
     {{- end }}

--- a/tools/kubeblocks_helm/pika-cluster/templates/cluster.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/templates/cluster.yaml
@@ -15,15 +15,16 @@ spec:
   tolerations: {{ . | toYaml | nindent 4 }}
   {{- end }}
   componentSpecs:
-    - name: pika # user-defined
-      componentDefRef: pika # ref clusterDefinition componentDefs.name
-      monitor: {{ .Values.monitor.enabled | default false }}
-      enabledLogs: {{ .Values.enabledLogs | toJson | indent 4 }}
-      replicas: {{ .Values.replicaCount | default 2 }}
-      serviceAccountName: {{ include "pika-cluster.serviceAccountName" . }}
+    {{- range $i := until (int .Values.replicaCount) }}
+    - name: pika-group-{{ add ($i) 1 }} # user-defined
+      componentDefRef: pika-group # ref clusterDefinition componentDefs.name
+      monitor: {{ $.Values.monitor.enabled | default false }}
+      enabledLogs: {{ $.Values.enabledLogs | toJson | indent 4 }}
+      replicas: {{ add (int $.Values.slaveCount) 1 | default 2 }}
+      serviceAccountName: {{ include "pika-cluster.serviceAccountName" $ }}
       switchPolicy:
-        type: {{ .Values.switchPolicy.type}}
-      {{- with  .Values.resources }}
+        type: {{ $.Values.switchPolicy.type}}
+      {{- with  $.Values.resources }}
       resources:
         limits:
           cpu: {{ .limits.cpu | quote }}
@@ -32,7 +33,7 @@ spec:
           cpu: {{ .requests.cpu | quote }}
           memory: {{ .requests.memory | quote }}
       {{- end }}
-      {{- if .Values.persistence.enabled }}
+      {{- if $.Values.persistence.enabled }}
       volumeClaimTemplates:
         - name: data # ref clusterdefinition components.containers.volumeMounts.name
           spec:
@@ -40,8 +41,9 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ .Values.persistence.data.size }}
+                storage: {{ $.Values.persistence.data.size }}
       {{- end }}
+    {{- end }}
     - name: etcd # user-defined
       componentDefRef: etcd # ref clusterdefinition components.name
       monitor: {{ .Values.monitor.enabled | default false }}

--- a/tools/kubeblocks_helm/pika-cluster/templates/cluster.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/templates/cluster.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: {{ include "pika-cluster.serviceAccountName" $ }}
       switchPolicy:
         type: {{ $.Values.switchPolicy.type}}
-      {{- with  $.Values.resources }}
+      {{- with  $.Values.resources.pikaGroup }}
       resources:
         limits:
           cpu: {{ .limits.cpu | quote }}
@@ -35,21 +35,23 @@ spec:
       {{- end }}
       {{- if $.Values.persistence.enabled }}
       volumeClaimTemplates:
+        {{- with  $.Values.persistence.pikaData }}
         - name: data # ref clusterdefinition components.containers.volumeMounts.name
           spec:
-            storageClassName: {{ .Values.persistence.pikaData.storageClassName }}
+            storageClassName: {{ .storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ $.Values.persistence.pikaData.size }}
+                storage: {{ .size }}
+        {{- end }}
       {{- end }}
     {{- end }}
     - name: etcd # user-defined
       componentDefRef: etcd # ref clusterdefinition components.name
       monitor: {{ .Values.monitor.enabled | default false }}
       replicas: {{ .Values.etcdReplicaCount| default 3 }}
-      {{- with  .Values.resources }}
+      {{- with  .Values.resources.etcd }}
       resources:
         {{- with .limits }}
         limits:
@@ -64,19 +66,21 @@ spec:
       {{- end }}
       {{- if .Values.persistence.enabled }}
       volumeClaimTemplates:
+        {{- with  $.Values.persistence.pikaData }}
         - name: data # ref clusterdefinition components.containers.volumeMounts.name
           spec:
-            storageClassName: {{ .Values.persistence.etcdData.storageClassName }}
+            storageClassName: {{ .storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ .Values.persistence.etcdData.size }}
+                storage: {{ .size }}
+        {{- end }}
       {{- end }}
     - name: codis-proxy
       componentDefRef: codis-proxy # ref clusterDefinition componentDefs.name
       replicas: {{ .Values.codisProxyReplicaCount | default 2 }}
-      {{- with  .Values.resources }}
+      {{- with  .Values.resources.codisProxy }}
       resources:
         limits:
           cpu: {{ .limits.cpu | quote }}
@@ -88,7 +92,7 @@ spec:
     - name: codis-fe
       componentDefRef: codis-fe # ref clusterDefinition componentDefs.name
       replicas: {{ .Values.codisFeReplicaCount | default 1 }}
-      {{- with  .Values.resources }}
+      {{- with  .Values.resources.codisFe }}
       resources:
         limits:
           cpu: {{ .limits.cpu | quote }}
@@ -100,7 +104,7 @@ spec:
     - name: codis-dashboard
       componentDefRef: codis-dashboard # ref clusterDefinition componentDefs.name
       replicas: 1
-    {{- with  .Values.resources }}
+    {{- with  .Values.resources.codisFe }}
       resources:
         limits:
           cpu: {{ .limits.cpu | quote }}

--- a/tools/kubeblocks_helm/pika-cluster/values.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/values.yaml
@@ -7,6 +7,8 @@ fullnameOverride: ""
 
 replicaCount: 2
 
+slaveCount: 1
+
 etcdReplicaCount: 3
 
 codisProxyReplicaCount: 2

--- a/tools/kubeblocks_helm/pika-cluster/values.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/values.yaml
@@ -41,7 +41,10 @@ resources:
 
 persistence:
   enabled: true
-  data:
+  pikaData:
+    storageClassName:
+    size: 10Gi
+  etcdData:
     storageClassName:
     size: 1Gi
 

--- a/tools/kubeblocks_helm/pika-cluster/values.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/values.yaml
@@ -32,12 +32,41 @@ resources:
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
-    cpu: 500m
-    memory: 3Gi
-  requests:
-    cpu: 500m
-    memory: 1Gi
+  pikaGroup:
+    limits:
+      cpu: 500m
+      memory: 3Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  etcd:
+    limits:
+      cpu: 500m
+      memory: 3Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  codisProxy:
+    limits:
+      cpu: 500m
+      memory: 3Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  codisFe:
+    limits:
+      cpu: 500m
+      memory: 3Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  codisDashboard:
+    limits:
+      cpu: 500m
+      memory: 3Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
 
 persistence:
   enabled: true

--- a/tools/kubeblocks_helm/pika/script/admin.sh
+++ b/tools/kubeblocks_helm/pika/script/admin.sh
@@ -1,0 +1,84 @@
+#! /bin/bash
+set -x
+
+# set instance role
+set_instance_role() {
+  POD_ID=${HOSTNAME##*-}
+  echo "POD_ID: "${POD_ID}
+}
+
+# set group id
+set_group_id() {
+  GROUP_ID=${KB_CLUSTER_COMP_NAME##*-}
+  echo "GROUP_ID: "${GROUP_ID}
+}
+
+# set codis dashboard
+set_codis_dashboard() {
+  CODIS_DASHBOARD="${KB_CLUSTER_NAME}-codis-dashboard"
+  echo "CODIS_DASHBOARD: "${CODIS_DASHBOARD}
+  CODIS_ADMIN="/codis/bin/codis-admin --dashboard=${CODIS_DASHBOARD}:18080"
+  echo "CODIS_ADMIN: "${CODIS_ADMIN}
+}
+
+wait_server_running() {
+  until nc -z 127.0.0.1 9221; do
+    echo waiting for pika
+    sleep 2
+  done
+}
+
+wait_dashboard_running() {
+  until nc -z ${CODIS_DASHBOARD} 18080; do
+    echo waiting for codis dashboard
+    sleep 2
+  done
+}
+
+register_server() {
+  $CODIS_ADMIN --reload
+  if [ $? != 0 ]; then exit 1; fi
+  $CODIS_ADMIN --create-group --gid=${GROUP_ID} 1>/dev/null 2>&1
+  $CODIS_ADMIN --group-add --gid=${GROUP_ID} --addr=${KB_POD_FQDN}:9221
+  if [ $? != 0 -a ${POD_ID} -gt 1 ]; then exit 1; fi
+  $CODIS_ADMIN --sync-action --create --addr=${KB_POD_FQDN}:9221 1>/dev/null 2>&1
+}
+
+remove_server() {
+  $CODIS_ADMIN --reload
+  if [ $? != 0 ]; then exit 1; fi
+  gid=${GROUP_ID}
+  sleep 5
+  $CODIS_ADMIN --group-del --gid=${GROUP_ID} --addr=${KB_POD_FQDN}:9221
+}
+
+set_group_id
+set_instance_role
+set_codis_dashboard
+
+if [ $# -eq 1 ]; then
+  case $1 in
+  --help)
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --help                show help information"
+    echo "  --register-server     register server to dashboard"
+    echo "  --remove-server       remove server from dashboard"
+    exit 0
+    ;;
+  --register-server)
+    wait_dashboard_running
+    wait_server_running
+    register_server
+    exit 0
+    ;;
+  --remove-server)
+    remove_server
+    exit 0
+    ;;
+  *)
+    echo "Error: invalid option '$1'"
+    exit 1
+    ;;
+  esac
+fi

--- a/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
@@ -31,6 +31,7 @@ spec:
           templateRef: pika-script-template
           namespace: {{ .Release.Namespace }}
           volumeName: script
+          defaultMode: 0555
       podSpec:
         containers:
           - name: pika
@@ -53,7 +54,7 @@ spec:
               - "/bin/bash"
             args:
               - "-c"
-              - "bash /script/admin.sh --register-server;tail -f /dev/null"
+              - "/script/admin.sh --register-server;tail -f /dev/null"
     - name: etcd
       workloadType: Stateful
       characterType: etcd

--- a/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
@@ -13,8 +13,8 @@ spec:
     host: "$(SVC_FQDN)"
     port: "$(SVC_PORT_pika)"
   componentDefs:
-    - name: pika
-      workloadType: Replication
+    - name: pika-group
+      workloadType: Stateful
       characterType: pika
       service:
         ports:
@@ -26,6 +26,11 @@ spec:
           templateRef: pika-conf-template
           namespace: {{ .Release.Namespace }}
           volumeName: config
+      scriptSpecs:
+        - name: pika-script
+          templateRef: pika-script-template
+          namespace: {{ .Release.Namespace }}
+          volumeName: script
       volumeTypes:
         - name: data
           type: data
@@ -45,6 +50,15 @@ spec:
             args:
               - "-c"
               - "/etc/pika/pika.conf"
+          - name: codis-admin
+            volumeMounts:
+              - name: script
+                mountPath: /script
+            command:
+              - "/bin/bash"
+            args:
+              - "-c"
+              - "bash /script/admin.sh --register-server;tail -f /dev/null"
     - name: etcd
       workloadType: Stateful
       characterType: etcd
@@ -137,7 +151,7 @@ spec:
               - name: ETCD_ENABLE_V2
                 value: "true"
     - name: codis-proxy
-      workloadType: Stateless
+      workloadType: Stateful
       characterType: pika
       service:
         ports:

--- a/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
@@ -31,9 +31,6 @@ spec:
           templateRef: pika-script-template
           namespace: {{ .Release.Namespace }}
           volumeName: script
-      volumeTypes:
-        - name: data
-          type: data
       podSpec:
         containers:
           - name: pika
@@ -41,8 +38,6 @@ spec:
               - name: pika
                 containerPort: 9221
             volumeMounts:
-              - name: data
-                mountPath: /data
               - name: config
                 mountPath: /etc/pika
             command:
@@ -289,9 +284,6 @@ spec:
           templateRef: pika-conf-template
           namespace: {{ .Release.Namespace }}
           volumeName: config
-      volumeTypes:
-        - name: data
-          type: data
       podSpec:
         initContainers:
           - name: wait-etcd
@@ -310,8 +302,6 @@ spec:
               - containerPort: 18080
                 name: dashboard
             volumeMounts:
-              - name: data
-                mountPath: /data
               - name: config
                 mountPath: /etc/codis
             env:

--- a/tools/kubeblocks_helm/pika/templates/clusterversion.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterversion.yaml
@@ -7,12 +7,15 @@ metadata:
 spec:
   clusterDefinitionRef: pika
   componentVersions:
-    - componentDefRef: pika
+    - componentDefRef: pika-group
       versionsContext:
         containers:
           - name: pika
             image: {{ include "pika.image" . }}
             imagePullPolicy: {{ include "pika.imagePullPolicy" . }}
+          - name: codis-admin
+            image: {{ include "codis.image" . }}
+            imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
     - componentDefRef: etcd
       versionsContext:
         containers:

--- a/tools/kubeblocks_helm/pika/templates/script.yaml
+++ b/tools/kubeblocks_helm/pika/templates/script.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pika-script-template
+  labels:
+    {{- include "pika.labels" . | nindent 4 }}
+data:
+  admin.sh: |-
+    {{- .Files.Get "script/admin.sh" | nindent 4 }}


### PR DESCRIPTION
This PR implements automatic registration for the Pika service, which will automatically register when it starts up, achieving self-organization of the cluster.  
It also includes some small improvements, such as allowing each component to independently set CPU, memory, and PVC.   

Automatic rebalancing for the cluster is not yet complete, for two reasons:  
1. The cluster's own rebalancing mechanism is incomplete and requires manually transferring the solt.  
2. It requires relying on Kubeblocks to implement scaling related functions for components in order to obtain the total number of components to determine if all Pika components are present. 

relate issue #1906
