### PR TITLE
Feat/s3: implementing pika storage on s3 using the rocksdb-cloud library

### DIFF
--- a/.github/workflows/pika_cloud.yml
+++ b/.github/workflows/pika_cloud.yml
@@ -1,0 +1,277 @@
+name: Pika_cloud
+
+on:
+  push:
+    branches: [ "unstable", "3.5.0" ]
+  pull_request:
+    branches: [ "unstable", "3.5.0" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: RelWithDebInfo
+  LD_LIBRARY_PATH: /usr/local/lib
+
+jobs:
+  build_on_ubuntu:
+    # The CMake configure and build commands are platform-agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: cache dependencies
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
+            ~/.cache/pip
+          key: ${{ runner.os }}-dependencies
+
+      - name: install Deps
+        if: ${{ steps.cache.output.cache-hit != 'true' }}
+        run: |
+          sudo apt-get install -y autoconf libprotobuf-dev protobuf-compiler
+          sudo apt-get install -y clang-tidy-12 python3-pip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install redis
+      
+      - name: Set up AWS SDK for C++
+        run: |
+          sudo apt-get install libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev
+          git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp
+          mkdir sdk_build
+          cd sdk_build
+          cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.LD_LIBRARY_PATH }} DCMAKE_INSTALL_PREFIX=${{ env.LD_LIBRARY_PATH }} -DBUILD_ONLY="s3;core;transfer;kinesis" -DBUILD_SHARED_LIBS=ON
+          make
+          sudo make install
+      
+      - name: Set up and start MinIO
+        run: |
+          wget https://dl.minio.org.cn/server/minio/release/linux-amd64/minio
+          chmod +x minio
+          ./minio server minio_data&
+
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_S3=ON -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
+
+      - name: Build
+        # Build your program with the given configuration
+        run: cmake --build build --config ${{ env.BUILD_TYPE }}
+
+      - name: Test
+        working-directory: ${{ github.workspace }}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C ${{ env.BUILD_TYPE }}
+
+
+      # - name: Unit Test
+      #   working-directory: ${{ github.workspace }}
+      #   run: ./pikatests.sh all
+
+        # master on port 9221, slave on port 9231, all with 2 db
+      - name: Start pika master and slave
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          chmod +x ../tests/integration/start_master_and_slave.sh
+          ../tests/integration/start_master_and_slave.sh
+
+      - name: Run Python E2E Tests
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          python3 ../tests/integration/pika_replication_test.py
+          python3 ../tests/unit/Blpop_Brpop_test.py
+
+      - name: Run Go E2E Tests
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          cd ../tests/integration/
+          chmod +x integrate_test.sh 
+          sh integrate_test.sh
+
+  # build_on_centos:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: centos:7
+
+  #   steps:
+  #     - name: Install deps
+  #       run: |
+  #         yum install -y wget git autoconf centos-release-scl gcc-c++
+  #         yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util
+  #         yum install -y llvm-toolset-7 llvm-toolset-7-clang tcl which python3
+  #         python3 -m pip install --upgrade pip
+  #         python3 -m pip install redis
+
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: 1.19
+
+  #     - name: Install cmake
+  #       run: |
+  #         wget https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4-linux-x86_64.sh
+  #         bash ./cmake-3.26.4-linux-x86_64.sh --skip-license --prefix=/usr
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Set up AWS SDK for C++
+  #       run: |
+  #         yum install -y libcurl-devel openssl-devel libuuid-devel pulseaudio-libs-devel
+  #         git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp
+  #         mkdir sdk_build
+  #         cd sdk_build
+  #         cmake ../aws-sdk-cpp -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ env.LD_LIBRARY_PATH }} -DCMAKE_INSTALL_PREFIX=${{ env.LD_LIBRARY_PATH }} -DBUILD_ONLY="s3;core;transfer;kinesis" -DBUILD_SHARED_LIBS=ON
+  #         make
+  #         make install
+
+  #     - name: Set up and start MinIO
+  #       run: |
+  #         wget https://dl.minio.org.cn/server/minio/release/linux-amd64/minio
+  #         chmod +x minio
+  #         ./minio server minio_data&
+      
+  #     - name: Configure CMake
+  #       run: |
+  #         source /opt/rh/devtoolset-10/enable
+  #         cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_S3=ON -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
+
+  #     - name: Build
+  #       run: |
+  #         source /opt/rh/devtoolset-10/enable
+  #         cmake --build build --config ${{ env.BUILD_TYPE }}
+
+  #     - name: Test
+  #       working-directory: ${{ github.workspace }}/build
+  #       run: ctest -C ${{ env.BUILD_TYPE }}
+
+  #     # - name: Unit Test
+  #     #   working-directory: ${{ github.workspace }}
+  #     #   run: ./pikatests.sh all
+
+  #     - name: Start pika master and slave
+  #       working-directory: ${{ github.workspace }}/build
+  #       run: |
+  #         chmod +x ../tests/integration/start_master_and_slave.sh
+  #         ../tests/integration/start_master_and_slave.sh
+
+  #     - name: Run Python E2E Tests
+  #       working-directory: ${{ github.workspace }}/build
+  #       run: |
+  #         python3 ../tests/integration/pika_replication_test.py
+  #         python3 ../tests/unit/Blpop_Brpop_test.py
+
+  # build_on_macos:
+  #   runs-on: macos-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: 1.19
+
+  #     - name: cache dependencies
+  #       uses: actions/cache@v2
+  #       id: cache
+  #       with:
+  #         path: |
+  #           ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
+  #           ~/.cache/pip
+  #         key: ${{ runner.os }}-dependencies
+
+  #     - name: install Deps
+  #       if: ${{ steps.cache.output.cache-hit != 'true' }}
+  #       run: |
+  #         brew update
+  #         brew install --overwrite python autoconf protobuf llvm wget git
+  #         brew install gcc@10 automake cmake make binutils
+  #         python3 -m pip install --upgrade pip
+  #         python3 -m pip install redis
+
+      # - name: Start UP MinIO
+      #   uses: infleet/minio-action@v0.0.1
+      #   with:
+      #     username: "minioadmin"
+      #     password: "minioadmin"
+
+      # - name: Configure CMake
+      #   run: |
+      #     export CC=/usr/local/opt/gcc@10/bin/gcc-10 
+      #     cmake -B build -DCMAKE_C_COMPILER=/usr/local/opt/gcc@10/bin/gcc-10 -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
+      #   #  cmake -B build -DCMAKE_C_COMPILER=/usr/local/opt/gcc@10/bin/gcc-10 -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_S3=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
+
+      # - name: Build
+      #   run: |
+      #     cmake --build build --config ${{ env.BUILD_TYPE }}
+
+      # - name: Test
+      #   working-directory: ${{ github.workspace }}/build
+      #   run: ctest -C ${{ env.BUILD_TYPE }}
+
+      # - name: Unit Test
+      #   working-directory: ${{ github.workspace }}
+      #   run: |
+      #     ./pikatests.sh all
+
+      # - name: Start pika master and slave
+      #   working-directory: ${{ github.workspace }}/build
+      #   run: |
+      #     chmod +x ../tests/integration/start_master_and_slave.sh
+      #     ../tests/integration/start_master_and_slave.sh
+
+      # - name: Run Python E2E Tests
+      #   working-directory: ${{ github.workspace }}/build
+      #   run: |
+      #     python3 ../tests/integration/pika_replication_test.py
+      #     python3 ../tests/unit/Blpop_Brpop_test.py
+
+      # - name: Run Go E2E Tests
+      #   working-directory: ${{ github.workspace }}/build
+      #   run: |
+      #     cd ../tests/integration/
+      #     chmod +x integrate_test.sh 
+      #     sh integrate_test.sh
+
+  # build_pika_image:
+  #   name: Build Pika Docker image
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out the repo
+  #       uses: actions/checkout@v3
+
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v2
+
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+      
+  #     - name: Extract metadata (tags, labels) for Docker
+  #       id: meta
+  #       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+  #       with:
+  #         images: pikadb/pika
+      
+  #     - name: Build Docker image
+  #       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+  #       with:
+  #         context: .
+  #         file: ./Dockerfile
+  #         push: false
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/pika_cloud.yml
+++ b/.github/workflows/pika_cloud.yml
@@ -45,6 +45,7 @@ jobs:
       
       - name: Set up AWS SDK for C++
         run: |
