### PR TITLE
add codis slow log

### DIFF
--- a/codis/pkg/proxy/backend.go
+++ b/codis/pkg/proxy/backend.go
@@ -284,6 +284,7 @@ func (bc *BackendConn) loopReader(tasks <-chan *Request, c *redis.Conn, round in
 	}()
 	for r := range tasks {
 		resp, err := c.Decode()
+		r.ReceiveFromServerTime = time.Now().UnixNano()
 		if err != nil {
 			return bc.setResponse(r, nil, fmt.Errorf("backend conn failure, %s", err))
 		}
@@ -363,6 +364,7 @@ func (bc *BackendConn) loopWriter(round int) (err error) {
 		} else {
 			tasks <- r
 		}
+		r.SendToServerTime = time.Now().UnixNano()
 	}
 	return nil
 }

--- a/codis/pkg/proxy/request.go
+++ b/codis/pkg/proxy/request.go
@@ -21,8 +21,11 @@ type Request struct {
 	OpStr string
 	OpFlag
 
-	Database int32
-	UnixNano int64
+	Database              int32
+	ReceiveTime           int64
+	SendToServerTime      int64
+	ReceiveFromServerTime int64
+	TasksLen              int64
 
 	*redis.Resp
 	Err error
@@ -43,7 +46,7 @@ func (r *Request) MakeSubRequest(n int) []Request {
 		x.OpFlag = r.OpFlag
 		x.Broken = r.Broken
 		x.Database = r.Database
-		x.UnixNano = r.UnixNano
+		x.ReceiveTime = r.ReceiveTime
 	}
 	return sub
 }
@@ -51,7 +54,7 @@ func (r *Request) MakeSubRequest(n int) []Request {
 const GOLDEN_RATIO_PRIME_32 = 0x9e370001
 
 func (r *Request) Seed16() uint {
-	h32 := uint32(r.UnixNano) + uint32(uintptr(unsafe.Pointer(r)))
+	h32 := uint32(r.ReceiveTime) + uint32(uintptr(unsafe.Pointer(r)))
 	h32 *= GOLDEN_RATIO_PRIME_32
 	return uint(h32 >> 16)
 }


### PR DESCRIPTION
本PR主要用于跟踪codis大毛刺的问题，
主要记录3个时间段
//client -> proxy -> server -> porxy -> client
//分别记录从客户端接收到发送到后端server等待时间、从发送到后端server到从server接收响应等待时间、
//从接收到server响应到发送给客户端等待时间。
目前是默认耗时50ms会打印这个日志方便定位毛刺问题