### PR TITLE
fix: handle rsync response error in slave side

### DIFF
--- a/include/rsync_client.h
+++ b/include/rsync_client.h
@@ -221,6 +221,12 @@ public:
       delete resp;
       return;
     }
+    if (resp->code() != RsyncService::kOk) {
+      LOG(WARNING) << "rsync response error";
+      wo_vec_[index]->WakeUp(resp);
+      return;
+    }
+
     if (resp->type() == RsyncService::kRsyncFile &&
         ((resp->file_resp().filename() != wo_vec_[index]->Filename()) ||
 	 (resp->file_resp().offset() != wo_vec_[index]->Offset()))) {

--- a/src/rsync_client.cc
+++ b/src/rsync_client.cc
@@ -200,14 +200,13 @@ Status RsyncClient::CopyRemoteFile(const std::string& filename, int index) {
         continue;
       }
 
+      if (resp->code() != RsyncService::kOk) {
+        return Status::IOError("kRsyncFile request failed, master response error code");
+      }
+
       size_t ret_count = resp->file_resp().count();
       size_t elaspe_time_us = pstd::NowMicros() - copy_file_begin_time;
       Throttle::GetInstance().ReturnUnusedThroughput(count, ret_count, elaspe_time_us);
-
-      if (resp->code() != RsyncService::kOk) {
-        //TODO: handle different error
-        continue;
-      }
 
       if (resp->snapshot_uuid() != snapshot_uuid_) {
         LOG(WARNING) << "receive newer dump, reset state to STOP, local_snapshot_uuid:"


### PR DESCRIPTION
master节点收到slave节点拉取文件的请求之后，如果本地的dump目录被删除，会向slave节点回包，返回错误，但没有设置offset字段。
slave节点在收到回包之后，会比对offset字段，如果offset字段不匹配，会认为这是一个过期的回包丢弃掉，继续等待新的回包。这种情况下，master的错误会被被意外丢弃掉，导致请求超时。
修复方式，即在收到回包时单独处理错误的回包。