### PR TITLE
add pksetexat in pika-port

### DIFF
--- a/tools/pika-port/pika_port_3/master_conn.cc
+++ b/tools/pika-port/pika_port_3/master_conn.cc
@@ -275,10 +275,21 @@ bool MasterConn::ProcessBinlogData(const net::RedisCmdArgsType& argv, const Port
   if (1 < argv.size()) {
     key = argv[1];
   }
-  int ret = g_pika_port->SendRedisCommand(binlog_item.content(), key);
+
+  int ret = 0;
+  std::string command;
+  if (argv[0] == "pksetexat"){
+    command = binlog_item.content();
+    command.erase(0, 4);
+    command.replace(0, 13, "*4\r\n$5\r\nsetex");
+  } else {
+    command = binlog_item.content();
+  }
+  ret = g_pika_port->SendRedisCommand(command, key);
   if (ret != 0) {
-    LOG(WARNING) << "send redis command:" << binlog_item.ToString() << ", ret:" << ret;
+    LOG(WARNING) << "send redis command:" << command << ", ret:" << ret;
   }
 
   return true;
 }
+

--- a/tools/pika-port/pika_port_3/master_conn.cc
+++ b/tools/pika-port/pika_port_3/master_conn.cc
@@ -276,16 +276,39 @@ bool MasterConn::ProcessBinlogData(const net::RedisCmdArgsType& argv, const Port
     key = argv[1];
   }
 
-  int ret = 0;
   std::string command;
   if (argv[0] == "pksetexat"){
+    //struct timeval now;
+    std::string temp("");
+    std::string time_out("");
+    std::string time_cmd("");
+    int start;
+    int old_time_size;
+    int new_time_size;
+    int diff;
+    temp = argv[2];
+    //gettimeofday(&now, NULL);
+    unsigned long int sec= time(NULL);
+    unsigned long int tot;
+    tot = std::stol(temp) - sec;
+    time_out = std::to_string(tot);
+    
     command = binlog_item.content();
-    command.erase(0, 4);
+    command.erase(0,4);
     command.replace(0, 13, "*4\r\n$5\r\nsetex");
+    //"*4\r\n$5\r\nsetex\r\n$48\r\n1691478611637921200018685540810_4932190141418052\r\n$10\r\n1691483848\r\n$1681\r\n(\265/\375`\332\024=4"}}
+    start = 13 + 3 + std::to_string(key.size()).size() + 2 + key.size() +3;
+    old_time_size = std::to_string(temp.size()).size() + 2 + temp.size();
+    new_time_size = std::to_string(time_out.size()).size() + 2 + time_out.size();
+    diff =  old_time_size - new_time_size;
+    command.erase(start, diff);
+    time_cmd = std::to_string(time_out.size()) + "\r\n" + time_out;
+    command.replace(start, new_time_size, time_cmd);
   } else {
     command = binlog_item.content();
   }
-  ret = g_pika_port->SendRedisCommand(command, key);
+  
+  int ret = g_pika_port->SendRedisCommand(command, key);
   if (ret != 0) {
     LOG(WARNING) << "send redis command:" << command << ", ret:" << ret;
   }


### PR DESCRIPTION
fix issue https://github.com/OpenAtomFoundation/pika/issues/1760

pksetexat 是 pika 的内部命令，这个命令的意思是在某个确定的墙面精确时间让 key 失效。

Redis 是没法解决主从情况下超时时间一致的问题的。这个一定程度上，解决了这个问题，当然前提是主从所在的物理机的物理时钟一致无错乱。
