### PR TITLE
feat: pika clusters support automatic rebalance in operater

### DIFF
--- a/tools/kubeblocks_helm/README.md
+++ b/tools/kubeblocks_helm/README.md
@@ -1,5 +1,5 @@
 
-# Install pika cluster by kubeblocks
+# Install pika cluster by kubeblocks 
 Fellow the kubeblock docs [Install kbcli](https://kubeblocks.io/docs/preview/user_docs/installation/install-kbcli)
 
 ## install kubeblocks
@@ -9,7 +9,6 @@ Fellow the kubeblock docs [kubeblocks](https://kubeblocks.io/docs/preview/user_d
 
 ### install pika CD and pika cluster 
 First, use helm install pika cluster definition and install pika cluster.
-
 ```bash
 cd ./tools/kubeblocks-helm/
 helm install pika ./pika
@@ -28,15 +27,6 @@ Then connect codis front end.
 ```
 Open browser and visit `http://localhost:8080`
 
-Then add pika instance to codis
-1. Input group id `1` and click `Add Group` button
-2. Input the following pika instance url and group id, then click `Add Server` button
-- pika-cluster-pika-0.pika-cluster-pika-headless:9221
-- pika-cluster-pika-1.pika-cluster-pika-headless:9221
- 
-3. Click `Rebalance all slots` button
-
-
 ### connect to pika cluster
 ```bash
 kubectl port-forward svc/pika-cluster-codis-proxy 19000
@@ -46,15 +36,13 @@ redis-cli -p 19000 info
 
 ## Scale pika cluster
 
-Use kbcli horizontal scale pika instance, you will get 2 new pika instances.
+### Scale out
+
+1. First, edit pika-cluster/values.yaml to increase replicaCount.
+2. Then upgrade the cluster.
 ```bash
-kbcli cluster hscale pika-cluster --replicas 4 --components pika
+helm upgrade pika-cluster ./pika-cluster
 ```
 
-Add new pika instances to codis
-1. Input group id `2` and click `Add Group` button
-2. Input the following pika instance url and group id, then click `Add Server` button
-- pika-cluster-pika-2.pika-cluster-pika-headless:9221
-- pika-cluster-pika-3.pika-cluster-pika-headless:9221
-3. Click `Rebalance all slots` button
-
+### Scale in
+scale in is not supported now.

--- a/tools/kubeblocks_helm/pika-cluster/Chart.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Pika Codis Cluster Helm chart for KubeBlocks.
 
 type: application
 
-version:  0.7.1-beta.1
+version: 0.7.1-beta.1
 
 appVersion: "3.5.1"
 

--- a/tools/kubeblocks_helm/pika-cluster/Chart.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Pika Codis Cluster Helm chart for KubeBlocks.
 
 type: application
 
-version: 0.6.0-alpha.21
+version:  0.7.1-beta.1
 
 appVersion: "3.5.1"
 

--- a/tools/kubeblocks_helm/pika-cluster/values.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/values.yaml
@@ -5,7 +5,7 @@
 nameOverride: ""
 fullnameOverride: ""
 
-replicaCount: 5
+replicaCount: 2
 
 slaveCount: 1
 

--- a/tools/kubeblocks_helm/pika-cluster/values.yaml
+++ b/tools/kubeblocks_helm/pika-cluster/values.yaml
@@ -5,7 +5,7 @@
 nameOverride: ""
 fullnameOverride: ""
 
-replicaCount: 2
+replicaCount: 5
 
 slaveCount: 1
 

--- a/tools/kubeblocks_helm/pika/Chart.yaml
+++ b/tools/kubeblocks_helm/pika/Chart.yaml
@@ -4,7 +4,7 @@ description: A Pika Codis cluster definition Helm chart for Kubernetes
 
 type: application
 
-version: 0.6.0-alpha.21
+version: 0.7.1-beta.1
 
 appVersion: "3.5.1"
 

--- a/tools/kubeblocks_helm/pika/config/pika-config.tpl
+++ b/tools/kubeblocks_helm/pika/config/pika-config.tpl
@@ -306,7 +306,7 @@ max-bytes-for-level-multiplier : 10
 # slotmigrate is mainly used to migrate slots, usually we will set it to no.
 # When you migrate slots, you need to set it to yes, and reload slotskeys before.
 # slotmigrate  [yes | no]
-slotmigrate : no
+slotmigrate : yes
 
 # BlockBasedTable block_size, default 4k
 # block-size: 4096

--- a/tools/kubeblocks_helm/pika/script/admin.sh
+++ b/tools/kubeblocks_helm/pika/script/admin.sh
@@ -42,7 +42,7 @@ wait_master_registered() {
   done
 }
 
-## 确认这个group是最大的 pika-group
+# confirm group has the max index of all groups
 confirm_max_group() {
     max_group_id=0
     for component in ${KB_CLUSTER_COMPONENT_LIST//,/ }; do

--- a/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
@@ -32,6 +32,16 @@ spec:
           namespace: {{ .Release.Namespace }}
           volumeName: script
           defaultMode: 0555
+      postStartSpec:
+        cmdExecutorConfig:
+          image: {{ include "codis.image" . }}
+          command:
+            - "/bin/bash"
+          args:
+            - "-c"
+            - "/script/admin.sh --rebalance"
+        scriptSpecSelectors:
+          - name: pika-script
       podSpec:
         containers:
           - name: pika

--- a/tools/kubeblocks_helm/pika/templates/clusterversion.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterversion.yaml
@@ -7,36 +7,36 @@ metadata:
 spec:
   clusterDefinitionRef: pika
   componentVersions:
-    - componentDefRef: pika-group
-      versionsContext:
-        containers:
-          - name: pika
-            image: {{ include "pika.image" . }}
-            imagePullPolicy: {{ include "pika.imagePullPolicy" . }}
-          - name: codis-admin
-            image: {{ include "codis.image" . }}
-            imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
-    - componentDefRef: etcd
-      versionsContext:
-        containers:
-          - name: etcd
-            image: {{ include "etcd.image" . }}
-            imagePullPolicy: {{ include "etcd.imagePullPolicy" . }}
-    - componentDefRef: codis-proxy
-      versionsContext:
-        containers:
-          - name: codis-proxy
-            image: {{ include "codis.image" . }}
-            imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
-    - componentDefRef: codis-fe
-      versionsContext:
-        containers:
-          - name: codis-fe
-            image: {{ include "codis.image" . }}
-            imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
-    - componentDefRef: codis-dashboard
-      versionsContext:
-        containers:
-          - name: codis-dashboard
-            image: {{ include "codis.image" . }}
-            imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
+  - componentDefRef: pika-group
+    versionsContext:
+      containers:
+        - name: pika
+          image: {{ include "pika.image" . }}
+          imagePullPolicy: {{ include "pika.imagePullPolicy" . }}
+        - name: codis-admin
+          image: {{ include "codis.image" . }}
+          imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
+  - componentDefRef: etcd
+    versionsContext:
+      containers:
+        - name: etcd
+          image: {{ include "etcd.image" . }}
+          imagePullPolicy: {{ include "etcd.imagePullPolicy" . }}
+  - componentDefRef: codis-proxy
+    versionsContext:
+      containers:
+        - name: codis-proxy
+          image: {{ include "codis.image" . }}
+          imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
+  - componentDefRef: codis-fe
+    versionsContext:
+      containers:
+        - name: codis-fe
+          image: {{ include "codis.image" . }}
+          imagePullPolicy: {{ include "codis.imagePullPolicy" . }}
+  - componentDefRef: codis-dashboard
+    versionsContext:
+      containers:
+        - name: codis-dashboard
+          image: {{ include "codis.image" . }}
+          imagePullPolicy: {{ include "codis.imagePullPolicy" . }}

--- a/tools/kubeblocks_helm/pika/templates/script.yaml
+++ b/tools/kubeblocks_helm/pika/templates/script.yaml
@@ -7,3 +7,4 @@ metadata:
 data:
   admin.sh: |-
     {{- .Files.Get "script/admin.sh" | nindent 4 }}
+


### PR DESCRIPTION
This PR implements automatic rebalance after pika cluster expansion. The specific verification method is as follows:

1. Upgrade or update kubeblocks to 0.7.1-beta.1
```bash
# install
kbcli kubeblocks install --version 0.7.1-beta.1

# or upgrade
kbcli kubeblocks upgrade --version 0.7.1-beta.1
```

2. Install the cluster
```bash
helm install pika ./pika && helm install pika-cluster ./pika-cluster
```

3. Verify the cluster status
```bash
kubectl port-forward svc/pika-cluster-codis-fe 8080
```
Open codis-fe at http://127.0.0.1:8080/, and you can see the cluster has automatically rebalanced.

4. Scale out
First, edit `pika-cluster/values.yaml` to increase `replicaCount`.
Then upgrade the cluster.
```bash
helm upgrade pika-cluster ./pika-cluster
```

5. Verify the cluster status
Observe the cluster status on codis-fe, and you can see the cluster rebalances again.


related issue #1906 