### PR TITLE
[Feature] pika-exporter: let one exporter monitor the whole cluster (#1929)

### DIFF
--- a/tools/pika_exporter/discovery/codis_dashboard.go
+++ b/tools/pika_exporter/discovery/codis_dashboard.go
@@ -1,0 +1,29 @@
+package discovery
+
+type CodisServerAction struct {
+	Action string `json:"action"`
+}
+
+type CodisServerInfo struct {
+	Server             string            `json:"server"`
+	Datacenter         string            `json:"datacenter"`
+	ServerAction       CodisServerAction `json:"action"`
+	ServerReplicaGroup bool              `json:"replica_group"`
+}
+
+type CodisModelInfo struct {
+	Id      int               `json:"id"`
+	Servers []CodisServerInfo `json:"servers"`
+}
+
+type CodisGroupInfo struct {
+	Models []CodisModelInfo `json:"models"`
+}
+
+type CodisStatsInfo struct {
+	Group CodisGroupInfo `json:"group"`
+}
+
+type CodisTopomInfo struct {
+	Stats CodisStatsInfo `json:"stats"`
+}

--- a/tools/pika_exporter/discovery/discovery.go
+++ b/tools/pika_exporter/discovery/discovery.go
@@ -2,6 +2,8 @@ package discovery
 
 import (
 	"encoding/csv"
+	"encoding/json"
+	"net/http"
 	"os"
 	"strings"
 
@@ -99,5 +101,58 @@ func NewFileDiscovery(fileName string) (*fileDiscovery, error) {
 }
 
 func (d *fileDiscovery) GetInstances() []Instance {
+	return d.instances
+}
+
+type codisDiscovery struct {
+	instances []Instance
+}
+
+func NewCodisDiscovery(url, password, alias string) (*codisDiscovery, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Warnln("Get codis topom failed:", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result CodisTopomInfo
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		log.Warnln("Response body decode failed:", err)
+		return &codisDiscovery{}, err
+	}
+
+	var addrs []string
+	for _, model := range result.Stats.Group.Models {
+		for _, server := range model.Servers {
+			if server.Server != "" {
+				addrs = append(addrs, server.Server)
+			}
+		}
+	}
+
+	passwords := strings.Split(password, defaultSeparator)
+	for len(passwords) < len(addrs) {
+		passwords = append(passwords, passwords[0])
+	}
+
+	aliases := strings.Split(alias, defaultSeparator)
+	for len(aliases) < len(addrs) {
+		aliases = append(aliases, aliases[0])
+	}
+
+	instances := make([]Instance, len(addrs))
+	for i := range addrs {
+		instances[i] = Instance{
+			Addr:     addrs[i],
+			Password: passwords[i],
+			Alias:    aliases[i],
+		}
+	}
+	return &codisDiscovery{instances: instances}, nil
+}
+
+func (d *codisDiscovery) GetInstances() []Instance {
 	return d.instances
 }

--- a/tools/pika_exporter/discovery/discovery_test.go
+++ b/tools/pika_exporter/discovery/discovery_test.go
@@ -1,0 +1,60 @@
+package discovery
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewCodisDiscovery(t *testing.T) {
+	jsonFile := "mockCodisTopom.json"
+	jsonData, err := ioutil.ReadFile(jsonFile)
+	if err != nil {
+		t.Fatalf("failed to read test data: %v", err)
+	}
+
+	var result CodisTopomInfo
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("failed to parse test data: %v", err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(result)
+	}))
+	defer ts.Close()
+
+	url := ts.URL
+	password := "password1,password2"
+	alias := ""
+
+	discovery, err := NewCodisDiscovery(url, password, alias)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expectedAddrs := []string{
+		"1.1.1.6:1100",
+		"1.1.1.7:1100",
+	}
+	expectedPasswords := []string{
+		"password1",
+		"password2",
+	}
+
+	if len(discovery.instances) != len(expectedAddrs) {
+		t.Errorf("expected %d instances but got %d", len(expectedAddrs), len(discovery.instances))
+	}
+
+	for i := range expectedAddrs {
+		if discovery.instances[i].Addr != expectedAddrs[i] {
+			t.Errorf("instance %d address: expected %s but got %s", i, expectedAddrs[i], discovery.instances[i].Addr)
+		}
+		if discovery.instances[i].Password != expectedPasswords[i] {
+			t.Errorf("instance %d password: expected %s but got %s", i, expectedPasswords[i], discovery.instances[i].Password)
+		}
+	}
+}

