### PR TITLE
Feature: The WAL command can be dynamically disabled

### DIFF
--- a/docs/ops/APIDifference.md
+++ b/docs/ops/APIDifference.md
@@ -126,6 +126,26 @@ slaveof命令允许通过指定write2file(binlog)的文件名称及同步位置�
 
 ### diskrecovery 
 Pika 原创命令，功能为当磁盘意外写满后，RocksDB 会进入写保护状态，当我们将空间调整为充足空间时，这个命令可以将 RocksDB 的写保护状态解除，变为可以继续写的状态, 避免了 Pika 因为磁盘写满后需要重启才能恢复写的情况，执行成功时返回 OK，如果当前磁盘空间依然不足，执行这个命令返回`"The available disk capacity is insufficient`，该命令执行时不需要额外参数，只需要执行 diskrecovery 即可。
-
+```bash
+> diskrecovery 
+> OK
+```
 ### clearreplicationid
 Pika 原创命令，功能是清空 Pika 实例的 replicationid 的值并持久化到配置文件中
+```bash
+> clearreplicationid
+> OK
+```
+
+### DisableWal
+我们可以根据 disablewal (true/false) 接受两个参数来决定 WAL 选项的开关，true 表示写 WAL 功能关闭，false 表示写 WAL 功能开启，需要注意的是写 WAL 默认是开启的 
+```bash
+> disablewal true  // 写 WAL 关闭
+> OK
+> disablewal false  // 写 WAL 开启
+> OK
+> disablewal asdfs // 识别到异常参数
+> (error) ERR Invalid parameter
+> disable false dasfasd // 参数数目异常
+> (error) ERR wrong number of arguments for 'disablewal' command
+```

--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -475,6 +475,18 @@ class ClearReplicationIDCmd : public Cmd {
   void DoInitial() override;
 };
 
+class DisableWalCmd : public Cmd {
+ public:
+  DisableWalCmd(const std::string& name, int arity, uint16_t flag) : Cmd(name, arity, flag) {}
+  void Do(std::shared_ptr<Slot> slot = nullptr) override;
+  void Split(std::shared_ptr<Slot> slot, const HintKeys& hint_keys) override{};
+  void Merge() override{};
+  Cmd* Clone() override { return new DisableWalCmd(*this); }
+
+ private:
+  void DoInitial() override;
+};
+
 #ifdef WITH_COMMAND_DOCS
 class CommandCmd : public Cmd {
  public:

--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -52,6 +52,7 @@ const std::string kCmdNameHello = "hello";
 const std::string kCmdNameCommand = "command";
 const std::string kCmdNameDiskRecovery = "diskrecovery";
 const std::string kCmdNameClearReplicationID = "clearreplicationid";
+const std::string kCmdNameDisableWal = "disablewal";
 
 // Migrate slot
 const std::string kCmdNameSlotsMgrtSlot = "slotsmgrtslot";

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2660,6 +2660,28 @@ void ClearReplicationIDCmd::Do(std::shared_ptr<Slot> slot) {
   res_.SetRes(CmdRes::kOk, "ReplicationID is cleared");
 }
 
+void DisableWalCmd::DoInitial() {
+  if (!CheckArg(argv_.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameDisableWal);
+    return;
+  }
+}
+
+void DisableWalCmd::Do(std::shared_ptr<Slot> slot) {
+  std::string option = argv_[1].data();
+  bool is_wal_disable = false;
+  if (option.compare("true") == 0) {
+    is_wal_disable = true;
+  } else if (option.compare("false") == 0) {
+    is_wal_disable = false;
+  } else {
+    res_.SetRes(CmdRes::kErrOther, "Invalid parameter");
+    return;
+  }
+  slot->db()->DisableWal(is_wal_disable);
+  res_.SetRes(CmdRes::kOk, "Wal options is changed");
+}
+
 #ifdef WITH_COMMAND_DOCS
 
 bool CommandCmd::CommandFieldCompare::operator()(const std::string& a, const std::string& b) const {

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -96,6 +96,8 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameDiskRecovery, std::move(diskrecoveryptr)));
   std::unique_ptr<Cmd> clearreplicationidptr = std::make_unique<ClearReplicationIDCmd>(kCmdNameClearReplicationID, 1, kCmdFlagsWrite | kCmdFlagsAdmin);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameClearReplicationID, std::move(clearreplicationidptr)));
