### PR TITLE
Add codis-proxy slow  log

### DIFF
--- a/codis/pkg/proxy/backend.go
+++ b/codis/pkg/proxy/backend.go
@@ -284,6 +284,7 @@ func (bc *BackendConn) loopReader(tasks <-chan *Request, c *redis.Conn, round in
 	}()
 	for r := range tasks {
 		resp, err := c.Decode()
+		r.ReceiveFromServerTime = time.Now().UnixNano()
 		if err != nil {
 			return bc.setResponse(r, nil, fmt.Errorf("backend conn failure, %s", err))
 		}
@@ -363,6 +364,7 @@ func (bc *BackendConn) loopWriter(round int) (err error) {
 		} else {
 			tasks <- r
 		}
+		r.SendToServerTime = time.Now().UnixNano()
 	}
 	return nil
 }

--- a/codis/pkg/proxy/request.go
+++ b/codis/pkg/proxy/request.go
@@ -22,7 +22,10 @@ type Request struct {
 	OpFlag
 
 	Database int32
-	UnixNano int64
+	ReceiveTime int64
+	SendToServerTime int64
+	ReceiveFromServerTime int64
+	TasksLen    int64
 
 	*redis.Resp
 	Err error
@@ -43,7 +46,7 @@ func (r *Request) MakeSubRequest(n int) []Request {
 		x.OpFlag = r.OpFlag
 		x.Broken = r.Broken
 		x.Database = r.Database
-		x.UnixNano = r.UnixNano
+		x.ReceiveTime = r.ReceiveTime
 	}
 	return sub
 }
@@ -51,7 +54,7 @@ func (r *Request) MakeSubRequest(n int) []Request {
 const GOLDEN_RATIO_PRIME_32 = 0x9e370001
 
 func (r *Request) Seed16() uint {
-	h32 := uint32(r.UnixNano) + uint32(uintptr(unsafe.Pointer(r)))
+	h32 := uint32(r.ReceiveTime) + uint32(uintptr(unsafe.Pointer(r)))
 	h32 *= GOLDEN_RATIO_PRIME_32
 	return uint(h32 >> 16)
 }

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -239,7 +239,7 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 		}
 		nowTime := time.Now().UnixNano()
 		duration := int64((nowTime - r.ReceiveTime) / 1e3)
