### PR TITLE
fix: Slow log timestamp format is inconsistent with Redis

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -146,7 +146,7 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
 
 void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, uint64_t do_duration) {
   if (time_stat_->total_time() > g_pika_conf->slowlog_slower_than()) {
-    g_pika_server->SlowlogPushEntry(argv, time_stat_->start_ts(), time_stat_->total_time());
+    g_pika_server->SlowlogPushEntry(argv, time_stat_->start_ts() / 1000000, time_stat_->total_time());
     if (g_pika_conf->slowlog_write_errorlog()) {
       bool trim = false;
       std::string slow_log;

--- a/tests/integration/slowlog_test.go
+++ b/tests/integration/slowlog_test.go
@@ -81,7 +81,8 @@ var _ = Describe("Slowlog Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			for i := 0; i < 10; i++ {
-				Expect(isBetween(time1.UnixNano(), time2.UnixNano(), time.Unix(0, result[i].Time.Unix()*1e3).UnixNano())).To(Equal(true))
+				Expect(result[i].Time.Unix()).To(BeNumerically("~", 0, 9999999999))
+				Expect(isBetween(time1.Unix(), time2.Unix(), result[i].Time.Unix())).To(Equal(true))
 			}
 		})
 	})


### PR DESCRIPTION
fix: #2206

### go test result for slowlog: 
  ginkgo --focus-file="slowlog_test.go" -vv 
  
![image](https://github.com/OpenAtomFoundation/pika/assets/34958405/f1641c18-8ada-44a2-8a45-ef619c88fc04)

### slowlog
![image](https://github.com/OpenAtomFoundation/pika/assets/34958405/d92e04d7-869c-457c-9417-6c0654053a6f)