+  std::unique_ptr<Cmd> disablewalptr = std::make_unique<DisableWalCmd>(kCmdNameDisableWal, 2, kCmdFlagsAdmin);
+  cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameDisableWal, std::move(disablewalptr)));
 
 #ifdef WITH_COMMAND_DOCS
   std::unique_ptr<Cmd> commandptr = std::make_unique<CommandCmd>(kCmdNameCommand, -1, kCmdFlagsRead | kCmdFlagsAdmin);

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -976,6 +976,9 @@ class Storage {
 
   Status Keys(const DataType& data_type, const std::string& pattern, std::vector<std::string>* keys);
 
+  // Dynamic switch WAL
+  void DisableWal(const bool is_wal_disable);
+
   // Iterate through all the data in the database.
   void ScanDatabase(const DataType& type);
 

--- a/src/storage/src/redis.cc
+++ b/src/storage/src/redis.cc
@@ -165,4 +165,8 @@ void Redis::GetRocksDBInfo(std::string &info, const char *prefix) {
     info.append(string_stream.str());
 }
 
+void Redis::SetWriteWalOptions(const bool is_wal_disable) {
+  default_write_options_.disableWAL = is_wal_disable;
+}
+
 }  // namespace storage

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -31,6 +31,7 @@ class Redis {
   rocksdb::DB* GetDB() { return db_; }
 
   Status SetOptions(const OptionType& option_type, const std::unordered_map<std::string, std::string>& options);
+  void SetWriteWalOptions(const bool is_wal_disable);
 
   // Common Commands
   virtual Status Open(const StorageOptions& storage_options, const std::string& db_path) = 0;

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1761,4 +1761,12 @@ void Storage::GetRocksDBInfo(std::string& info) {
   zsets_db_->GetRocksDBInfo(info, "zsets_");
 }
 
+void Storage::DisableWal(const bool is_wal_disable) {
+  strings_db_->SetWriteWalOptions(is_wal_disable);
+  hashes_db_->SetWriteWalOptions(is_wal_disable);
+  lists_db_->SetWriteWalOptions(is_wal_disable);
+  sets_db_->SetWriteWalOptions(is_wal_disable);
+  zsets_db_->SetWriteWalOptions(is_wal_disable);
+}
+
 }  //  namespace storage


### PR DESCRIPTION
## 背景

RocksDB 中的 `disableWAL` 是禁用 Write-Ahead Logging（WAL）的选项。用于确保数据的持久性和一致性。在 RocksDB 中，WAL 是默认启用的，这意味着每次写入操作都会首先追加到一个日志文件中，然后再写入内存中的数据结构。Pika 目前打算支持 WAL 动态关闭的命令，在写压力大的情况下，用户可以根据自己的需求动态去关闭 WAL 去缓解写瓶颈。



## 命令介绍

我们可以根据 disablewal (true/false) 命令接受两个参数来决定 WAL 选项的开关，true 表示写 WAL 功能关闭，false 表示写 WAL 功能开启，需要注意的是写 WAL 默认是开启的

```bash
> disablewal true  // 写 WAL 关闭
> OK
> disablewal false  // 写 WAL 开启
> OK
> disablewal asdfs // 识别到异常参数
> (error) ERR Invalid parameter
> disable false dasfasd // 参数数目异常
> (error) ERR wrong number of arguments for 'disablewal' command
```



## 压测命令

在同一配置下，我们对 WAL 的开关场景进行在 Mac 本机进行了压测

```bash
redis-benchmark -p 9221 -n 100000 -r 100000 -t set -d 8196
```



### 关闭 WAL

