### PR TITLE
WIP: fix_synced_failed

### DIFF
--- a/tools/kubeblocks_helm/pika/script/admin.sh
+++ b/tools/kubeblocks_helm/pika/script/admin.sh
@@ -51,10 +51,14 @@ reload_until_success() {
 
 register_server() {
   reload_until_success
-  if [ ${POD_ID} -gt 0 ]; then wait_master_registered; fi
+  if [ ${POD_ID} -gt 0 ]; then
+    wait_master_registered;
+    $CODIS_ADMIN --group-add --gid=${GROUP_ID} --addr=${KB_POD_FQDN}:9221 1>/dev/null 2>&1
+    $CODIS_ADMIN --sync-action --create --addr=${KB_POD_FQDN}:9221
+    return
+  fi
   $CODIS_ADMIN --create-group --gid=${GROUP_ID} 1>/dev/null 2>&1
   $CODIS_ADMIN --group-add --gid=${GROUP_ID} --addr=${KB_POD_FQDN}:9221
-  $CODIS_ADMIN --sync-action --create --addr=${KB_POD_FQDN}:9221 1>/dev/null 2>&1
 }
 
 remove_server() {


### PR DESCRIPTION
## 背景
当前在 K8s 环境下自动化部署 Pika 集群的时候会出现 Synced_failed 的问题，但是测试后发现其实主从节点双方数据同步本身是没有问题的，只是在 Dashboard 页面上显示出现了问题，原本情况是所有节点都会出现 Synced_failed，本 PR 改到只有从节点出现 Synced_failed，当然这不是最终的解决办法。

## 想法
目前在 K8s 环境中进行自动化部署 Group 和往里面添加 Pika 并建立主从关系是通过一个脚本文件 `admin.sh` 来实现的，只是这里有个问题是在一个 Group 中建立主从关系使用的是 codis-admin 命令中的 `codis-admin [-v] --dashboard=ADDR --sync-action --create --addr=${KB_POD_FQDN}:9221` 调用完这个命令后会出现 Synced_failed 的情况，如果注释掉这行则主从不会进行绑定同时也没有 Synced_failed 的情况。想问下大家如果不用 codis-admin 命令的绑定主从的话还有其他的方法的吗？或者 Synced_failed 的问题怎么去排查，目前通过双击那个绿色的小扳手可以使 Synced_failed 消息移除

**修改前:**

<img width="1639" alt="截屏2023-09-27 10 37 10" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/9ecaeb70-8ffd-4425-b3cd-f7fcb36e041b">

**修改后:**

<img width="1655" alt="截屏2023-09-27 10 37 35" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/01b1892a-6598-4dd1-8666-88d534727e1f">

## 讨论

大家有好的想法欢迎在评论区留言

fix: #1967 