### PR TITLE
fix: incorrect initialization sequence about pika role and cmdstat_map(#2235)

### DIFF
--- a/include/pika_cmd_table_manager.h
+++ b/include/pika_cmd_table_manager.h
@@ -31,6 +31,11 @@ class PikaCmdTableManager {
   bool CmdExist(const std::string& cmd) const;
   CmdTable* GetCmdTable();
 
+  /*
+  * Info Commandstats used
+  */
+  std::unordered_map<std::string, CommandStatistics>* GetCommandStatMap();
+
  private:
   std::shared_ptr<Cmd> NewCommand(const std::string& opt);
 
@@ -41,5 +46,10 @@ class PikaCmdTableManager {
 
   std::shared_mutex map_protector_;
   std::unordered_map<std::thread::id, std::unique_ptr<PikaDataDistribution>> thread_distribution_map_;
+
+  /*
+  * Info Commandstats used
+  */
+  std::unordered_map<std::string, CommandStatistics> cmdstat_map_;
 };
 #endif

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -151,10 +151,6 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return run_id_;
   }
-  std::string master_run_id() {
-    std::shared_lock l(rwlock_);
-    return master_run_id_;
-  }
   std::string replication_id() {
     std::shared_lock l(rwlock_);
     return replication_id_;
@@ -402,11 +398,6 @@ class PikaConf : public pstd::BaseConf {
     std::lock_guard l(rwlock_);
     TryPushDiffCommands("slaveof", value);
     slaveof_ = value;
-  }
-  void SetMasterRunID(const std::string& value) {
-    std::lock_guard l(rwlock_);
-    TryPushDiffCommands("master-run-id", value);
-    master_run_id_ = value;
   }
   void SetReplicationID(const std::string& value) {
     std::lock_guard l(rwlock_);
@@ -672,7 +663,6 @@ class PikaConf : public pstd::BaseConf {
   int timeout_ = 0;
   std::string server_id_;
   std::string run_id_;
-  std::string master_run_id_;
   std::string replication_id_;
   std::string requirepass_;
   std::string masterauth_;

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -167,8 +167,6 @@ class PikaServer : public pstd::noncopyable {
   int port();
   time_t start_time_s();
   std::string master_ip();
-  std::string master_run_id();
-  void set_master_run_id(const std::string& master_run_id);
   int master_port();
   int role();
   bool leader_protected_mode();
@@ -518,11 +516,6 @@ class PikaServer : public pstd::noncopyable {
    */
   storage::Status RewriteStorageOptions(const storage::OptionType& option_type,
                                         const std::unordered_map<std::string, std::string>& options);
- /*
-  * Info Commandstats used
-  */
-  std::unordered_map<std::string, CommandStatistics>* GetCommandStatMap();
-
 
  /*
   * Instantaneous Metric used
@@ -627,7 +620,6 @@ class PikaServer : public pstd::noncopyable {
    */
   std::string master_ip_;
   int master_port_ = 0;
-  std::string master_run_id_;
   int repl_state_ = PIKA_REPL_NO_CONNECT;
   int role_ = PIKA_ROLE_SINGLE;
   int last_meta_sync_timestamp_ = 0;
@@ -697,11 +689,6 @@ class PikaServer : public pstd::noncopyable {
    * Statistic used
    */
   Statistic statistic_;
-
-  /*
-  * Info Commandstats used
-  */
-  std::unordered_map<std::string, CommandStatistics> cmdstat_map_;
 
   net::BGThread common_bg_thread_;
 

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -118,7 +118,7 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   // Process Command
   c_ptr->Execute();
   time_stat_->process_done_ts_ = pstd::NowMicros();
-  auto cmdstat_map = g_pika_server->GetCommandStatMap();
+  auto cmdstat_map = g_pika_cmd_table_manager->GetCommandStatMap();
   (*cmdstat_map)[opt].cmd_count.fetch_add(1);
   (*cmdstat_map)[opt].cmd_time_consuming.fetch_add(time_stat_->total_time());
 

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -17,6 +17,15 @@ PikaCmdTableManager::PikaCmdTableManager() {
   cmds_ = std::make_unique<CmdTable>();
   cmds_->reserve(300);
   InitCmdTable(cmds_.get());
+
+  CommandStatistics statistics;
+  for (auto& iter : *cmds_) {
+    cmdstat_map_.emplace(iter.first, statistics);
+  }
+}
+
+std::unordered_map<std::string, CommandStatistics>* PikaCmdTableManager::GetCommandStatMap() {
+  return &cmdstat_map_;
 }
 
 std::shared_ptr<Cmd> PikaCmdTableManager::GetCmd(const std::string& opt) {

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -572,13 +572,7 @@ int PikaConf::Load() {
   // slaveof
   slaveof_ = "";
   GetConfStr("slaveof", &slaveof_);
-  if (slaveof_ != "") {
-    std::string master_run_id;
-    GetConfStr("master-run-id", &master_run_id);
-    if (master_run_id.length() == configRunIDSize) {
-      master_run_id_ = master_run_id;
-    }
-  }
+  
   int cache_num = 16;
   GetConfInt("cache-num", &cache_num);
   cache_num_ = (0 >= cache_num || 48 < cache_num) ? 16 : cache_num;
@@ -732,7 +726,6 @@ int PikaConf::ConfigRewrite() {
   SetConfInt("slowlog-max-len", slowlog_max_len_);
   SetConfStr("write-binlog", write_binlog_ ? "yes" : "no");
   SetConfStr("run-id", run_id_);
-  SetConfStr("master-run-id", master_run_id_);
   SetConfStr("replication-id", replication_id_);
   SetConfInt("max-cache-statistic-keys", max_cache_statistic_keys_);
   SetConfInt("small-compaction-threshold", small_compaction_threshold_);

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -93,6 +93,19 @@ PikaServer::PikaServer()
   exit_mutex_.lock();
   int64_t lastsave = GetLastSaveTime(g_pika_conf->bgsave_path());
   UpdateLastSave(lastsave);
+
+  // init role
+  std::string slaveof = g_pika_conf->slaveof();
+  if (!slaveof.empty()) {
+    auto sep = static_cast<int32_t>(slaveof.find(':'));
+    std::string master_ip = slaveof.substr(0, sep);
+    int32_t master_port = std::stoi(slaveof.substr(sep + 1));
+    if ((master_ip == "127.0.0.1" || master_ip == host_) && master_port == port_) {
+      LOG(FATAL) << "you will slaveof yourself as the config file, please check";
+    } else {
+      SetMaster(master_ip, master_port);
+    }
+  }
 }
 
 PikaServer::~PikaServer() {
@@ -180,26 +193,6 @@ void PikaServer::Start() {
   }
 
   time(&start_time_s_);
-
-  std::string master_run_id = g_pika_conf->master_run_id();
-  set_master_run_id(master_run_id);
-  std::string slaveof = g_pika_conf->slaveof();
-  if (!slaveof.empty()) {
-    auto sep = static_cast<int32_t>(slaveof.find(':'));
-    std::string master_ip = slaveof.substr(0, sep);
-    int32_t master_port = std::stoi(slaveof.substr(sep + 1));
-    if ((master_ip == "127.0.0.1" || master_ip == host_) && master_port == port_) {
-      LOG(FATAL) << "you will slaveof yourself as the config file, please check";
-    } else {
-      g_pika_server->set_master_run_id(g_pika_conf->master_run_id());
-      SetMaster(master_ip, master_port);
-    }
-  }
-  CommandStatistics statistics;
-  auto cmdstat_map = g_pika_server->GetCommandStatMap();
-  for (auto& iter : *g_pika_cmd_table_manager->GetCmdTable()) {
-    cmdstat_map->emplace(iter.first, statistics);
-  }
   LOG(INFO) << "Pika Server going to start";
   rsync_server_->Start();
   while (!exit_) {
@@ -231,16 +224,6 @@ std::string PikaServer::master_ip() {
 int PikaServer::master_port() {
   std::shared_lock l(state_protector_);
   return master_port_;
-}
-
-std::string PikaServer::master_run_id() {
-  std::shared_lock l(state_protector_);
-  return master_run_id_;
-}
-
-void PikaServer::set_master_run_id(const std::string& master_run_id) {
-  std::lock_guard l(state_protector_);
-  master_run_id_ = master_run_id;
 }
 
 int PikaServer::role() {
@@ -769,7 +752,6 @@ void PikaServer::RemoveMaster() {
 
     master_ip_ = "";
     master_port_ = -1;
-    master_run_id_ = "";
     DoSameThingEverySlot(TaskType::kResetReplState);
   }
 }
@@ -1714,10 +1696,6 @@ void PikaServer::Bgslotsreload(const std::shared_ptr<Slot>& slot) {
   // Start new thread if needed
   bgsave_thread_.StartThread();
   bgsave_thread_.Schedule(&DoBgslotsreload, static_cast<void*>(this));
-}
-
-std::unordered_map<std::string, CommandStatistics>* PikaServer::GetCommandStatMap() {
-  return &cmdstat_map_;
 }
 
 void DoBgslotsreload(void* arg) {


### PR DESCRIPTION
fix: incorrect initialization sequence about pika role and cmdstat_map(#2235)

**Modified test results：**
1. command statistics
![image](https://github.com/OpenAtomFoundation/pika/assets/21003538/b39ca1b1-dc29-458c-9eb1-0d96b0395a2a)

2. pike role
![image](https://github.com/OpenAtomFoundation/pika/assets/21003538/cac7ad8f-1418-4e83-a724-873089108591)
