### PR TITLE
refactor:use method instead of friend in txn

### DIFF
--- a/include/pika_db.h
+++ b/include/pika_db.h
@@ -22,9 +22,6 @@ class DB : public std::enable_shared_from_this<DB>, public pstd::noncopyable {
   friend class InfoCmd;
   friend class PkClusterInfoCmd;
   friend class PikaServer;
-  friend class ExecCmd;
-  friend class FlushdbCmd;
-  friend class FlushallCmd;
 
   std::string GetDBName();
   void BgSaveDB();
@@ -36,6 +33,21 @@ class DB : public std::enable_shared_from_this<DB>, public pstd::noncopyable {
   bool IsBinlogIoError();
   uint32_t SlotNum();
   void GetAllSlots(std::set<uint32_t>& slot_ids);
+  std::shared_mutex& GetSlotLock() {
+    return slots_rw_;
+  }
+  void SlotLock() {
+    slots_rw_.lock();
+  }
+  void SlotLockShared() {
+    slots_rw_.lock_shared();
+  }
+  void SlotUnlock() {
+    slots_rw_.unlock();
+  }
+  void SlotUnlockShared() {
+    slots_rw_.unlock_shared();
+  }
 
   // Dynamic change slot
   pstd::Status AddSlots(const std::set<uint32_t>& slot_ids);

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -177,9 +177,6 @@ class PikaReplicaManager {
   ~PikaReplicaManager() = default;
 
   friend Cmd;
-  friend class FlushdbCmd;
-  friend class FlushallCmd;
-  friend class ExecCmd;
 
   void Start();
   void Stop();
@@ -252,6 +249,27 @@ class PikaReplicaManager {
 
   void ReplServerRemoveClientConn(int fd);
   void ReplServerUpdateClientConnMap(const std::string& ip_port, int fd);
+
+  std::shared_mutex& GetSlotLock() { return slots_rw_; }
+  void SlotLock() {
+    slots_rw_.lock();
+  }
+  void SlotLockShared() {
+    slots_rw_.lock_shared();
+  }
+  void SlotUnlock() {
+    slots_rw_.unlock();
+  }
+  void SlotUnlockShared() {
+    slots_rw_.unlock_shared();
+  }
+
+  std::unordered_map<SlotInfo, std::shared_ptr<SyncMasterSlot>, hash_slot_info>& GetSyncMasterSlots() {
+    return sync_master_slots_;
+  }
+  std::unordered_map<SlotInfo, std::shared_ptr<SyncSlaveSlot>, hash_slot_info>& GetSyncSlaveSlots() {
+    return sync_slave_slots_;
+  }
 
  private:
   void InitSlot();

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -181,6 +181,21 @@ class PikaServer : public pstd::noncopyable {
   bool IsDBSlotExist(const std::string& db_name, uint32_t slot_id);
   bool IsDBBinlogIoError(const std::string& db_name);
   pstd::Status DoSameThingSpecificDB(const TaskType& type, const std::set<std::string>& dbs = {});
+  std::shared_mutex& GetDBLock() {
+    return dbs_rw_;
+  }
+  void DBLockShared() {
+    dbs_rw_.lock_shared();
+  }
+  void DBLock() {
+    dbs_rw_.lock();
+  }
+  void DBUnlock() {
+    dbs_rw_.unlock();
+  }
+  void DBUnlockShared() {
+    dbs_rw_.unlock_shared();
+  }
 
   /*
    * Slot use
@@ -508,8 +523,6 @@ class PikaServer : public pstd::noncopyable {
   friend class InfoCmd;
   friend class PikaReplClientConn;
   friend class PkClusterInfoCmd;
-  friend class FlushallCmd;
-  friend class ExecCmd;
 
  private:
   /*

--- a/src/pika_transaction.cc
+++ b/src/pika_transaction.cc
@@ -137,12 +137,12 @@ bool ExecCmd::IsTxnFailedAndSetState() {
 }
 
 void ExecCmd::Lock() {
-  g_pika_server->dbs_rw_.lock_shared();
+  g_pika_server->DBLockShared();
   std::for_each(lock_db_.begin(), lock_db_.end(), [](auto& need_lock_db) {
-    need_lock_db->slots_rw_.lock();
+    need_lock_db->SlotLock();
   });
   if (is_lock_rm_slots_) {
-    g_pika_rm->slots_rw_.lock();
+    g_pika_rm->SlotLock();
   }
 
   std::for_each(r_lock_slots_.begin(), r_lock_slots_.end(), [this](auto& need_lock_slot) {
@@ -163,12 +163,12 @@ void ExecCmd::Unlock() {
     need_lock_slot->DbRWUnLock();
   });
   if (is_lock_rm_slots_) {
-    g_pika_rm->slots_rw_.unlock();
+    g_pika_rm->SlotUnlock();
   }
   std::for_each(lock_db_.begin(), lock_db_.end(), [](auto& need_lock_db) {
-    need_lock_db->slots_rw_.unlock();
+    need_lock_db->SlotUnlock();
   });
-  g_pika_server->dbs_rw_.unlock_shared();
+  g_pika_server->DBUnlockShared();
 }
 
 void ExecCmd::SetCmdsVec() {


### PR DESCRIPTION
Instead of using friend, use encapsulated methods to access members in a class.