### PR TITLE
fix: Solve the problem that the slot of the calculated key is negative

### DIFF
--- a/src/pika_slot_command.cc
+++ b/src/pika_slot_command.cc
@@ -786,7 +786,7 @@ int GetSlotsID(const std::string &str, uint32_t *pcrc, int *phastag) {
   } else {
     hastag = 1;
   }
-  auto crc = static_cast<int32_t>(CRC32CheckSum(tag, taglen));
+  uint32_t crc = CRC32CheckSum(tag, taglen);
   if (pcrc != nullptr) {
     *pcrc = crc;
   }


### PR DESCRIPTION
**fix:** #1940 

**Screenshots**

修改前：
<img width="450" alt="截屏2023-08-28 16 34 43" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/a36e8c57-c8d1-43fb-bc7e-cca81ae4d50d">
修改后：
<img width="346" alt="截屏2023-08-28 16 35 16" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/e3b8edda-ffe4-45e1-b3ee-0212ef010dcc">

**solution**

之前 CRC32CheckSum 函数返回 uint32_t 类型的值，由于之前的 Clang-tidy 返回值被强转为 int32_t 通过修改把强转的 static_cast<int32_t> 去掉即可
