### PR TITLE
fix: Optimize-slaveof

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -108,7 +108,7 @@ void SlaveofCmd::DoInitial() {
     return;
   }
 
-  // self is master of A , want to slavof B
+  // self is master of A , want to slaveof B
   if ((g_pika_server->role() & PIKA_ROLE_MASTER) != 0) {
     res_.SetRes(CmdRes::kErrOther, "already master of others, invalid usage");
     return;
@@ -122,7 +122,7 @@ void SlaveofCmd::DoInitial() {
   }
 
   if ((master_ip_ == "127.0.0.1" || master_ip_ == g_pika_server->host()) && master_port_ == g_pika_server->port()) {
-    res_.SetRes(CmdRes::kErrOther, "you fucked up");
+    res_.SetRes(CmdRes::kErrOther, "The ip and port of the connection are themselves");
     return;
   }
 
@@ -148,6 +148,7 @@ void SlaveofCmd::Do(std::shared_ptr<Slot> slot) {
   if (is_none_) {
     res_.SetRes(CmdRes::kOk);
     g_pika_conf->SetSlaveof(std::string());
+    g_pika_conf->ConfigRewrite();
     return;
   }
 
@@ -161,6 +162,7 @@ void SlaveofCmd::Do(std::shared_ptr<Slot> slot) {
     res_.SetRes(CmdRes::kOk);
     g_pika_conf->SetSlaveof(master_ip_ + ":" + std::to_string(master_port_));
     g_pika_conf->SetMasterRunID("");
+    g_pika_conf->ConfigRewrite();
     g_pika_server->SetFirstMetaSync(true);
   } else {
     res_.SetRes(CmdRes::kErrOther, "Server is not in correct state for slaveof");


### PR DESCRIPTION
## 背景

当前版本的 Pika 在执行 `slaveof ip port` 和 `slaveof no one` 命令时只会修改内存中的值，但是不会修改配置文件中的信息，即不会进行数据落盘，这个会导致一个问题就是，当一个从节点 `slaveof no one` 之后，其实该从节点配置文件中还是会保留之前解绑的主节点的信息，当该从节点重启之后的角色依然是 `slave`, 这是非常不合理的。



## 解决方案

当我们进行 `slaveof no one` 或者 `slaveof ip port`操作时，我们同时执行 `config rewrite` 使配置文件中的信息一起进行更改，这样能保证从节点解绑后实现真正的对主节点的信息进行删除，不会有重启之后依然是从节点的问题

**fix:#2026**