```bash
====== SET ======                                                   
  100000 requests completed in 4.70 seconds
  50 parallel clients
  8196 bytes payload
  keep alive: 1
  host configuration "save": 
  host configuration "appendonly": no
  multi-thread: no

Latency by percentile distribution:
0.000% <= 0.439 milliseconds (cumulative count 1)
50.000% <= 1.263 milliseconds (cumulative count 50492)
75.000% <= 1.551 milliseconds (cumulative count 75379)
87.500% <= 1.831 milliseconds (cumulative count 87701)
93.750% <= 2.175 milliseconds (cumulative count 93797)
96.875% <= 2.703 milliseconds (cumulative count 96881)
98.438% <= 13.679 milliseconds (cumulative count 98438)
99.219% <= 25.487 milliseconds (cumulative count 99219)
99.609% <= 89.855 milliseconds (cumulative count 99613)
99.805% <= 147.455 milliseconds (cumulative count 99805)
99.902% <= 185.727 milliseconds (cumulative count 99904)
99.951% <= 311.295 milliseconds (cumulative count 99952)
99.976% <= 312.575 milliseconds (cumulative count 99979)
99.988% <= 317.439 milliseconds (cumulative count 99991)
99.994% <= 317.951 milliseconds (cumulative count 99995)
99.997% <= 319.999 milliseconds (cumulative count 99999)
99.999% <= 320.767 milliseconds (cumulative count 100000)
100.000% <= 320.767 milliseconds (cumulative count 100000)

Cumulative distribution of latencies:
0.000% <= 0.103 milliseconds (cumulative count 0)
0.007% <= 0.503 milliseconds (cumulative count 7)
0.140% <= 0.607 milliseconds (cumulative count 140)
1.070% <= 0.703 milliseconds (cumulative count 1070)
4.413% <= 0.807 milliseconds (cumulative count 4413)
10.597% <= 0.903 milliseconds (cumulative count 10597)
20.547% <= 1.007 milliseconds (cumulative count 20547)
31.738% <= 1.103 milliseconds (cumulative count 31738)
44.245% <= 1.207 milliseconds (cumulative count 44245)
54.674% <= 1.303 milliseconds (cumulative count 54674)
64.487% <= 1.407 milliseconds (cumulative count 64487)
72.169% <= 1.503 milliseconds (cumulative count 72169)
78.662% <= 1.607 milliseconds (cumulative count 78662)
83.306% <= 1.703 milliseconds (cumulative count 83306)
86.984% <= 1.807 milliseconds (cumulative count 86984)
89.502% <= 1.903 milliseconds (cumulative count 89502)
91.581% <= 2.007 milliseconds (cumulative count 91581)
92.975% <= 2.103 milliseconds (cumulative count 92975)
97.628% <= 3.103 milliseconds (cumulative count 97628)
98.051% <= 4.103 milliseconds (cumulative count 98051)
98.146% <= 5.103 milliseconds (cumulative count 98146)
98.152% <= 6.103 milliseconds (cumulative count 98152)
98.175% <= 7.103 milliseconds (cumulative count 98175)
98.234% <= 8.103 milliseconds (cumulative count 98234)
98.288% <= 9.103 milliseconds (cumulative count 98288)
98.299% <= 10.103 milliseconds (cumulative count 98299)
98.312% <= 11.103 milliseconds (cumulative count 98312)
98.323% <= 12.103 milliseconds (cumulative count 98323)
98.404% <= 13.103 milliseconds (cumulative count 98404)
98.499% <= 14.103 milliseconds (cumulative count 98499)
98.531% <= 15.103 milliseconds (cumulative count 98531)
98.598% <= 16.103 milliseconds (cumulative count 98598)
98.611% <= 17.103 milliseconds (cumulative count 98611)
98.681% <= 18.111 milliseconds (cumulative count 98681)
98.758% <= 19.103 milliseconds (cumulative count 98758)
98.776% <= 20.111 milliseconds (cumulative count 98776)
98.804% <= 21.103 milliseconds (cumulative count 98804)
98.895% <= 22.111 milliseconds (cumulative count 98895)
99.002% <= 23.103 milliseconds (cumulative count 99002)
99.099% <= 24.111 milliseconds (cumulative count 99099)
99.182% <= 25.103 milliseconds (cumulative count 99182)
99.244% <= 26.111 milliseconds (cumulative count 99244)
99.250% <= 27.103 milliseconds (cumulative count 99250)
99.266% <= 29.103 milliseconds (cumulative count 99266)
99.297% <= 30.111 milliseconds (cumulative count 99297)
99.300% <= 31.103 milliseconds (cumulative count 99300)
99.301% <= 36.127 milliseconds (cumulative count 99301)
99.324% <= 37.119 milliseconds (cumulative count 99324)
99.347% <= 38.111 milliseconds (cumulative count 99347)
99.350% <= 39.103 milliseconds (cumulative count 99350)
99.358% <= 42.111 milliseconds (cumulative count 99358)
99.384% <= 43.103 milliseconds (cumulative count 99384)
99.399% <= 44.127 milliseconds (cumulative count 99399)
99.400% <= 45.119 milliseconds (cumulative count 99400)
99.411% <= 48.127 milliseconds (cumulative count 99411)
99.437% <= 49.119 milliseconds (cumulative count 99437)
99.450% <= 50.111 milliseconds (cumulative count 99450)
99.503% <= 67.135 milliseconds (cumulative count 99503)
99.550% <= 68.159 milliseconds (cumulative count 99550)
99.551% <= 76.159 milliseconds (cumulative count 99551)
99.562% <= 77.119 milliseconds (cumulative count 99562)
99.592% <= 78.143 milliseconds (cumulative count 99592)
99.600% <= 79.103 milliseconds (cumulative count 99600)
99.626% <= 90.111 milliseconds (cumulative count 99626)
99.650% <= 91.135 milliseconds (cumulative count 99650)
99.662% <= 94.143 milliseconds (cumulative count 99662)
99.684% <= 95.103 milliseconds (cumulative count 99684)
99.698% <= 96.127 milliseconds (cumulative count 99698)
99.700% <= 97.151 milliseconds (cumulative count 99700)
99.701% <= 104.127 milliseconds (cumulative count 99701)
99.748% <= 105.151 milliseconds (cumulative count 99748)
99.750% <= 106.111 milliseconds (cumulative count 99750)
99.771% <= 111.103 milliseconds (cumulative count 99771)
99.799% <= 112.127 milliseconds (cumulative count 99799)
99.800% <= 113.151 milliseconds (cumulative count 99800)
99.802% <= 147.199 milliseconds (cumulative count 99802)
99.841% <= 148.223 milliseconds (cumulative count 99841)
99.849% <= 149.119 milliseconds (cumulative count 99849)
99.850% <= 150.143 milliseconds (cumulative count 99850)
99.863% <= 173.183 milliseconds (cumulative count 99863)
99.899% <= 174.207 milliseconds (cumulative count 99899)
99.900% <= 175.103 milliseconds (cumulative count 99900)
99.924% <= 186.111 milliseconds (cumulative count 99924)
99.949% <= 187.135 milliseconds (cumulative count 99949)
99.950% <= 188.159 milliseconds (cumulative count 99950)
99.952% <= 311.295 milliseconds (cumulative count 99952)
99.969% <= 312.319 milliseconds (cumulative count 99969)
99.982% <= 313.343 milliseconds (cumulative count 99982)
99.984% <= 314.111 milliseconds (cumulative count 99984)
99.987% <= 317.183 milliseconds (cumulative count 99987)
99.995% <= 318.207 milliseconds (cumulative count 99995)
99.996% <= 319.231 milliseconds (cumulative count 99996)
99.999% <= 320.255 milliseconds (cumulative count 99999)
100.000% <= 321.279 milliseconds (cumulative count 100000)

Summary:
  throughput summary: 21290.19 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        2.301     0.432     1.263     2.319    23.071   320.767
```



