### PR TITLE
fix: delete old sst files when re-downloading sst files in full synchronization

### DIFF
--- a/include/rsync_client.h
+++ b/include/rsync_client.h
@@ -33,6 +33,7 @@ extern std::unique_ptr<PikaConf> g_pika_conf;
 
 const std::string kDumpMetaFileName = "DUMP_META_DATA";
 const std::string kUuidPrefix = "snapshot-uuid:";
+const size_t kInvalidOffset = 0xFFFFFFFF;
 
 namespace rsync {
 
@@ -42,8 +43,7 @@ class WaitObject;
 class WaitObjectManager;
 
 using pstd::Status;
-
-
+using ResponseSPtr = std::shared_ptr<RsyncService::RsyncResponse>;
 class RsyncClient : public net::Thread {
  public:
   enum State {
@@ -151,18 +151,18 @@ public:
 
   void Reset(const std::string& filename, RsyncService::Type t, size_t offset) {
     std::lock_guard<std::mutex> guard(mu_);
-    resp_ = nullptr;
+    resp_.reset();
     filename_ = filename;
     type_ = t;
     offset_ = offset;
   }
 
-  pstd::Status Wait(RsyncService::RsyncResponse*& resp) {
+  pstd::Status Wait(ResponseSPtr& resp) {
     pstd::Status s = Status::Timeout("rsync timeout", "timeout");
     {
       std::unique_lock<std::mutex> lock(mu_);
       auto cv_s = cond_.wait_for(lock, std::chrono::seconds(1), [this] {
-          return resp_ != nullptr;
+          return resp_.get() != nullptr;
       });
       if (!cv_s) {
         return s;
@@ -175,19 +175,19 @@ public:
 
   void WakeUp(RsyncService::RsyncResponse* resp) {
     std::unique_lock<std::mutex> lock(mu_);
-    resp_ = resp;
+    resp_.reset(resp);
+    offset_ = kInvalidOffset;
     cond_.notify_all();
   }
 
-  RsyncService::RsyncResponse* Response() {return resp_;}
   std::string Filename() {return filename_;}
   RsyncService::Type Type() {return type_;}
   size_t Offset() {return offset_;}
 private:
   std::string filename_;
   RsyncService::Type type_;
-  size_t offset_ = 0xFFFFFFFF;
-  RsyncService::RsyncResponse* resp_ = nullptr;
+  size_t offset_ = kInvalidOffset;
+  ResponseSPtr resp_ = nullptr;
   std::condition_variable cond_;
   std::mutex mu_;
 };
@@ -222,7 +222,8 @@ public:
       return;
     }
     if (resp->type() == RsyncService::kRsyncFile &&
-        (resp->file_resp().filename() != wo_vec_[index]->Filename())) {
+        ((resp->file_resp().filename() != wo_vec_[index]->Filename()) ||
+	 (resp->file_resp().offset() != wo_vec_[index]->Offset()))) {
       delete resp;
       return;
     }

--- a/src/rsync_server.cc
+++ b/src/rsync_server.cc
@@ -48,13 +48,15 @@ int RsyncServer::Start() {
   LOG(INFO) << "start RsyncServer ...";
   int res = rsync_server_thread_->StartThread();
   if (res != net::kSuccess) {
-    LOG(FATAL) << "Start rsync Server Thread Error: " << res;
+    LOG(FATAL) << "Start rsync Server Thread Error. ret_code: " << res << " message: "
+               << (res == net::kBindError ? ": bind port conflict" : ": other error");
   }
   res = work_thread_->start_thread_pool();
   if (res != net::kSuccess) {
-    LOG(FATAL) << "Start ThreadPool Error: " << res
+    LOG(FATAL) << "Start rsync Server ThreadPool Error, ret_code: " << res << " message: "
                << (res == net::kCreateThreadError ? ": create thread error " : ": other error");
   }
+  LOG(INFO) << "RsyncServer started ...";
   return res;
 }
 


### PR DESCRIPTION
When RsyncClient(https://github.com/OpenAtomFoundation/pika/blob/unstable/src/rsync_client.cc) downloads a sst file in a master-slave replication, if the request times out more than the set number of times, it will retry downloading the entire file. Currently, the path used to delete temporary files is incorrect, resulting in deletion failure. When re-downloading, the old file is actually appended, which ultimately leads to an sst file mismatch with the manifest and a RocksDBiine open failure.

Chinese：

rsync主从复制下载sst文件时，如果请求超时超过设定的次数，会重试下载整个文件。目前的实现中删除临时文件时的路径不对，所以导致删除失败，重新下载的时候实际是在追加写老的文件，最终导致sst文件与manifest不匹配，rocksdb打开失败。