### PR TITLE
fix: reduce exporter's non-essential logs

### DIFF
--- a/tools/pika_exporter/exporter/conf.go
+++ b/tools/pika_exporter/exporter/conf.go
@@ -35,7 +35,7 @@ func LoadConfig() error {
 	}
 
 	InfoConf.CheckInfo()
-	InfoConf.Display()
+	//InfoConf.Display()
 
 	return nil
 }
@@ -75,8 +75,8 @@ func (c *InfoConfig) Display() {
 }
 
 func (c *InfoConfig) CheckInfo() {
-    c.InfoAll = false
-    c.Info = false
+	c.InfoAll = false
+	c.Info = false
 
 	if c.Server && c.Data && c.Clients && c.Stats && c.CPU && c.Replication && c.Keyspace {
 		c.Info = true

--- a/tools/pika_exporter/exporter/metrics/parser.go
+++ b/tools/pika_exporter/exporter/metrics/parser.go
@@ -109,7 +109,7 @@ func (p *regexParser) Parse(m MetricMeta, c Collector, opt ParseOption) {
 
 	matchMaps := p.regMatchesToMap(s)
 	if len(matchMaps) == 0 {
-		log.Warnf("regexParser::Parse reg find sub match nil. name:%s text:%s", p.name, s)
+		log.Warnf("regexParser::Parse reg find sub match nil. name:%s", p.name)
 	}
 
 	extracts := make(map[string]string)
@@ -133,7 +133,7 @@ func (p *regexParser) regMatchesToMap(s string) []map[string]string {
 
 	multiMatches := p.reg.FindAllStringSubmatch(s, -1)
 	if len(multiMatches) == 0 {
-		log.Errorf("regexParser::regMatchesToMap reg find sub match nil. name:%s text:%s", p.name, s)
+		log.Errorf("regexParser::regMatchesToMap reg find sub match nil. name:%s", p.name)
 		return nil
 	}
 


### PR DESCRIPTION
**fix:** #1944 

**Screenshots**

修改前：
<img width="1014" alt="截屏2023-08-29 16 41 32" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/8c6c5ded-45ff-4e82-be32-a3b7effab08c">

修改后：
<img width="1097" alt="截屏2023-08-30 09 55 25" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/4d19c137-684b-4486-bfec-0a9ffcd05a5f">

**solution**

去掉了 infoall 里面打印出的信息