### PR TITLE
bugfix: rate-limiter setting the default value repeatedly

### DIFF
--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -673,9 +673,9 @@ class PikaConf : public pstd::BaseConf {
   bool pin_l0_filter_and_index_blocks_in_cache_ = false;
   bool optimize_filters_for_hits_ = false;
   bool level_compaction_dynamic_level_bytes_ = false;
-  int64_t rate_limiter_bandwidth_ = 200 * 1024 * 1024;  // 200M
-  int64_t rate_limiter_refill_period_us_ = 100 * 1000;
-  int64_t rate_limiter_fairness_ = 10;
+  int64_t rate_limiter_bandwidth_ = 0;
+  int64_t rate_limiter_refill_period_us_ = 0;
+  int64_t rate_limiter_fairness_ = 0;
   bool rate_limiter_auto_tuned_ = true;
 
   std::atomic<int> sync_window_size_;


### PR DESCRIPTION
rate-limiter相关参数会在类声明时和Load()函数两个地方设置初值。如果两个地方设置的默认值不同，Load()中设置的值就不会生效。所以考虑在类声明中设置一个无效值，有效的默认值统一在load函数中设置。