### PR TITLE
fix: ZRemCmd

### DIFF
--- a/src/pika_zset.cc
+++ b/src/pika_zset.cc
@@ -685,7 +685,6 @@ void ZRemCmd::Do(std::shared_ptr<Slot> slot) {
   int32_t count = 0;
   s_ = slot->db()->ZRem(key_, members_, &count);
   if (s_.ok() || s_.IsNotFound()) {
-    AddSlotKey("z", key_, slot);
     res_.AppendInteger(count);
   } else {
     res_.SetRes(CmdRes::kErrOther, s_.ToString());


### PR DESCRIPTION
#2189 
fix ZRemCmd addslotkey bug 
把所有容器看了一遍，根据文档看了一下，发现所有容器新增的部分都具有合适的addslotkey, 只有zremcmd 那里出现了不该出现的addslotkey