### PR TITLE
fix:use info replication get master ip and port

### DIFF
--- a/codis/pkg/topom/topom_stats.go
+++ b/codis/pkg/topom/topom_stats.go
@@ -66,7 +66,7 @@ func (s *Topom) RefreshRedisStats(timeout time.Duration) (*sync2.Future, error) 
 	for _, g := range ctx.group {
 		for _, x := range g.Servers {
 			goStats(x.Addr, func(addr string) (*RedisStats, error) {
-				m, err := s.stats.redisp.InfoFull(addr)
+				m, err := s.stats.redisp.InfoFullv2(addr)
 				if err != nil {
 					return nil, err
 				}

--- a/codis/pkg/utils/redis/client.go
+++ b/codis/pkg/utils/redis/client.go
@@ -255,6 +255,32 @@ func (c *Client) InfoReplication() (*InfoReplication, error) {
 }
 
 func (c *Client) InfoFull() (map[string]string, error) {
+	if info, err := c.Info(); err != nil {
+		return nil, errors.Trace(err)
+	} else {
+		host := info["master_host"]
+		port := info["master_port"]
+		if host != "" || port != "" {
+			info["master_addr"] = net.JoinHostPort(host, port)
+		}
+		r, err := c.Do("CONFIG", "GET", "maxmemory")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		p, err := redigo.Values(r, nil)
+		if err != nil || len(p) != 2 {
+			return nil, errors.Errorf("invalid response = %v", r)
+		}
+		v, err := redigo.Int(p[1], nil)
+		if err != nil {
+			return nil, errors.Errorf("invalid response = %v", r)
+		}
+		info["maxmemory"] = strconv.Itoa(v)
+		return info, nil
+	}
+}
+
+func (c *Client) InfoFullv2() (map[string]string, error) {
 	if info, err := c.InfoReplicationIpPort(); err != nil {
 		return nil, errors.Trace(err)
 	} else {
@@ -525,6 +551,15 @@ func (p *Pool) InfoFull(addr string) (_ map[string]string, err error) {
 	}
 	defer p.PutClient(c)
 	return c.InfoFull()
+}
+
+func (p *Pool) InfoFullv2(addr string) (_ map[string]string, err error) {
+	c, err := p.GetClient(addr)
+	if err != nil {
+		return nil, err
+	}
+	defer p.PutClient(c)
+	return c.InfoFullv2()
 }
 
 type InfoCache struct {

--- a/codis/pkg/utils/redis/client.go
+++ b/codis/pkg/utils/redis/client.go
@@ -157,6 +157,24 @@ func (c *Client) Info() (map[string]string, error) {
 	return info, nil
 }
 
+func (c *Client) InfoReplicationIpPort() (map[string]string, error) {
+	text, err := redigo.String(c.Do("INFO", "replication"))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	info := make(map[string]string)
+	for _, line := range strings.Split(text, "\n") {
+		kv := strings.SplitN(line, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		if key := strings.TrimSpace(kv[0]); key != "" {
+			info[key] = strings.TrimSpace(kv[1])
+		}
+	}
+	return info, nil
+}
+
 func (c *Client) InfoKeySpace() (map[int]string, error) {
 	text, err := redigo.String(c.Do("INFO", "keyspace"))
 	if err != nil {
@@ -237,7 +255,7 @@ func (c *Client) InfoReplication() (*InfoReplication, error) {
 }
 
 func (c *Client) InfoFull() (map[string]string, error) {
-	if info, err := c.Info(); err != nil {
+	if info, err := c.InfoReplicationIpPort(); err != nil {
 		return nil, errors.Trace(err)
 	} else {
 		host := info["master_host"]


### PR DESCRIPTION
本PR主要修改dashboard访问pika的master_ip 和 Port部分，这里只需要用info replication去访问即可，不需要用info命令去访问，info命令获取的信息太多了，可能会导致长尾毛刺

测试结果：
下线dashboard并换包
![image](https://github.com/OpenAtomFoundation/pika/assets/64316617/a47dfbab-1c0a-498f-a1d4-37a4c8c029ef)
重启dashboard
![image](https://github.com/OpenAtomFoundation/pika/assets/64316617/cc27bd2a-d7b9-4727-9c39-44419651c339)

实例的主从信息：
![image](https://github.com/OpenAtomFoundation/pika/assets/64316617/d372473a-d3d4-4687-8f3c-c80752e1ee54)

杀掉主节点
 10.174.24.10:50003, 备节点10.173.89.204:50003升为主节点
![image](https://github.com/OpenAtomFoundation/pika/assets/64316617/0ecc7352-21f9-4b94-926c-3a5047527743)

重启老主节点并建立连接，恢复

![image](https://github.com/OpenAtomFoundation/pika/assets/64316617/b4c91cf4-a16d-4afb-acac-c3c236267782)