--- a/tools/pika_exporter/discovery/mockCodisTopom.json
+++ b/tools/pika_exporter/discovery/mockCodisTopom.json
@@ -1,0 +1,195 @@
+{
+    "version": "unknown version",
+    "compile": "2019-10-08 16:18:19 +0800 by go version go1.7.4 linux/amd64",
+    "config": {
+        "coordinator_name": "zookeeper",
+        "coordinator_addr": "1.1.1.1:2181,1.1.1.2:2181,1.1.1.3:2181",
+        "coordinator_auth": "",
+        "admin_addr": "0.0.0.0:1234",
+        "product_name": "test",
+        "migration_method": "semi-async",
+        "migration_parallel_slots": 100,
+        "migration_async_maxbulks": 200,
+        "migration_async_maxbytes": "32mb",
+        "migration_async_numkeys": 500,
+        "migration_timeout": "30s",
+        "sentinel_client_timeout": "10s",
+        "sentinel_quorum": 2,
+        "sentinel_parallel_syncs": 1,
+        "sentinel_down_after": "30s",
+        "sentinel_failover_timeout": "5m",
+        "sentinel_notification_script": "",
+        "sentinel_client_reconfig_script": ""
+    },
+    "model": {
+        "token": "sdf123sdf112xx4",
+        "start_time": "2021-06-28 11:32:49.497871229 +0800 CST",
+        "admin_addr": "1.1.1.4:12345",
+        "product_name": "test",
+        "pid": 1740,
+        "pwd": "/data/codis",
+        "sys": "Linux localhost.localdomain 3.10.0-693.el7.x86_64 #1 SMP Tue Aug 22 21:09:27 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux"
+    },
+    "stats": {
+        "closed": false,
+        "slots": [
+            {
+                "id": 0,
+                "group_id": 1,
+                "action": {}
+            },
+            {
+                "id": 1,
+                "group_id": 1,
+                "action": {}
+            }
+        ],
+        "group": {
+            "models": [
+                {
+                    "id": 1,
+                    "servers": [
+                        {
+                            "server": "1.1.1.6:1100",
+                            "datacenter": "",
+                            "action": {},
+                            "replica_group": false
+                        },
+                        {
+                            "server": "1.1.1.7:1100",
+                            "datacenter": "",
+                            "action": {
+                                "state": "synced"
+                            },
+                            "replica_group": false
+                        }
+                    ],
+                    "promoting": {},
+                    "out_of_sync": false
+                }
+            ],
+            "stats": {
+                "1.1.1.6:1100": {
+                    "stats": {
+                        "active_defrag_hits": "0"
+                    },
+                    "unixtime": 1693281655
+                },
+                "1.1.1.7:1100": {
+                    "stats": {
+                        "active_defrag_hits": "0"
+                    },
+                    "unixtime": 1693281655
+                },
+                    "unixtime": 1693281655
+                }
+        },
+        "proxy": {
+            "models": [
+                {
+                    "id": 2,
+                    "token": "4337153123141c4df6e363d281",
+                    "start_time": "2021-07-06 10:30:33.588330243 +0800 CST",
+                    "datacenter": ""
+                },
+                {
+                    "id": 3,
+                    "token": "ef7e1ad5422ab8e28241410e856",
+                    "start_time": "2021-07-06 10:34:21.305110128 +0800 CST",
+                    "datacenter": ""
+                }
+            ],
+            "stats": {
+                "4337153c64e1babd3b5c4df6e363d281": {
+                    "stats": {
+                        "online": true,
+                        "closed": false,
+                        "sentinels": {},
+                        "ops": {
+                            "total": 791976,
+                            "fails": 6,
+                            "redis": {
+                                "errors": 1
+                            },
+                            "qps": 11
+                        },
+                        "sessions": {
+                            "total": 528784,
+                            "alive": 34
+                        },
+                        "rusage": {
+                            "now": "2023-08-29 12:00:53.605229492 +0800 CST",
+                            "cpu": 0.009997645624438964,
+                            "mem": 162881512312336,
+                            "raw": {
+                                "utime": 4474490510000000,
+                                "stime": 4125310130000000,
+                                "cutime": 0,
+                                "cstime": 0,
+                                "num_threads": 358,
+                                "vm_size": 29351325696,
+                                "vm_rss": 162881536
+                            }
+                        },
+                        "backend": {
+                            "primary_only": false
+                        }
+                    },
+                    "unixtime": 1693281654
+                },
+                "ef87e1ad5422ab8e2816b6694750e856": {
+                    "stats": {
+                        "online": true,
+                        "closed": false,
+                        "sentinels": {},
+                        "ops": {
+                            "total": 27570566,
+                            "fails": 31,
+                            "redis": {
+                                "errors": 2
+                            },
+                            "qps": 8
+                        },
+                        "sessions": {
+                            "total": 6349,
+                            "alive": 4
+                        },
+                        "rusage": {
+                            "now": "2023-08-29 12:00:54.516379647 +0800 CST",
+                            "cpu": 0,
+                            "mem": 19081124412160,
+                            "raw": {
+                                "utime": 1666690710000000,
+                                "stime": 2573457670000000,
+                                "cutime": 0,
+                                "cstime": 0,
+                                "num_threads": 51,
+                                "vm_size": 8284008448,
+                                "vm_rss": 190812160
+                            }
+                        },
+                        "backend": {
+                            "primary_only": false
+                        }
+                    },
+                    "unixtime": 1693281654
+                }
+            }
+        },
+        "slot_action": {
+            "interval": 0,
+            "disabled": false,
+            "progress": {
+                "status": ""
+            },
+            "executor": 0
+        },
+        "sentinels": {
+            "model": {
+                "out_of_sync": false
+            },
+            "stats": {},
+            "masters": {}
+        }
+    }
+}