+          sudo apt-get update --fix-missing
           sudo apt-get install libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev
           git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp
           mkdir sdk_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,57 +574,112 @@ set(PROTOBUF_INCLUDE_DIR ${INSTALL_INCLUDEDIR})
 set(PROTOBUF_LIBRARY ${INSTALL_LIBDIR}/${LIB_PROTOBUF})
 set(PROTOBUF_PROTOC ${STAGED_INSTALL_PREFIX}/bin/protoc)
 
-ExternalProject_Add(rocksdb
-  DEPENDS
-  gflags
-  gtest
-  snappy
-  zstd
-  lz4
-  zlib
-  ${LIBGPERF_NAME}
-  ${LIBJEMALLOC_NAME}
-  URL
-  https://github.com/facebook/rocksdb/archive/refs/tags/v8.1.1.tar.gz
-  URL_HASH
-  MD5=3b4c97ee45df9c8a5517308d31ab008b
-  DOWNLOAD_NO_PROGRESS
-  1
-  UPDATE_COMMAND
-  ""
-  LOG_CONFIGURE
-  1
-  LOG_BUILD
-  1
-  LOG_INSTALL
-  1
-  BUILD_ALWAYS
-  1
-  CMAKE_ARGS
-  -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
-  -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-  -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
-  -DUSE_RTTI=1
-  -DWITH_BENCHMARK=OFF
-  -DWITH_BENCHMARK_TOOLS=OFF
-  -DWITH_TOOLS=OFF
-  -DWITH_CORE_TOOLS=OFF
-  -DWITH_TESTS=OFF
-  -DWITH_TRACE_TOOLS=OFF
-  -DWITH_EXAMPLES=OFF
-  -DROCKSDB_BUILD_SHARED=OFF
-  -DWITH_JEMALLOC=${JEMALLOC_ON}
-  -DWITH_LZ4=ON
-  -DWITH_SNAPPY=ON
-  -DWITH_ZLIB=ON
-  -DWITH_ZSTD=ON
-  -DWITH_GFLAGS=ON
-  -DFAIL_ON_WARNINGS=OFF
-  -DWITH_LIBURING=OFF
-  -DPORTABLE=1
-  BUILD_COMMAND
-  make -j${CPU_CORE}
-)
+if (USE_S3)
+  ExternalProject_Add(rocksdb
+    DEPENDS
+    gflags
+    gtest
+    snappy
+    zstd
+    lz4
+    zlib
+    ${LIBGPERF_NAME}
+    ${LIBJEMALLOC_NAME}
+    URL
+    https://github.com/longfar-ncy/rocksdb-cloud/archive/refs/heads/pika.zip
+    URL_HASH
+    MD5=761d1f7ccd6ea9aa86c1f2ce0e246a26
+    DOWNLOAD_NO_PROGRESS
+    1
+    UPDATE_COMMAND
+    ""
+    LOG_CONFIGURE
+    1
+    LOG_BUILD
+    1
+    LOG_INSTALL
+    1
+    BUILD_ALWAYS
+    1
+    CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
+    -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+    -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
+    -DUSE_RTTI=1
+    -DWITH_BENCHMARK=OFF
+    -DWITH_BENCHMARK_TOOLS=OFF
+    -DWITH_TOOLS=OFF
+    -DWITH_CORE_TOOLS=OFF
+    -DWITH_TESTS=OFF
+    -DWITH_TRACE_TOOLS=OFF
+    -DWITH_EXAMPLES=OFF
+    -DROCKSDB_BUILD_SHARED=OFF
+    -DWITH_JEMALLOC=${JEMALLOC_ON}
+    -DWITH_LZ4=ON
+    -DWITH_SNAPPY=ON
+    -DWITH_ZLIB=ON
+    -DWITH_ZSTD=ON
+    -DWITH_GFLAGS=ON
+    -DFAIL_ON_WARNINGS=OFF
+    -DWITH_LIBURING=OFF
+    -DPORTABLE=1
+    -DWITH_AWS=ON
+    BUILD_COMMAND
+    make -j${CPU_CORE}
+  )
+else()
+  ExternalProject_Add(rocksdb
+    DEPENDS
+    gflags
+    gtest
+    snappy
+    zstd
+    lz4
+    zlib
+    ${LIBGPERF_NAME}
+    ${LIBJEMALLOC_NAME}
+    URL
+    https://github.com/facebook/rocksdb/archive/refs/tags/v8.1.1.tar.gz
+    URL_HASH
+    MD5=3b4c97ee45df9c8a5517308d31ab008b
+    DOWNLOAD_NO_PROGRESS
+    1
+    UPDATE_COMMAND
+    ""
+    LOG_CONFIGURE
+    1
+    LOG_BUILD
+    1
+    LOG_INSTALL
+    1
+    BUILD_ALWAYS
+    1
+    CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
+    -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+    -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
+    -DUSE_RTTI=1
+    -DWITH_BENCHMARK=OFF
+    -DWITH_BENCHMARK_TOOLS=OFF
+    -DWITH_TOOLS=OFF
+    -DWITH_CORE_TOOLS=OFF
+    -DWITH_TESTS=OFF
+    -DWITH_TRACE_TOOLS=OFF
+    -DWITH_EXAMPLES=OFF
+    -DROCKSDB_BUILD_SHARED=OFF
+    -DWITH_JEMALLOC=${JEMALLOC_ON}
+    -DWITH_LZ4=ON
+    -DWITH_SNAPPY=ON
+    -DWITH_ZLIB=ON
+    -DWITH_ZSTD=ON
+    -DWITH_GFLAGS=ON
+    -DFAIL_ON_WARNINGS=OFF
+    -DWITH_LIBURING=OFF
+    -DPORTABLE=1
+    BUILD_COMMAND
+    make -j${CPU_CORE}
+  )
+endif()
 
 option(USE_PIKA_TOOLS "compile pika-tools" OFF)
 if (USE_PIKA_TOOLS)
