### PR TITLE
Fixed the slow log timestamp error.

### DIFF
--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -294,7 +294,7 @@ class PikaServer : public pstd::noncopyable {
   void SlowlogReset();
   uint32_t SlowlogLen();
   void SlowlogObtain(int64_t number, std::vector<SlowlogEntry>* slowlogs);
-  void SlowlogPushEntry(const PikaCmdArgsType& argv, int32_t time, int64_t duration);
+  void SlowlogPushEntry(const PikaCmdArgsType& argv, int64_t time, int64_t duration);
 
   /*
    * Statistic used

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1149,7 +1149,7 @@ void PikaServer::SlowlogObtain(int64_t number, std::vector<SlowlogEntry>* slowlo
   }
 }
 
-void PikaServer::SlowlogPushEntry(const PikaCmdArgsType& argv, int32_t time, int64_t duration) {
+void PikaServer::SlowlogPushEntry(const PikaCmdArgsType& argv, int64_t time, int64_t duration) {
   SlowlogEntry entry;
   uint32_t slargc = (argv.size() < SLOWLOG_ENTRY_MAX_ARGC) ? argv.size() : SLOWLOG_ENTRY_MAX_ARGC;
 

--- a/tests/integration/slowlog_test.go
+++ b/tests/integration/slowlog_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+func isBetween(first, second, target int64) bool {
+	return first <= target && second >= target
+}
+
 var _ = Describe("Slowlog Commands", func() {
 	ctx := context.TODO()
 	var client *redis.Client
@@ -23,7 +27,7 @@ var _ = Describe("Slowlog Commands", func() {
 		Expect(client.Close()).NotTo(HaveOccurred())
 	})
 
-	Describe("SlowLogGet", func() {
+	Describe("SlowLog", func() {
 		It("returns slow query result", func() {
 			const key = "slowlog-log-slower-than"
 
@@ -40,5 +44,46 @@ var _ = Describe("Slowlog Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).NotTo(BeZero())
 		})
+		It("Should be able to handle the situation when the log is full correctly", func() {
+			const key1 = "slowlog-log-slower-than"
+			old := client.ConfigGet(ctx, key1).Val()
+			defer Expect(client.ConfigSet(ctx, key1, old[key1]).Err()).NotTo(HaveOccurred())
+			client.ConfigSet(ctx, key1, "0")
+
+			const key2 = "slowlog-max-len"
+			oldMaxLen := client.ConfigGet(ctx, key2).Val()
+			defer Expect(client.ConfigSet(ctx, key2, oldMaxLen[key2]).Err()).NotTo(HaveOccurred())
+			client.ConfigSet(ctx, key2, "10")
+
+			for i := 0; i < 20; i++ {
+				Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			}
+
+			result, err := client.SlowLogGet(ctx, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(result)).To(Equal(int(10)))
+		})
+		It("Make sure that the returned timestamp is correct.", func() {
+			const key1 = "slowlog-log-slower-than"
+			old := client.ConfigGet(ctx, key1).Val()
+			defer Expect(client.ConfigSet(ctx, key1, old[key1]).Err()).NotTo(HaveOccurred())
+			client.ConfigSet(ctx, key1, "0")
+			time1 := time.Now()
+			Expect(client.Do(ctx, "SLOWLOG", "reset").Val()).To(Equal("OK"))
+
+			time.Sleep(200 * time.Millisecond)
+			for i := 0; i < 15; i++ {
+				Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			}
+			result, err := client.SlowLogGet(ctx, 10).Result()
+			time.Sleep(200 * time.Millisecond)
+			time2 := time.Now()
+			Expect(err).NotTo(HaveOccurred())
+
+			for i := 0; i < 10; i++ {
+				Expect(isBetween(time1.UnixNano(), time2.UnixNano(), time.Unix(0, result[i].Time.Unix()*1e3).UnixNano())).To(Equal(true))
+			}
+		})
 	})
+
 })


### PR DESCRIPTION
issue:https://github.com/OpenAtomFoundation/pika/issues/2111
Now the local test has the correct timestamp.
![截屏2023-11-09 17 02 34](https://github.com/OpenAtomFoundation/pika/assets/56024577/49fe6852-67cd-4537-9080-2cd66123902d)