-		if duration >= 20000 {
+		if duration >= 50000 {
 			//client -> proxy -> server -> porxy -> client
 			//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
 			//从接收到server响应到发送给客户端等待时间。

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -239,7 +239,7 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 		}
 		nowTime := time.Now().UnixNano()
 		duration := int64((nowTime - r.ReceiveTime) / 1e3)
-		if duration >= 10000000 {
+		if duration >= 1000000 {
 			//client -> proxy -> server -> porxy -> client
 			//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
 			//从接收到server响应到发送给客户端等待时间。
@@ -673,7 +673,7 @@ func (s *Session) incrOpStats(r *Request, t redis.RespType) {
 	e.calls.Incr()
 	e.nsecs.Add(time.Now().UnixNano() - r.ReceiveTime)
 	Receiveduration := time.Now().UnixNano() - r.ReceiveTime
-	if Receiveduration > 100000 {
+	if Receiveduration > 1000000 {
 		log.Errorf("%s remote:%s, start_time(us):%d, duration(us): [%d, %d, %d], %d, tasksLen:%d",
 			time.Unix(r.ReceiveTime/1e9, 0).Format("2006-01-02 15:04:05"), s.Conn.RemoteAddr(), r.ReceiveTime/1e3, Receiveduration, r.TasksLen)
 	}

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -239,7 +239,7 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 		}
 		nowTime := time.Now().UnixNano()
 		duration := int64((nowTime - r.ReceiveTime) / 1e3)
-		if duration >= 30000000 {
+		if duration >= 10000000 {
 			//client -> proxy -> server -> porxy -> client
 			//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
 			//从接收到server响应到发送给客户端等待时间。
@@ -253,7 +253,7 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 			if r.ReceiveFromServerTime > 0 {
 				d2 = int64((nowTime - r.ReceiveFromServerTime) / 1e3)
 			}
-			log.Errorf("%s remote:%s, start_time(us):%d, duration(us): [%d, %d, %d], %d, tasksLen:%d, command:[%s].",
+			log.Errorf("%s remote:%s, start_time(us):%d, duration(us): [%d, %d, %d], %d, tasksLen:%d",
 				time.Unix(r.ReceiveTime/1e9, 0).Format("2006-01-02 15:04:05"), s.Conn.RemoteAddr(), r.ReceiveTime/1e3, d0, d1, d2, duration, r.TasksLen)
 		}
 

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -239,7 +239,7 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 		}
 		nowTime := time.Now().UnixNano()
 		duration := int64((nowTime - r.ReceiveTime) / 1e3)
-		if duration >= 100000 {
+		if duration >= 30000000 {
 			//client -> proxy -> server -> porxy -> client
 			//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
 			//从接收到server响应到发送给客户端等待时间。

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -239,7 +239,7 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 		}
 		nowTime := time.Now().UnixNano()
 		duration := int64((nowTime - r.ReceiveTime) / 1e3)
-		if duration >= 10000 {
+		if duration >= 20000 {
 			//client -> proxy -> server -> porxy -> client
 			//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
 			//从接收到server响应到发送给客户端等待时间。

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -170,7 +170,7 @@ func (s *Session) loopReader(tasks *RequestChan, d *Router) (err error) {
 		s.incrOpTotal()
 
 		tasksLen := tasks.Buffered()
-		if tasks.Buffered() > maxPipelineLen {
+		if tasksLen > maxPipelineLen {
 			return s.incrOpFails(nil, ErrTooManyPipelinedRequests)
 		}
 

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -169,6 +169,7 @@ func (s *Session) loopReader(tasks *RequestChan, d *Router) (err error) {
 		}
 		s.incrOpTotal()
 
+		tasksLen := tasks.Buffered()
 		if tasks.Buffered() > maxPipelineLen {
 			return s.incrOpFails(nil, ErrTooManyPipelinedRequests)
 		}
@@ -181,7 +182,8 @@ func (s *Session) loopReader(tasks *RequestChan, d *Router) (err error) {
 		r.Multi = multi
 		r.Batch = &sync.WaitGroup{}
 		r.Database = s.database
-		r.UnixNano = start.UnixNano()
+		r.ReceiveTime = start.UnixNano()
+		r.TasksLen = int64(tasksLen)
 
 		if err := s.handleRequest(r, d); err != nil {
 			r.Resp = redis.NewErrorf("ERR handle request, %s", err)
@@ -235,6 +237,26 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 		if fflush {
 			s.flushOpStats(false)
 		}
+		nowTime := time.Now().UnixNano()
+		duration := int64((nowTime - r.ReceiveTime) / 1e3)
+		if duration >= 100000 {
+			//client -> proxy -> server -> porxy -> client
+			//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
+			//从接收到server响应到发送给客户端等待时间。
+			var d0, d1, d2 int64 = -1, -1, -1
+			if r.SendToServerTime > 0 {
+				d0 = int64((r.SendToServerTime - r.ReceiveTime) / 1e3)
+			}
+			if r.SendToServerTime > 0 && r.ReceiveFromServerTime > 0 {
+				d1 = int64((r.ReceiveFromServerTime - r.SendToServerTime) / 1e3)
+			}
+			if r.ReceiveFromServerTime > 0 {
+				d2 = int64((nowTime - r.ReceiveFromServerTime) / 1e3)
+			}
+			log.Errorf("%s remote:%s, start_time(us):%d, duration(us): [%d, %d, %d], %d, tasksLen:%d, command:[%s].",
+				time.Unix(r.ReceiveTime/1e9, 0).Format("2006-01-02 15:04:05"), s.Conn.RemoteAddr(), r.ReceiveTime/1e3, d0, d1, d2, duration, r.TasksLen)
+		}
+
 		return nil
 	})
 }
@@ -649,7 +671,12 @@ func (s *Session) getOpStats(opstr string) *opStats {
 func (s *Session) incrOpStats(r *Request, t redis.RespType) {
 	e := s.getOpStats(r.OpStr)
 	e.calls.Incr()
-	e.nsecs.Add(time.Now().UnixNano() - r.UnixNano)
+	e.nsecs.Add(time.Now().UnixNano() - r.ReceiveTime)
+	Receiveduration := time.Now().UnixNano() - r.ReceiveTime
+	if Receiveduration > 100000 {
+		log.Errorf("%s remote:%s, start_time(us):%d, duration(us): [%d, %d, %d], %d, tasksLen:%d",
+			time.Unix(r.ReceiveTime/1e9, 0).Format("2006-01-02 15:04:05"), s.Conn.RemoteAddr(), r.ReceiveTime/1e3, Receiveduration, r.TasksLen)
+	}
 	switch t {
 	case redis.TypeError:
 		e.redis.errors.Incr()

--- a/codis/pkg/proxy/session.go
+++ b/codis/pkg/proxy/session.go
@@ -239,7 +239,7 @@ func (s *Session) loopWriter(tasks *RequestChan) (err error) {
 		}
 		nowTime := time.Now().UnixNano()
 		duration := int64((nowTime - r.ReceiveTime) / 1e3)
-		if duration >= 1000000 {
+		if duration >= 10000 {
 			//client -> proxy -> server -> porxy -> client
 			//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
 			//从接收到server响应到发送给客户端等待时间。
@@ -672,11 +672,6 @@ func (s *Session) incrOpStats(r *Request, t redis.RespType) {
 	e := s.getOpStats(r.OpStr)
 	e.calls.Incr()
 	e.nsecs.Add(time.Now().UnixNano() - r.ReceiveTime)
-	Receiveduration := time.Now().UnixNano() - r.ReceiveTime
-	if Receiveduration > 1000000 {
-		log.Errorf("%s remote:%s, start_time(us):%d, duration(us): [%d, %d, %d], %d, tasksLen:%d",
-			time.Unix(r.ReceiveTime/1e9, 0).Format("2006-01-02 15:04:05"), s.Conn.RemoteAddr(), r.ReceiveTime/1e3, Receiveduration, r.TasksLen)
-	}
 	switch t {
 	case redis.TypeError:
 		e.redis.errors.Incr()


### PR DESCRIPTION
本PR主要用于跟踪codis大毛刺的问题，
主要记录3个时间段
//client -> proxy -> server -> porxy -> client
//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
//从接收到server响应到发送给客户端等待时间。
目前是默认耗时50ms会打印这个日志方便定位毛刺问题