### 开启 WAL

```bash
====== SET ======                                                   
  100000 requests completed in 8.18 seconds
  50 parallel clients
  8196 bytes payload
  keep alive: 1
  host configuration "save": 
  host configuration "appendonly": no
  multi-thread: no

Latency by percentile distribution:
0.000% <= 0.735 milliseconds (cumulative count 1)
50.000% <= 1.799 milliseconds (cumulative count 50099)
75.000% <= 2.391 milliseconds (cumulative count 75007)
87.500% <= 3.847 milliseconds (cumulative count 87510)
93.750% <= 7.911 milliseconds (cumulative count 93752)
96.875% <= 23.855 milliseconds (cumulative count 96876)
98.438% <= 29.567 milliseconds (cumulative count 98443)
99.219% <= 46.111 milliseconds (cumulative count 99219)
99.609% <= 75.775 milliseconds (cumulative count 99610)
99.805% <= 180.607 milliseconds (cumulative count 99805)
99.902% <= 263.423 milliseconds (cumulative count 99905)
99.951% <= 311.039 milliseconds (cumulative count 99955)
99.976% <= 313.855 milliseconds (cumulative count 99987)
99.988% <= 314.111 milliseconds (cumulative count 99991)
99.994% <= 335.359 milliseconds (cumulative count 99994)
99.997% <= 335.615 milliseconds (cumulative count 99999)
99.999% <= 335.871 milliseconds (cumulative count 100000)
100.000% <= 335.871 milliseconds (cumulative count 100000)

Cumulative distribution of latencies:
0.000% <= 0.103 milliseconds (cumulative count 0)
0.004% <= 0.807 milliseconds (cumulative count 4)
0.050% <= 0.903 milliseconds (cumulative count 50)
0.320% <= 1.007 milliseconds (cumulative count 320)
1.342% <= 1.103 milliseconds (cumulative count 1342)
4.184% <= 1.207 milliseconds (cumulative count 4184)
9.021% <= 1.303 milliseconds (cumulative count 9021)
16.432% <= 1.407 milliseconds (cumulative count 16432)
24.502% <= 1.503 milliseconds (cumulative count 24502)
33.979% <= 1.607 milliseconds (cumulative count 33979)
42.311% <= 1.703 milliseconds (cumulative count 42311)
50.647% <= 1.807 milliseconds (cumulative count 50647)
57.155% <= 1.903 milliseconds (cumulative count 57155)
62.778% <= 2.007 milliseconds (cumulative count 62778)
67.005% <= 2.103 milliseconds (cumulative count 67005)
83.614% <= 3.103 milliseconds (cumulative count 83614)
88.466% <= 4.103 milliseconds (cumulative count 88466)
91.345% <= 5.103 milliseconds (cumulative count 91345)
92.742% <= 6.103 milliseconds (cumulative count 92742)
93.437% <= 7.103 milliseconds (cumulative count 93437)
93.828% <= 8.103 milliseconds (cumulative count 93828)
94.144% <= 9.103 milliseconds (cumulative count 94144)
94.263% <= 10.103 milliseconds (cumulative count 94263)
94.435% <= 11.103 milliseconds (cumulative count 94435)
94.616% <= 12.103 milliseconds (cumulative count 94616)
94.980% <= 13.103 milliseconds (cumulative count 94980)
95.238% <= 14.103 milliseconds (cumulative count 95238)
95.415% <= 15.103 milliseconds (cumulative count 95415)
95.677% <= 16.103 milliseconds (cumulative count 95677)
95.883% <= 17.103 milliseconds (cumulative count 95883)
96.115% <= 18.111 milliseconds (cumulative count 96115)
96.312% <= 19.103 milliseconds (cumulative count 96312)
96.394% <= 20.111 milliseconds (cumulative count 96394)
96.441% <= 21.103 milliseconds (cumulative count 96441)
96.653% <= 22.111 milliseconds (cumulative count 96653)
96.766% <= 23.103 milliseconds (cumulative count 96766)
96.906% <= 24.111 milliseconds (cumulative count 96906)
97.137% <= 25.103 milliseconds (cumulative count 97137)
97.368% <= 26.111 milliseconds (cumulative count 97368)
97.690% <= 27.103 milliseconds (cumulative count 97690)
98.056% <= 28.111 milliseconds (cumulative count 98056)
98.307% <= 29.103 milliseconds (cumulative count 98307)
98.553% <= 30.111 milliseconds (cumulative count 98553)
98.610% <= 31.103 milliseconds (cumulative count 98610)
98.649% <= 32.111 milliseconds (cumulative count 98649)
98.699% <= 33.119 milliseconds (cumulative count 98699)
98.755% <= 34.111 milliseconds (cumulative count 98755)
98.800% <= 35.103 milliseconds (cumulative count 98800)
98.849% <= 36.127 milliseconds (cumulative count 98849)
98.850% <= 37.119 milliseconds (cumulative count 98850)
98.900% <= 38.111 milliseconds (cumulative count 98900)
98.917% <= 39.103 milliseconds (cumulative count 98917)
98.959% <= 40.127 milliseconds (cumulative count 98959)
98.983% <= 42.111 milliseconds (cumulative count 98983)
99.001% <= 43.103 milliseconds (cumulative count 99001)
99.107% <= 44.127 milliseconds (cumulative count 99107)
99.164% <= 45.119 milliseconds (cumulative count 99164)
99.219% <= 46.111 milliseconds (cumulative count 99219)
99.292% <= 47.103 milliseconds (cumulative count 99292)
99.313% <= 48.127 milliseconds (cumulative count 99313)
99.363% <= 49.119 milliseconds (cumulative count 99363)
99.390% <= 50.111 milliseconds (cumulative count 99390)
99.395% <= 51.103 milliseconds (cumulative count 99395)
99.397% <= 52.127 milliseconds (cumulative count 99397)
99.398% <= 53.119 milliseconds (cumulative count 99398)
99.401% <= 55.103 milliseconds (cumulative count 99401)
99.447% <= 56.127 milliseconds (cumulative count 99447)
99.452% <= 57.119 milliseconds (cumulative count 99452)
99.464% <= 59.103 milliseconds (cumulative count 99464)
99.525% <= 60.127 milliseconds (cumulative count 99525)
99.529% <= 61.119 milliseconds (cumulative count 99529)
99.539% <= 62.111 milliseconds (cumulative count 99539)
99.540% <= 63.103 milliseconds (cumulative count 99540)
99.584% <= 70.143 milliseconds (cumulative count 99584)
99.600% <= 71.103 milliseconds (cumulative count 99600)
99.603% <= 75.135 milliseconds (cumulative count 99603)
99.614% <= 76.159 milliseconds (cumulative count 99614)
99.655% <= 90.111 milliseconds (cumulative count 99655)
99.664% <= 91.135 milliseconds (cumulative count 99664)
99.670% <= 98.111 milliseconds (cumulative count 99670)
99.684% <= 99.135 milliseconds (cumulative count 99684)
99.685% <= 117.119 milliseconds (cumulative count 99685)
99.734% <= 118.143 milliseconds (cumulative count 99734)
99.738% <= 123.135 milliseconds (cumulative count 99738)
99.742% <= 124.159 milliseconds (cumulative count 99742)
99.744% <= 127.103 milliseconds (cumulative count 99744)
99.781% <= 128.127 milliseconds (cumulative count 99781)
99.800% <= 129.151 milliseconds (cumulative count 99800)
99.846% <= 181.119 milliseconds (cumulative count 99846)
99.850% <= 182.143 milliseconds (cumulative count 99850)
99.894% <= 202.111 milliseconds (cumulative count 99894)
99.900% <= 203.135 milliseconds (cumulative count 99900)
99.949% <= 264.191 milliseconds (cumulative count 99949)
99.950% <= 265.215 milliseconds (cumulative count 99950)
99.957% <= 311.295 milliseconds (cumulative count 99957)
99.991% <= 314.111 milliseconds (cumulative count 99991)
100.000% <= 336.127 milliseconds (cumulative count 100000)

Summary:
  throughput summary: 12226.43 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        4.021     0.728     1.799    13.319    43.103   335.871
```



## 结论

可以看到对于 10w 条请求的压测命令，关闭 WAL 会比开启 WAL 平均快 3~4 秒完成对请求的处理返回

**fix: #1961**