@@ -693,6 +748,10 @@ endif()
 
 set(ROCKSDB_INCLUDE_DIR ${INSTALL_INCLUDEDIR})
 set(ROCKSDB_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${EP_BASE_SUFFIX}/Source/rocksdb)
+
+if(USE_S3)
+	add_compile_definitions(USE_S3)
+endif()
 
 add_subdirectory(src/pstd)
 add_subdirectory(src/net)
@@ -788,7 +847,17 @@ target_link_libraries(${PROJECT_NAME}
   liblz4.a
   libz.a
   ${LIBUNWIND_LIBRARY}
-  ${JEMALLOC_LIBRARY})
+  ${JEMALLOC_LIBRARY}
+)
+
+if (USE_S3)
+  target_link_libraries(${PROJECT_NAME}
+    libaws-cpp-sdk-core.so 
+    libaws-cpp-sdk-transfer.so
+    libaws-cpp-sdk-kinesis.so
+    libaws-cpp-sdk-s3.so
+  )
+endif()
 
 option(USE_SSL "Enable SSL support" OFF)
 add_custom_target(

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -418,3 +418,31 @@ max-rsync-parallel-num : 4
 # The synchronization mode of Pika primary/secondary replication is determined by ReplicationID. ReplicationID in one replication_cluster are the same
 # replication-id :
 
+######################################################################
+#         rocksdb-cloud options                    
+#######################################################################
+
+# Normally, the AWS SDK will automatically determine the endpoint based on the selected region.
+# However, in special cases, you can manually specify the URL of the endpoint through this configuration,
+# such as local development.
+# Default: ""
+# cloud-endpoint-override : 
+
+# The aws access key id and aws secret key used for authentication when accessing aws s3.
+cloud-access-key : 
+cloud-secret-key : 
+
+# The source bucket name prefix and suffix to use for storage on s3
+# The final bucket name is [prefix][suffix] 
+# Default: "pika."
+# cloud-src-bucket-prefix :
+# Default: "database"
+# cloud-src-bucket-suffix :
+
+# The source bucket region 
+# cloud-src-bucket-region :
+
+# Configuration information of the destination bucket
+# cloud-dest-bucket-prefix :
+# cloud-dest-bucket-suffix :
+# cloud-dest-bucket-region : 

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -351,6 +351,19 @@ class PikaConf : public pstd::BaseConf {
   std::string compression_all_levels() const { return compression_per_level_; };
   static rocksdb::CompressionType GetCompression(const std::string& value);
 
+#ifdef USE_S3
+  // rocksdb-cloud options
+  std::string cloud_endpoint_override() { return cloud_endpoint_override_; }
+  std::string cloud_access_key() { return cloud_access_key_; }
+  std::string cloud_secret_key() { return cloud_secret_key_; }
+  std::string cloud_src_bucket_prefix() { return cloud_src_bucket_prefix_; }
+  std::string cloud_src_bucket_suffix() { return cloud_src_bucket_suffix_; }
+  std::string cloud_src_bucket_region() { return cloud_src_bucket_region_; }
+  std::string cloud_dest_bucket_prefix() { return cloud_dest_bucket_prefix_; }
+  std::string cloud_dest_bucket_suffix() { return cloud_dest_bucket_suffix_; }
+  std::string cloud_dest_bucket_region() { return cloud_dest_bucket_region_; }
+#endif
+
   // Setter
   void SetPort(const int value) {
     std::lock_guard l(rwlock_);
@@ -696,6 +709,21 @@ class PikaConf : public pstd::BaseConf {
   double blob_garbage_collection_force_threshold_ = 1.0;
   int64_t blob_cache_ = 0;
   int64_t blob_num_shard_bits_ = 0;
+
+#ifdef USE_S3
+  // rocksdb-cloud options
+  std::string cloud_endpoint_override_;
+  std::string cloud_access_key_;
+  std::string cloud_secret_key_;
+  // rocksdb-cloud src bucket
+  std::string cloud_src_bucket_prefix_ = "pika.";
+  std::string cloud_src_bucket_suffix_ = "database";
+  std::string cloud_src_bucket_region_;
+  // rocksdb-cloud dest bucket
+  std::string cloud_dest_bucket_prefix_ = "pika.";
+  std::string cloud_dest_bucket_suffix_ = "database";
+  std::string cloud_dest_bucket_region_;
+#endif
 
   std::unique_ptr<PikaMeta> local_meta_;
 

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -601,6 +601,19 @@ int PikaConf::Load() {
   GetConfInt64("blob-cache", &block_cache_);
   GetConfInt64("blob-num-shard-bits", &blob_num_shard_bits_);
 
+#ifdef USE_S3
+  // rocksdb-cloud options
+  GetConfStr("cloud-endpoint-override", &cloud_endpoint_override_);
+  GetConfStr("cloud-access-key", &cloud_access_key_);
+  GetConfStr("cloud-secret-key", &cloud_secret_key_);
+  GetConfStr("cloud-src-bucket-prefix", &cloud_src_bucket_prefix_);
+  GetConfStr("cloud-src-bucket-suffix", &cloud_src_bucket_suffix_);
+  GetConfStr("cloud-src-bucket-region", &cloud_src_bucket_region_);
+  GetConfStr("cloud-dest-bucket-prefix", &cloud_dest_bucket_prefix_);
+  GetConfStr("cloud-dest-bucket-suffix", &cloud_dest_bucket_suffix_);
+  GetConfStr("cloud-dest-bucket-region", &cloud_dest_bucket_region_);
+#endif
+
   return ret;
 
   // throttle-bytes-per-second

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1569,6 +1569,21 @@ void PikaServer::InitStorageOptions() {
           rocksdb::NewLRUCache(g_pika_conf->blob_cache(), static_cast<int>(g_pika_conf->blob_num_shard_bits()));
     }
   }
+
+#ifdef USE_S3
+  // rocksdb-cloud
+  auto& cloud_fs_opts = storage_options_.cloud_fs_options;
+  storage_options_.options.max_log_file_size = 0; // TODO: better handles of `assert(cloud_maifest)`
+	cloud_fs_opts.endpoint_override = g_pika_conf->cloud_endpoint_override();
+  cloud_fs_opts.credentials.InitializeSimple(g_pika_conf->cloud_access_key(), g_pika_conf->cloud_secret_key());
+  if (!cloud_fs_opts.credentials.HasValid().ok()) {
+    LOG(FATAL) << "Please set aws access key and secret key to access s3";
+  }
+  cloud_fs_opts.src_bucket.SetBucketName(g_pika_conf->cloud_src_bucket_suffix(), g_pika_conf->cloud_src_bucket_prefix());
+  cloud_fs_opts.src_bucket.SetRegion(g_pika_conf->cloud_src_bucket_region());
+  cloud_fs_opts.dest_bucket.SetBucketName(g_pika_conf->cloud_dest_bucket_suffix(), g_pika_conf->cloud_dest_bucket_prefix());
+  cloud_fs_opts.dest_bucket.SetRegion(g_pika_conf->cloud_dest_bucket_region());
+#endif
 }
 
 storage::Status PikaServer::RewriteStorageOptions(const storage::OptionType& option_type,

--- a/src/storage/include/storage/backupable.h
+++ b/src/storage/include/storage/backupable.h
@@ -8,8 +8,6 @@
 
 #include <utility>
 
-#include "rocksdb/db.h"
-
 #include "db_checkpoint.h"
 #include "storage.h"
 #include "util.h"

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -21,6 +21,9 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
+#ifdef USE_S3
+#include "rocksdb/cloud/cloud_file_system.h"
+#endif
 
 #include "pstd/include/pstd_mutex.h"
 
@@ -67,6 +70,11 @@ struct StorageOptions {
   size_t statistics_max_size = 0;
   size_t small_compaction_threshold = 5000;
   Status ResetOptions(const OptionType& option_type, const std::unordered_map<std::string, std::string>& options_map);
+  
+#ifdef USE_S3
+  // rocksdb-cloud option
+  rocksdb::CloudFileSystemOptions cloud_fs_options;
+#endif
 };
 
 struct KeyValue {

--- a/src/storage/src/base_filter.h
+++ b/src/storage/src/base_filter.h
@@ -128,8 +128,13 @@ class BaseDataFilter : public rocksdb::CompactionFilter {
 
 class BaseDataFilterFactory : public rocksdb::CompactionFilterFactory {
  public:
+#ifdef USE_S3
+  BaseDataFilterFactory(rocksdb::DBCloud** db_ptr, std::vector<rocksdb::ColumnFamilyHandle*>* handles_ptr)
+      : db_ptr_(db_ptr), cf_handles_ptr_(handles_ptr) {}
+#else
   BaseDataFilterFactory(rocksdb::DB** db_ptr, std::vector<rocksdb::ColumnFamilyHandle*>* handles_ptr)
       : db_ptr_(db_ptr), cf_handles_ptr_(handles_ptr) {}
+#endif
   std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(
       const rocksdb::CompactionFilter::Context& context) override {
     return std::unique_ptr<rocksdb::CompactionFilter>(new BaseDataFilter(*db_ptr_, cf_handles_ptr_));
@@ -137,7 +142,11 @@ class BaseDataFilterFactory : public rocksdb::CompactionFilterFactory {
   const char* Name() const override { return "BaseDataFilterFactory"; }
 
  private:
+#ifdef USE_S3
+  rocksdb::DBCloud** db_ptr_ = nullptr;
+#else
   rocksdb::DB** db_ptr_ = nullptr;
+#endif
   std::vector<rocksdb::ColumnFamilyHandle*>* cf_handles_ptr_ = nullptr;
 };
 

--- a/src/storage/src/lists_filter.h
+++ b/src/storage/src/lists_filter.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "rocksdb/compaction_filter.h"
-#include "rocksdb/db.h"
+
 #include "src/debug.h"
 #include "src/lists_data_key_format.h"
 #include "src/lists_meta_value_format.h"
@@ -129,8 +129,13 @@ class ListsDataFilter : public rocksdb::CompactionFilter {
 
 class ListsDataFilterFactory : public rocksdb::CompactionFilterFactory {
  public:
+#ifdef USE_S3
+  ListsDataFilterFactory(rocksdb::DBCloud** db_ptr, std::vector<rocksdb::ColumnFamilyHandle*>* handles_ptr)
+      : db_ptr_(db_ptr), cf_handles_ptr_(handles_ptr) {}
+#else
   ListsDataFilterFactory(rocksdb::DB** db_ptr, std::vector<rocksdb::ColumnFamilyHandle*>* handles_ptr)
       : db_ptr_(db_ptr), cf_handles_ptr_(handles_ptr) {}
+#endif
 
   std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(
       const rocksdb::CompactionFilter::Context& context) override {
@@ -139,7 +144,11 @@ class ListsDataFilterFactory : public rocksdb::CompactionFilterFactory {
   const char* Name() const override { return "ListsDataFilterFactory"; }
 
  private:
+#ifdef USE_S3
+  rocksdb::DBCloud** db_ptr_ = nullptr;
+#else
   rocksdb::DB** db_ptr_ = nullptr;
+#endif
   std::vector<rocksdb::ColumnFamilyHandle*>* cf_handles_ptr_ = nullptr;
 };
 

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -24,7 +24,19 @@ Status RedisHashes::Open(const StorageOptions& storage_options, const std::strin
   small_compaction_threshold_ = storage_options.small_compaction_threshold;
 
   rocksdb::Options ops(storage_options.options);
+
+#ifdef USE_S3
+  Status env_st = OpenCloudEnv(storage_options.cloud_fs_options, db_path);
+  if (!env_st.ok()) {
+    // TODO: add log
+    return env_st;
+  }
+  ops.env = cloud_env_.get();
+  Status s = rocksdb::DBCloud::Open(ops, db_path, "", 0, &db_);
+#else
   Status s = rocksdb::DB::Open(ops, db_path, &db_);
+#endif
+
   if (s.ok()) {
     // create column family
     rocksdb::ColumnFamilyHandle* cf;
@@ -38,7 +50,7 @@ Status RedisHashes::Open(const StorageOptions& storage_options, const std::strin
   }
 
   // Open
-  rocksdb::DBOptions db_ops(storage_options.options);
+  rocksdb::Options db_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions meta_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions data_cf_ops(storage_options.options);
   meta_cf_ops.compaction_filter_factory = std::make_shared<HashesMetaFilterFactory>();
@@ -61,7 +73,13 @@ Status RedisHashes::Open(const StorageOptions& storage_options, const std::strin
   column_families.emplace_back(rocksdb::kDefaultColumnFamilyName, meta_cf_ops);
   // Data CF
   column_families.emplace_back("data_cf", data_cf_ops);
+
+#ifdef USE_S3
+  db_ops.env = cloud_env_.get();
+  return rocksdb::DBCloud::Open(db_ops, db_path, column_families, "", 0, &handles_, &db_);
+#else
   return rocksdb::DB::Open(db_ops, db_path, column_families, &handles_, &db_);
+#endif
 }
 
 Status RedisHashes::CompactRange(const rocksdb::Slice* begin, const rocksdb::Slice* end, const ColumnFamilyType& type) {

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -35,7 +35,19 @@ Status RedisStrings::Open(const StorageOptions& storage_options, const std::stri
   table_ops.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, true));
   ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_ops));
 
+#ifdef USE_S3
+  // rocksdb-cloud
+  Status s = OpenCloudEnv(storage_options.cloud_fs_options, db_path);
+  if (!s.ok()) {
+    LOG(ERROR) << "Failed to open cloud environment: " << s.ToString();
+    return s;
+  }
+  assert(cloud_env_);
+  ops.env = cloud_env_.get();
+  return rocksdb::DBCloud::Open(ops, db_path, "", 0, &db_);
+#else
   return rocksdb::DB::Open(ops, db_path, &db_);
+#endif
 }
 
 Status RedisStrings::CompactRange(const rocksdb::Slice* begin, const rocksdb::Slice* end,

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -33,7 +33,19 @@ Status RedisZSets::Open(const StorageOptions& storage_options, const std::string
   small_compaction_threshold_ = storage_options.small_compaction_threshold;
 
   rocksdb::Options ops(storage_options.options);
+
+#ifdef USE_S3
+  Status env_st = OpenCloudEnv(storage_options.cloud_fs_options, db_path);
+  if (!env_st.ok()) {
+    // TODO: add log
+    return env_st;
+  }
+  ops.env = cloud_env_.get();
+  Status s = rocksdb::DBCloud::Open(ops, db_path, "", 0, &db_);
+#else
   Status s = rocksdb::DB::Open(ops, db_path, &db_);
+#endif
+
   if (s.ok()) {
     rocksdb::ColumnFamilyHandle *dcf = nullptr;
     rocksdb::ColumnFamilyHandle *scf = nullptr;
@@ -52,7 +64,7 @@ Status RedisZSets::Open(const StorageOptions& storage_options, const std::string
     delete db_;
   }
 
-  rocksdb::DBOptions db_ops(storage_options.options);
+  rocksdb::Options db_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions meta_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions data_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions score_cf_ops(storage_options.options);
@@ -80,7 +92,13 @@ Status RedisZSets::Open(const StorageOptions& storage_options, const std::string
   column_families.emplace_back(rocksdb::kDefaultColumnFamilyName, meta_cf_ops);
   column_families.emplace_back("data_cf", data_cf_ops);
   column_families.emplace_back("score_cf", score_cf_ops);
+
+#ifdef USE_S3
+  db_ops.env = cloud_env_.get();
+  return rocksdb::DBCloud::Open(db_ops, db_path, column_families, "", 0, &handles_, &db_);
+#else
   return rocksdb::DB::Open(db_ops, db_path, column_families, &handles_, &db_);
+#endif
 }
 
 Status RedisZSets::CompactRange(const rocksdb::Slice* begin, const rocksdb::Slice* end, const ColumnFamilyType& type) {

--- a/src/storage/src/zsets_filter.h
+++ b/src/storage/src/zsets_filter.h
@@ -87,8 +87,13 @@ class ZSetsScoreFilter : public rocksdb::CompactionFilter {
 
 class ZSetsScoreFilterFactory : public rocksdb::CompactionFilterFactory {
  public:
+#ifdef USE_S3
+  ZSetsScoreFilterFactory(rocksdb::DBCloud** db_ptr, std::vector<rocksdb::ColumnFamilyHandle*>* handles_ptr)
+      : db_ptr_(db_ptr), cf_handles_ptr_(handles_ptr) {}
+#else
   ZSetsScoreFilterFactory(rocksdb::DB** db_ptr, std::vector<rocksdb::ColumnFamilyHandle*>* handles_ptr)
       : db_ptr_(db_ptr), cf_handles_ptr_(handles_ptr) {}
+#endif
 
   std::unique_ptr<rocksdb::CompactionFilter> CreateCompactionFilter(
       const rocksdb::CompactionFilter::Context& context) override {
@@ -98,7 +103,11 @@ class ZSetsScoreFilterFactory : public rocksdb::CompactionFilterFactory {
   const char* Name() const override { return "ZSetsScoreFilterFactory"; }
 
  private:
+#ifdef USE_S3
+  rocksdb::DBCloud** db_ptr_ = nullptr;
+#else
   rocksdb::DB** db_ptr_ = nullptr;
+#endif
   std::vector<rocksdb::ColumnFamilyHandle*>* cf_handles_ptr_ = nullptr;
 };
 

--- a/src/storage/tests/CMakeLists.txt
+++ b/src/storage/tests/CMakeLists.txt
@@ -30,14 +30,14 @@ foreach(blackwindow_test_source ${BLACKWINDOW_TEST_SOURCE})
     PUBLIC ${GFLAGS_LIBRARY}
     PUBLIC ${LIBUNWIND_LIBRARY}
   )
-	if (USE_S3)
-		target_link_libraries(${blackwindow_test_name}
-			PUBLIC libaws-cpp-sdk-core.so 
-			PUBLIC libaws-cpp-sdk-transfer.so
-			PUBLIC libaws-cpp-sdk-kinesis.so
-			PUBLIC libaws-cpp-sdk-s3.so
-		)
-	endif()
+  if (USE_S3)
+    target_link_libraries(${blackwindow_test_name}
+      PUBLIC libaws-cpp-sdk-core.so 
+      PUBLIC libaws-cpp-sdk-transfer.so
+      PUBLIC libaws-cpp-sdk-kinesis.so
+      PUBLIC libaws-cpp-sdk-s3.so
+    )
+  endif()
   add_test(NAME ${blackwindow_test_name}
     COMMAND ${blackwindow_test_name}
     WORKING_DIRECTORY .)

--- a/src/storage/tests/CMakeLists.txt
+++ b/src/storage/tests/CMakeLists.txt
@@ -30,6 +30,14 @@ foreach(blackwindow_test_source ${BLACKWINDOW_TEST_SOURCE})
     PUBLIC ${GFLAGS_LIBRARY}
     PUBLIC ${LIBUNWIND_LIBRARY}
   )
+	if (USE_S3)
+		target_link_libraries(${blackwindow_test_name}
+			PUBLIC libaws-cpp-sdk-core.so 
+			PUBLIC libaws-cpp-sdk-transfer.so
+			PUBLIC libaws-cpp-sdk-kinesis.so
+			PUBLIC libaws-cpp-sdk-s3.so
+		)
+	endif()
   add_test(NAME ${blackwindow_test_name}
     COMMAND ${blackwindow_test_name}
     WORKING_DIRECTORY .)

--- a/src/storage/tests/hashes_test.cc
+++ b/src/storage/tests/hashes_test.cc
@@ -26,7 +26,17 @@ class HashesTest : public ::testing::Test {
       mkdir(path.c_str(), 0755);
     }
     storage_options.options.create_if_missing = true;
+#ifdef USE_S3
+    auto& cloud_fs_opts = storage_options.cloud_fs_options;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    ASSERT_TRUE(cloud_fs_opts.credentials.HasValid().ok());
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    storage_options.options.max_log_file_size = 0;
+#endif
     s = db.Open(storage_options, path);
+    ASSERT_TRUE(s.ok());
   }
 
   void TearDown() override {

--- a/src/storage/tests/hyperloglog_test.cc
+++ b/src/storage/tests/hyperloglog_test.cc
@@ -23,7 +23,17 @@ class HyperLogLogTest : public ::testing::Test {
       mkdir(path.c_str(), 0755);
     }
     storage_options.options.create_if_missing = true;
+#ifdef USE_S3
+    auto& cloud_fs_opts = storage_options.cloud_fs_options;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    ASSERT_TRUE(cloud_fs_opts.credentials.HasValid().ok());
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    storage_options.options.max_log_file_size = 0;
+#endif
     s = db.Open(storage_options, path);
+    ASSERT_TRUE(s.ok());
   }
 
   void TearDown() override {

--- a/src/storage/tests/keys_test.cc
+++ b/src/storage/tests/keys_test.cc
@@ -26,7 +26,17 @@ class KeysTest : public ::testing::Test {
       mkdir(path.c_str(), 0755);
     }
     storage_options.options.create_if_missing = true;
+#ifdef USE_S3
+    auto& cloud_fs_opts = storage_options.cloud_fs_options;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    ASSERT_TRUE(cloud_fs_opts.credentials.HasValid().ok());
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    storage_options.options.max_log_file_size = 0;
+#endif
     s = db.Open(storage_options, path);
+    ASSERT_TRUE(s.ok());
   }
 
   void TearDown() override {

--- a/src/storage/tests/lists_filter_test.cc
+++ b/src/storage/tests/lists_filter_test.cc
@@ -25,8 +25,37 @@ class ListsFilterTest : public ::testing::Test {
     if (access(db_path.c_str(), F_OK) != 0) {
       mkdir(db_path.c_str(), 0755);
     }
-    options.create_if_missing = true;
+
+		options.create_if_missing = true;
+
+#ifdef USE_S3
+    // rocksdb-cloud env
+    rocksdb::CloudFileSystemOptions cloud_fs_opts;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    assert(cloud_fs_opts.credentials.HasValid().ok());
+    std::string s3_path = db_path[0] == '.' ? db_path.substr(1) : db_path;
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.src_bucket.SetObjectPath(s3_path);
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetObjectPath(s3_path);
+    rocksdb::CloudFileSystem* cfs = nullptr;
+    Status s = rocksdb::CloudFileSystem::NewAwsFileSystem(
+      rocksdb::FileSystem::Default(), 
+      cloud_fs_opts, 
+      nullptr, 
+      &cfs
+    );
+    assert(s.ok());
+    std::shared_ptr<rocksdb::CloudFileSystem> cloud_fs(cfs);
+    cloud_env = NewCompositeEnv(cloud_fs);
+    assert(cloud_env);
+    options.env = cloud_env.get();
+    s = rocksdb::DBCloud::Open(options, db_path, "", 0, &meta_db);
+#else
     s = rocksdb::DB::Open(options, db_path, &meta_db);
+#endif
+
     if (s.ok()) {
       // create column family
       rocksdb::ColumnFamilyHandle* cf;
@@ -43,7 +72,12 @@ class ListsFilterTest : public ::testing::Test {
     // Data CF
     column_families.emplace_back("data_cf", data_cf_ops);
 
+#ifdef USE_S3
+    s = rocksdb::DBCloud::Open(options, db_path, column_families, "", 0, &handles, &meta_db);
+#else
     s = rocksdb::DB::Open(options, db_path, column_families, &handles, &meta_db);
+#endif
+		assert(s.ok());
   }
   ~ListsFilterTest() override = default;
 
@@ -56,8 +90,13 @@ class ListsFilterTest : public ::testing::Test {
   }
 
   storage::Options options;
-  rocksdb::DB* meta_db;
   storage::Status s;
+#ifdef USE_S3
+  rocksdb::DBCloud* meta_db;
+  std::unique_ptr<rocksdb::Env> cloud_env;
+#else
+  rocksdb::DB* meta_db;
+#endif
 
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   std::vector<rocksdb::ColumnFamilyHandle*> handles;

--- a/src/storage/tests/lists_filter_test.cc
+++ b/src/storage/tests/lists_filter_test.cc
@@ -25,9 +25,7 @@ class ListsFilterTest : public ::testing::Test {
     if (access(db_path.c_str(), F_OK) != 0) {
       mkdir(db_path.c_str(), 0755);
     }
-
-		options.create_if_missing = true;
-
+    options.create_if_missing = true;
 #ifdef USE_S3
     // rocksdb-cloud env
     rocksdb::CloudFileSystemOptions cloud_fs_opts;

--- a/src/storage/tests/lists_test.cc
+++ b/src/storage/tests/lists_test.cc
@@ -79,6 +79,15 @@ class ListsTest : public ::testing::Test {
       mkdir(path.c_str(), 0755);
     }
     storage_options.options.create_if_missing = true;
+#ifdef USE_S3
+    auto& cloud_fs_opts = storage_options.cloud_fs_options;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    ASSERT_TRUE(cloud_fs_opts.credentials.HasValid().ok()); 
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    storage_options.options.max_log_file_size = 0; 
+#endif
     s = db.Open(storage_options, path);
     if (!s.ok()) {
       printf("Open db failed, exit...\n");

--- a/src/storage/tests/sets_test.cc
+++ b/src/storage/tests/sets_test.cc
@@ -23,7 +23,17 @@ class SetsTest : public ::testing::Test {
       mkdir(path.c_str(), 0755);
     }
     storage_options.options.create_if_missing = true;
+#ifdef USE_S3
+    auto& cloud_fs_opts = storage_options.cloud_fs_options;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    ASSERT_TRUE(cloud_fs_opts.credentials.HasValid().ok());
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    storage_options.options.max_log_file_size = 0;
+#endif
     s = db.Open(storage_options, path);
+    ASSERT_TRUE(s.ok());
   }
 
   void TearDown() override {

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -23,7 +23,17 @@ class StringsTest : public ::testing::Test {
       mkdir(path.c_str(), 0755);
     }
     storage_options.options.create_if_missing = true;
+#ifdef USE_S3
+    auto& cloud_fs_opts = storage_options.cloud_fs_options;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    ASSERT_TRUE(cloud_fs_opts.credentials.HasValid().ok());
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    storage_options.options.max_log_file_size = 0;
+#endif
     s = db.Open(storage_options, path);
+    ASSERT_TRUE(s.ok());
   }
 
   void TearDown() override {

--- a/src/storage/tests/zsets_test.cc
+++ b/src/storage/tests/zsets_test.cc
@@ -28,6 +28,15 @@ class ZSetsTest : public ::testing::Test {
       mkdir(path.c_str(), 0755);
     }
     storage_options.options.create_if_missing = true;
+#ifdef USE_S3
+    auto& cloud_fs_opts = storage_options.cloud_fs_options;
+    cloud_fs_opts.endpoint_override = "http://127.0.0.1:9000";
+    cloud_fs_opts.credentials.InitializeSimple("minioadmin", "minioadmin");
+    ASSERT_TRUE(cloud_fs_opts.credentials.HasValid().ok());
+    cloud_fs_opts.src_bucket.SetBucketName("database.unit.test", "pika.");
+    cloud_fs_opts.dest_bucket.SetBucketName("database.unit.test", "pika.");
+    storage_options.options.max_log_file_size = 0;
+#endif
     s = db.Open(storage_options, path);
     if (!s.ok()) {
       printf("Open db failed, exit...\n");

--- a/tests/conf/pika.conf
+++ b/tests/conf/pika.conf
@@ -391,3 +391,32 @@ default-slot-num : 1024
 # blob-num-shard-bits default -1, the number of bits from cache keys to be use as shard id.
 # The cache will be sharded into 2^blob-num-shard-bits shards.
 # blob-num-shard-bits : -1
+
+######################################################################
+#         rocksdb-cloud options                    
+#######################################################################
+
+# Normally, the AWS SDK will automatically determine the endpoint based on the selected region.
+# However, in special cases, you can manually specify the URL of the endpoint through this configuration,
+# such as local development.
+# Default: ""
+cloud-endpoint-override : http://127.0.0.1:9000
+
+# The aws access key id and aws secret key used for authentication when accessing aws s3.
+cloud-access-key : minioadmin
+cloud-secret-key : minioadmin
+
+# The source bucket name prefix and suffix to use for storage on s3
+# The final bucket name is [prefix][suffix] 
+# Default: "pika."
+# cloud-src-bucket-prefix :
+# Default: "database"
+# cloud-src-bucket-suffix :
+
+# The source bucket region 
+# cloud-src-bucket-region :
+
+# Configuration information of the destination bucket
+# cloud-dest-bucket-prefix :
+# cloud-dest-bucket-suffix :
+# cloud-dest-bucket-region : 

--- a/tests/conf/pika.conf
+++ b/tests/conf/pika.conf
@@ -411,12 +411,12 @@ cloud-secret-key : minioadmin
 # Default: "pika."
 # cloud-src-bucket-prefix :
 # Default: "database"
-# cloud-src-bucket-suffix :
+cloud-src-bucket-suffix : integration.test
 
 # The source bucket region 
 # cloud-src-bucket-region :
 
 # Configuration information of the destination bucket
 # cloud-dest-bucket-prefix :
-# cloud-dest-bucket-suffix :
+cloud-dest-bucket-suffix : integration.test
 # cloud-dest-bucket-region : 

--- a/tests/integration/start_master_and_slave.sh
+++ b/tests/integration/start_master_and_slave.sh
@@ -9,4 +9,10 @@ sed -i '' -e 's|databases : 1|databases : 2|' -e 's|port : 9221|port : 9231|' -e
 ./pika -c ./pika_master.conf
 ./pika -c ./pika_slave.conf
 #ensure both master and slave are ready
-sleep 10
+for i in {1..100}; do
+	if lsof -i:9231 > /dev/null; then
+		break
+	else
+		sleep 1
+	fi
+done

--- a/tools/pika-port/pika_port_3/CMakeLists.txt
+++ b/tools/pika-port/pika_port_3/CMakeLists.txt
@@ -13,6 +13,16 @@ target_include_directories(pika_port PRIVATE ${INSTALL_INCLUDEDIR}
 target_link_libraries(pika_port ${ROCKSDB_LIBRARY} pthread rt net pstd storage ${GLOG_LIBRARY} 
                                 ${GFLAGS_LIBRARY} ${SNAPPY_LIBRARY} ${ZLIB_LIBRARY} ${BZ2_LIBRARY}
                                 ${LZ4_LIBRARY} ${ZSTD_LIBRARY})
+
+if(USE_S3)
+    target_link_libraries(pika_port
+		libaws-cpp-sdk-core.so 
+		libaws-cpp-sdk-transfer.so
+		libaws-cpp-sdk-kinesis.so
+		libaws-cpp-sdk-s3.so
+	)
+endif()
+
 set_target_properties(pika_port PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
     CMAKE_COMPILER_IS_GNUCXX TRUE

--- a/tools/pika_to_txt/CMakeLists.txt
+++ b/tools/pika_to_txt/CMakeLists.txt
@@ -15,6 +15,16 @@ target_include_directories(pika_to_txt PRIVATE ${INSTALL_INCLUDEDIR}
 
 target_link_libraries(pika_to_txt storage net pstd ${ROCKSDB_LIBRARY} pthread ${SNAPPY_LIBRARY}
                                   ${ZLIB_LIBRARY} ${BZ2_LIBRARY} ${GLOG_LIBRARY} ${GFLAGS_LIBRARY} rt)
+
+if(USE_S3)
+    target_link_libraries(pika_to_txt
+		libaws-cpp-sdk-core.so 
+		libaws-cpp-sdk-transfer.so
+		libaws-cpp-sdk-kinesis.so
+		libaws-cpp-sdk-s3.so
+	)
+endif()
+
 set_target_properties(pika_to_txt PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
     CMAKE_COMPILER_IS_GNUCXX TRUE


### PR DESCRIPTION
1. 使用rocksdb-cloud替换rocksdb，主要是将原本使用 rocksdb::DB 的地方替换为 rocksdb::DBCloud 并用宏包裹起来，以及一些配置信息的传递，包括tests中使用的地方。
2. 在cmake中增加编译选项USE_S3=[ON/OFF]来开启/关闭是否使用rocksdb-cloud，若使用，增加拉取rocksdb-cloud库的命令和链接相关动态库命令
3. 增加有关rocksdb-cloud的配置选项
4. 由于使用rocksdb-cloud的pika启动较慢，改动了./tests/integration/start_master_and_slave.sh脚本
5. 增加新工作流 pika_cloud.yml，pika.yml仍然以不使用rocksdb-cloud的方式编译，pika_cloud.yml增加安装aws sdk和启动minio用于测试的步骤，编译pika时开启USE_S3选项。但centos和mac的工作流还未能成功。