### PR TITLE
fix: 1981, exporter match rocksdb metrics error

### DIFF
--- a/tools/pika_exporter/exporter/metrics/binlog.go
+++ b/tools/pika_exporter/exporter/metrics/binlog.go
@@ -2,7 +2,7 @@ package metrics
 
 import "regexp"
 
-func init() {
+func RegisterBinlog() {
 	Register(collectBinlogMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/clients.go
+++ b/tools/pika_exporter/exporter/metrics/clients.go
@@ -1,6 +1,6 @@
 package metrics
 
-func init() {
+func RegisterClients() {
 	Register(collectClientsMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/command_exec_count.go
+++ b/tools/pika_exporter/exporter/metrics/command_exec_count.go
@@ -2,7 +2,7 @@ package metrics
 
 import "regexp"
 
-func init() {
+func RegisterCommandExecCount() {
 	Register(collectCommandExecCountMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/commandstats.go
+++ b/tools/pika_exporter/exporter/metrics/commandstats.go
@@ -2,7 +2,7 @@ package metrics
 
 import "regexp"
 
-func init() {
+func RegisterCommandstats() {
 	Register(collectCommandstatsMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/cpu.go
+++ b/tools/pika_exporter/exporter/metrics/cpu.go
@@ -1,6 +1,6 @@
 package metrics
 
-func init() {
+func RegisterCPU() {
 	Register(collectCPUMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/data.go
+++ b/tools/pika_exporter/exporter/metrics/data.go
@@ -1,6 +1,6 @@
 package metrics
 
-func init() {
+func RegisterData() {
 	Register(collectDataMetrics)
 }
 
@@ -15,16 +15,16 @@ var collectDataMetrics = map[string]MetricConfig{
 			ValueName: "db_size",
 		},
 	},
-    "log_size": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "log_size",
-            Help:      "pika serve instance total log size in bytes",
-            Type:      metricTypeGauge,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "log_size",
-        },
-    },
+	"log_size": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "log_size",
+			Help:      "pika serve instance total log size in bytes",
+			Type:      metricTypeGauge,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "log_size",
+		},
+	},
 	"used_memory": {
 		Parser: &normalParser{},
 		MetricMeta: &MetaData{

--- a/tools/pika_exporter/exporter/metrics/keyspace.go
+++ b/tools/pika_exporter/exporter/metrics/keyspace.go
@@ -2,7 +2,7 @@ package metrics
 
 import "regexp"
 
-func init() {
+func RegisterKeyspace() {
 	Register(collectKeySpaceMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/replication.go
+++ b/tools/pika_exporter/exporter/metrics/replication.go
@@ -2,7 +2,7 @@ package metrics
 
 import "regexp"
 
-func init() {
+func RegisterReplication() {
 	Register(collectReplicationMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/rocksdb.go
+++ b/tools/pika_exporter/exporter/metrics/rocksdb.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 )
 
-func init() {
+func RegisterRocksDB() {
 	Register(collectRocksDBMetrics)
 }
 
@@ -144,7 +144,7 @@ var collectRocksDBMetrics = map[string]MetricConfig{
 	},
 	"size_all_mem_tables": {
 		Parser: &regexParser{
-			name:   "size_all_mem_tables",
+			name: "size_all_mem_tables",
 			// TODO: need fix size_all_mem_tables contains wrong data type starting with cur
 			// issue: https://github.com/OpenAtomFoundation/pika/issues/1752
 			reg:    regexp.MustCompile(`(?P<data_type>\w+)_.*?size_all_mem_tables:(?P<size_all_mem_tables>\d+)`),
@@ -191,21 +191,21 @@ var collectRocksDBMetrics = map[string]MetricConfig{
 		},
 	},
 
-    // pending compaction bytes
-    "estimate_pending_compaction_bytes": {
-        Parser: &regexParser{
-            name:   "estimate_pending_compaction_bytes",
-            reg:    regexp.MustCompile(`(?P<data_type>\w+)_.*?estimate_pending_compaction_bytes:(?P<estimate_pending_compaction_bytes>\d+)`),
-            Parser: &normalParser{},
-        },
-        MetricMeta: &MetaData{
-            Name:      "estimate_pending_compaction_bytes",
-            Help:      "Estimated total number of bytes that compression needs to rewrite to bring all levels down below the target size. Has no effect on compression other than level-based compression.",
-            Type:      metricTypeGauge,
-            Labels:    []string{LabelNameAddr, LabelNameAlias, "data_type"},
-            ValueName: "estimate_pending_compaction_bytes",
-        },
-    },
+	// pending compaction bytes
+	"estimate_pending_compaction_bytes": {
+		Parser: &regexParser{
+			name:   "estimate_pending_compaction_bytes",
+			reg:    regexp.MustCompile(`(?P<data_type>\w+)_.*?estimate_pending_compaction_bytes:(?P<estimate_pending_compaction_bytes>\d+)`),
+			Parser: &normalParser{},
+		},
+		MetricMeta: &MetaData{
+			Name:      "estimate_pending_compaction_bytes",
+			Help:      "Estimated total number of bytes that compression needs to rewrite to bring all levels down below the target size. Has no effect on compression other than level-based compression.",
+			Type:      metricTypeGauge,
+			Labels:    []string{LabelNameAddr, LabelNameAlias, "data_type"},
+			ValueName: "estimate_pending_compaction_bytes",
+		},
+	},
 
 	// snapshots
 	"num_snapshots": {
@@ -439,7 +439,7 @@ var collectRocksDBMetrics = map[string]MetricConfig{
 			Name:      "compaction",
 			Help:      "\r#The all metrics of compaction_L<N>:\r#compaction.L<N>.AvgSec	Average time spent per Compact.\r#compaction.L<N>.CompCount	The number of times Compact has been accumulated.\r#compaction.L<N>.CompMergeCPU	CPU time used in compression, in seconds.\r#compaction.L<N>.CompSec	Compact cumulative time, in seconds.\r#compaction.L<N>.CompactedFiles	Number of files that have completed compact.\r#compaction.L<N>.KeyDrop	Number of keys deleted in compact.\r#compaction.L<N>.KeyIn	Number of records compared during the compaction process.\r#compaction.L<N>.MovedGB	During the compaction process, the number of bytes moved to level n+1.\r#compaction.L<N>.NumFiles	Total number of sst files.\r#compaction.L<N>.RblobGB	The size of data read from the blob file by the compaction, in GB.\r#compaction.L<N>.ReadGB	Read size in GB.\r#compaction.L<N>.ReadMBps	Read rate in MBps.\r#compaction.L<N>.RnGB	When performing compact, read the size of the current layer file in GB.\r#compaction.L<N>.Rnp1GB	When performing compact, read the size of the next level file in GB.\r#compaction.L<N>.Score	Score, the higher the score, the higher the priority.\r#compaction.L<N>.SizeBytes	Total size of SST in bytes.\r#compaction.L<N>.WblobGB	The size of the blob file written during compaction, in GB.\r#compaction.L<N>.WnewGB	WNP1- Rnp1.\r#compaction.L<N>.WriteAmp	Total bytes written to level<N+1>/(total bytes read from level<N>).\r#compaction.L<N>.WriteGB	The size of the table file written during the compaction period, in GB.\r#compaction.L<N>.WriteMBps	Data write rate in compaction.",
 			Type:      metricTypeGauge,
-			Labels:    []string{LabelNameAddr, LabelNameAlias, "data_type","info_type","compaction_level"},
+			Labels:    []string{LabelNameAddr, LabelNameAlias, "data_type", "info_type", "compaction_level"},
 			ValueName: "compaction",
 		},
 	},
@@ -453,7 +453,7 @@ var collectRocksDBMetrics = map[string]MetricConfig{
 			Name:      "compaction_Sum",
 			Help:      "The all metrics of compaction_Sum.",
 			Type:      metricTypeGauge,
-			Labels:    []string{LabelNameAddr, LabelNameAlias, "data_type","info_type"},
+			Labels:    []string{LabelNameAddr, LabelNameAlias, "data_type", "info_type"},
 			ValueName: "compaction_Sum",
 		},
 	},

--- a/tools/pika_exporter/exporter/metrics/server.go
+++ b/tools/pika_exporter/exporter/metrics/server.go
@@ -1,6 +1,6 @@
 package metrics
 
-func init() {
+func RegisterServer() {
 	Register(collectServerMetrics)
 }
 

--- a/tools/pika_exporter/exporter/metrics/stats.go
+++ b/tools/pika_exporter/exporter/metrics/stats.go
@@ -2,7 +2,7 @@ package metrics
 
 import "regexp"
 
-func init() {
+func RegisterStats() {
 	Register(collectStatsMetrics)
 }
 
@@ -37,86 +37,86 @@ var collectStatsMetrics = map[string]MetricConfig{
 			ValueName: "total_commands_processed",
 		},
 	},
-    "total_net_input_bytes": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "total_net_input_bytes",
-            Help:      "the total number of bytes read from the network",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "total_net_input_bytes",
-        },
-    },
-    "total_net_output_bytes": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "total_net_output_bytes",
-            Help:      "the total number of bytes written to the network",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "total_net_output_bytes",
-        },
-    },
-    "total_net_repl_input_bytes": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "total_net_repl_input_bytes",
-            Help:      "the total number of bytes read from the network for replication purposes",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "total_net_repl_input_bytes",
-        },
-    },
-    "total_net_repl_output_bytes": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "total_net_repl_output_bytes",
-            Help:      "the total number of bytes written to the network for replication purposes",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "total_net_repl_output_bytes",
-        },
-    },
-    "instantaneous_input_kbps": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "instantaneous_input_kbps",
-            Help:      "the network's read rate per second in KB/sec, calculated as an average of 16 samples collected every 5 seconds.",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "instantaneous_input_kbps",
-        },
-    },
-    "instantaneous_output_kbps": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "instantaneous_output_kbps",
-            Help:      "the network's write rate per second in KB/sec, calculated as an average of 16 samples collected every 5 seconds.",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "instantaneous_output_kbps",
-        },
-    },
-    "instantaneous_input_repl_kbps": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "instantaneous_input_repl_kbps",
-            Help:      "the network's read rate per second in KB/sec for replication purposes, calculated as an average of 16 samples collected every 5 seconds.",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "instantaneous_input_repl_kbps",
-        },
-    },
-    "instantaneous_output_repl_kbps": {
-        Parser: &normalParser{},
-        MetricMeta: &MetaData{
-            Name:      "instantaneous_output_repl_kbps",
-            Help:      "the network's write rate per second in KB/sec for replication purposes, calculated as an average of 16 samples collected every 5 seconds.",
-            Type:      metricTypeCounter,
-            Labels:    []string{LabelNameAddr, LabelNameAlias},
-            ValueName: "instantaneous_output_repl_kbps",
-        },
-    },
+	"total_net_input_bytes": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "total_net_input_bytes",
+			Help:      "the total number of bytes read from the network",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "total_net_input_bytes",
+		},
+	},
+	"total_net_output_bytes": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "total_net_output_bytes",
+			Help:      "the total number of bytes written to the network",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "total_net_output_bytes",
+		},
+	},
+	"total_net_repl_input_bytes": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "total_net_repl_input_bytes",
+			Help:      "the total number of bytes read from the network for replication purposes",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "total_net_repl_input_bytes",
+		},
+	},
+	"total_net_repl_output_bytes": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "total_net_repl_output_bytes",
+			Help:      "the total number of bytes written to the network for replication purposes",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "total_net_repl_output_bytes",
+		},
+	},
+	"instantaneous_input_kbps": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "instantaneous_input_kbps",
+			Help:      "the network's read rate per second in KB/sec, calculated as an average of 16 samples collected every 5 seconds.",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "instantaneous_input_kbps",
+		},
+	},
+	"instantaneous_output_kbps": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "instantaneous_output_kbps",
+			Help:      "the network's write rate per second in KB/sec, calculated as an average of 16 samples collected every 5 seconds.",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "instantaneous_output_kbps",
+		},
+	},
+	"instantaneous_input_repl_kbps": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "instantaneous_input_repl_kbps",
+			Help:      "the network's read rate per second in KB/sec for replication purposes, calculated as an average of 16 samples collected every 5 seconds.",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "instantaneous_input_repl_kbps",
+		},
+	},
+	"instantaneous_output_repl_kbps": {
+		Parser: &normalParser{},
+		MetricMeta: &MetaData{
+			Name:      "instantaneous_output_repl_kbps",
+			Help:      "the network's write rate per second in KB/sec for replication purposes, calculated as an average of 16 samples collected every 5 seconds.",
+			Type:      metricTypeCounter,
+			Labels:    []string{LabelNameAddr, LabelNameAlias},
+			ValueName: "instantaneous_output_repl_kbps",
+		},
+	},
 	"is_bgsaving": {
 		Parser: &regexParser{
 			name:   "is_bgsaving",

--- a/tools/pika_exporter/exporter/pika.go
+++ b/tools/pika_exporter/exporter/pika.go
@@ -56,6 +56,7 @@ func NewPikaExporter(dis discovery.Discovery, namespace string,
 	}
 	e.scanCount = scanCount
 
+	e.registerMetrics()
 	e.initMetrics()
 	e.wg.Add(1)
 	go e.statsKeySpace(statsClockHour)
@@ -293,6 +294,41 @@ func (e *exporter) collectKeys(c *client) error {
 	}
 
 	return nil
+}
+
+func (e *exporter) registerMetrics() {
+	config := InfoConf
+	if config.Server {
+		metrics.RegisterServer()
+	}
+	if config.Data {
+		metrics.RegisterData()
+	}
+	if config.Clients {
+		metrics.RegisterClients()
+	}
+	if config.Stats {
+		metrics.RegisterStats()
+	}
+	if config.CPU {
+		metrics.RegisterCPU()
+	}
+	if config.Replication {
+		metrics.RegisterReplication()
+	}
+	if config.Keyspace {
+		metrics.RegisterKeyspace()
+	}
+	if config.Execcount {
+		metrics.RegisterCommandExecCount()
+	}
+	if config.Commandstats {
+		metrics.RegisterCommandstats()
+	}
+	if config.Rocksdb {
+		metrics.RegisterRocksDB()
+	}
+	metrics.RegisterBinlog()
 }
 
 func getKeysFromPatterns(c *client, keyPatterns []dbKeyPair, scanCount int) ([]dbKeyPair, error) {


### PR DESCRIPTION
此 PR 修复了 rocksdb 选项为 false 时，exporter 尝试但拿不到 rocksdb 的信息，导致的匹配失败的问题。

使用手动控制是否注册，来避免错误

related issue: #1981 