### PR TITLE
fix set slow

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -360,7 +360,7 @@ default-slot-num : 1024
 #######################################################################E#######
 
 # rate limiter bandwidth, default 200MB
-#rate-limiter-bandwidth : 209715200
+#rate-limiter-bandwidth : 2097152000
 
 #rate-limiter-refill-period-us : 100000
 #

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -359,7 +359,7 @@ default-slot-num : 1024
 # https://github.com/EighteenZi/rocksdb_wiki/blob/master/Rate-Limiter.md
 #######################################################################E#######
 
-# rate limiter bandwidth, default 200MB
+# rate limiter bandwidth, default 2000MB/s
 #rate-limiter-bandwidth : 2097152000
 
 #rate-limiter-refill-period-us : 100000
@@ -411,8 +411,8 @@ default-slot-num : 1024
 # The cache will be sharded into 2^blob-num-shard-bits shards.
 # blob-num-shard-bits : -1
 
-# Rsync Rate limiting configuration
-throttle-bytes-per-second : 307200000
+# Rsync Rate limiting configuration 200MB/s
+throttle-bytes-per-second : 207200000
 max-rsync-parallel-num : 4
 
 # The synchronization mode of Pika primary/secondary replication is determined by ReplicationID. ReplicationID in one replication_cluster are the same

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -702,7 +702,7 @@ class PikaConf : public pstd::BaseConf {
   std::shared_mutex rwlock_;
 
   // Rsync Rate limiting configuration
-  int throttle_bytes_per_second_ = 307200000;
+  int throttle_bytes_per_second_ = 207200000;
   int max_rsync_parallel_num_ = 4;
 };
 

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -404,7 +404,7 @@ int PikaConf::Load() {
   // rate-limiter-bandwidth
   GetConfInt64("rate-limiter-bandwidth", &rate_limiter_bandwidth_);
   if (rate_limiter_bandwidth_ <= 0) {
-    rate_limiter_bandwidth_ = 2000 * 1024 * 1024;  // 200MB
+    rate_limiter_bandwidth_ = 2000 * 1024 * 1024;  // 2000MB/s
   }
 
   // rate-limiter-refill-period-us
@@ -606,7 +606,7 @@ int PikaConf::Load() {
   // throttle-bytes-per-second
   GetConfInt("throttle-bytes-per-second", &throttle_bytes_per_second_);
   if (throttle_bytes_per_second_ <= 0) {
-    throttle_bytes_per_second_ = 307200000;
+    throttle_bytes_per_second_ = 207200000;
   }
 
   GetConfInt("max-rsync-parallel-num", &max_rsync_parallel_num_);

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -404,7 +404,7 @@ int PikaConf::Load() {
   // rate-limiter-bandwidth
   GetConfInt64("rate-limiter-bandwidth", &rate_limiter_bandwidth_);
   if (rate_limiter_bandwidth_ <= 0) {
-    rate_limiter_bandwidth_ = 200 * 1024 * 1024;  // 200MB
+    rate_limiter_bandwidth_ = 2000 * 1024 * 1024;  // 200MB
   }
 
   // rate-limiter-refill-period-us


### PR DESCRIPTION
rate_limit参数默认值是200M/s，会影响memtable flush进磁盘的速度，200M/s太小，会导致rsp间接性为0