--- a/tools/pika_exporter/main.go
+++ b/tools/pika_exporter/main.go
@@ -18,6 +18,7 @@ import (
 var (
 	hostFile           = flag.String("pika.host-file", getEnv("PIKA_HOST_FILE", ""), "Path to file containing one or more pika nodes, separated by newline. NOTE: mutually exclusive with pika.addr.")
 	addr               = flag.String("pika.addr", getEnv("PIKA_ADDR", ""), "Address of one or more pika nodes, separated by comma.")
+	codisaddr          = flag.String("codis.addr", getEnv("CODIS_ADDR", "http://localhost:port/topom"), "Address of one or more codis topom urls, separated by comma.")
 	password           = flag.String("pika.password", getEnv("PIKA_PASSWORD", ""), "Password for one or more pika nodes, separated by comma.")
 	alias              = flag.String("pika.alias", getEnv("PIKA_ALIAS", ""), "Pika instance alias for one or more pika nodes, separated by comma.")
 	namespace          = flag.String("namespace", getEnv("PIKA_EXPORTER_NAMESPACE", "pika"), "Namespace for metrics.")
@@ -92,6 +93,8 @@ func main() {
 	var dis discovery.Discovery
 	if *hostFile != "" {
 		dis, err = discovery.NewFileDiscovery(*hostFile)
+	} else if *codisaddr != "" {
+		dis, err = discovery.NewCodisDiscovery(*codisaddr, *password, *alias)
 	} else {
 		dis, err = discovery.NewCmdArgsDiscovery(*addr, *password, *alias)
 	}

--- a/tools/pika_exporter/main.go
+++ b/tools/pika_exporter/main.go
@@ -115,23 +115,117 @@ func main() {
 	buildInfo.WithLabelValues(BuildVersion, BuildCommitSha, BuildDate, GoVersion).Set(1)
 
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(e)
-	registry.MustRegister(buildInfo)
+	updatechan := make(chan int)
+	defer close(updatechan)
 
-	http.Handle(*metricPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	var exptr_regis ExporterInterface = NewExporterRegistry(dis, e, buildInfo, registry, updatechan)
+	exptr_regis.Start()
+	defer exptr_regis.Stop()
+
+	http.Handle(*metricPath, promhttp.HandlerFor(exptr_regis.Getregis(), promhttp.HandlerOpts{}))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
-<head><title>Pika Exporter v` + BuildVersion + `</title></head>
-<body>
-<h1>Pika Exporter ` + BuildVersion + `</h1>
-<p><a href='` + *metricPath + `'>Metrics</a></p>
-</body>
-</html>`))
+	<head><title>Pika Exporter v` + BuildVersion + `</title></head>
+	<body>
+	<h1>Pika Exporter ` + BuildVersion + `</h1>
+	<p><a href='` + *metricPath + `'>Metrics</a></p>
+	</body>
+	</html>`))
 	})
 
 	log.Printf("Providing metrics on %s%s", *listenAddress, *metricPath)
 	for _, instance := range dis.GetInstances() {
 		log.Println("Connecting to Pika:", instance.Addr, "Alias:", instance.Alias)
 	}
+	if *codisaddr != "" {
+		go func() {
+			exptr_regis.LoopCheckUpdate(updatechan, *codisaddr)
+		}()
+		go func() {
+			for {
+				select {
+				case updatesignal := <-updatechan:
+					log.Warningln("Get signal from updatechan.")
+					if updatesignal == 1 {
+						exptr_regis.Update()
+					}
+				default:
+					time.Sleep(5 * time.Second)
+				}
+			}
+		}()
+	}
+
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))
+}
+
+type ExporterInterface interface {
+	Start()
+	Stop()
+	Update()
+	LoopCheckUpdate(updatechan chan int, codisaddr string)
+	Getregis() *prometheus.Registry
+}
+
+type ExporterRegistry struct {
+	dis        discovery.Discovery
+	expt       prometheus.Collector
+	regis      *prometheus.Registry
+	bif        prometheus.Collector
+	updatechan chan int
+}
+
+func NewExporterRegistry(dis discovery.Discovery, e, buildInfo prometheus.Collector, registry *prometheus.Registry, updatechan chan int) *ExporterRegistry {
+	return &ExporterRegistry{
+		dis:        dis,
+		expt:       e,
+		regis:      registry,
+		bif:        buildInfo,
+		updatechan: updatechan,
+	}
+}
+
+func (exptr_regis *ExporterRegistry) Getregis() *prometheus.Registry {
+	return exptr_regis.regis
+}
+
+func (exptr_regis *ExporterRegistry) Start() {
+	exptr_regis.regis.MustRegister(exptr_regis.expt)
+	exptr_regis.regis.MustRegister(exptr_regis.bif)
+}
+
+func (exptr_regis *ExporterRegistry) Stop() {
+	exptr_regis.regis.Unregister(exptr_regis.expt)
+	exptr_regis.regis.Unregister(exptr_regis.bif)
+}
+
+func (exptr_regis *ExporterRegistry) Update() {
+	if *codisaddr != "" {
+		newdis, err := discovery.NewCodisDiscovery(*codisaddr, *password, *alias)
+		if err != nil {
+			log.Fatalln("exporter get NewCodisDiscovery failed. err:", err)
+		}
+
+		exptr_regis.regis.Unregister(exptr_regis.expt)
+		exptr_regis.Stop()
+
+		new_e, err := exporter.NewPikaExporter(newdis, *namespace, *checkKeyPatterns, *checkKeys, *checkScanCount, *keySpaceStatsClock)
+		if err != nil {
+			log.Fatalln("exporter init failed. err:", err)
+		} else {
+			exptr_regis.dis = newdis
+			exptr_regis.expt = new_e
+		}
+		exptr_regis.Start()
+		for _, instance := range exptr_regis.dis.GetInstances() {
+			log.Println("Reconnecting to Pika:", instance.Addr, "Alias:", instance.Alias)
+		}
+	}
+}
+
+func (exptr_regis *ExporterRegistry) LoopCheckUpdate(updatechan chan int, codisaddr string) {
+	for {
+		time.Sleep(30 * time.Second)
+		exptr_regis.dis.CheckUpdate(updatechan, codisaddr)
+	}
 }


### PR DESCRIPTION
1.let one exporter monitor the whole cluster by codis.
2.Automatically reload after cluster node changes.

fix: #1929
test in #1929