### PR TITLE
fix: treat "sinter sunion sdiff" as wrtie commands

### DIFF
--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -640,7 +640,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSRem, std::move(sremptr)));
   ////SUnionCmd
   std::unique_ptr<Cmd> sunionptr = std::make_unique<SUnionCmd>(
-      kCmdNameSUnion, -2, kCmdFlagsRead | kCmdFlagsSet | kCmdFlagsSlow);
+      kCmdNameSUnion, -2, kCmdFlagsWrite | kCmdFlagsSet | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSUnion, std::move(sunionptr)));
   ////SUnionstoreCmd
   std::unique_ptr<Cmd> sunionstoreptr =
@@ -648,7 +648,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSUnionstore, std::move(sunionstoreptr)));
   ////SInterCmd
   std::unique_ptr<Cmd> sinterptr = std::make_unique<SInterCmd>(
-      kCmdNameSInter, -2, kCmdFlagsRead | kCmdFlagsSet | kCmdFlagsSlow);
+      kCmdNameSInter, -2, kCmdFlagsWrite | kCmdFlagsSet | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSInter, std::move(sinterptr)));
   ////SInterstoreCmd
   std::unique_ptr<Cmd> sinterstoreptr =
@@ -660,7 +660,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSIsmember, std::move(sismemberptr)));
   ////SDiffCmd
   std::unique_ptr<Cmd> sdiffptr =
-      std::make_unique<SDiffCmd>(kCmdNameSDiff, -2, kCmdFlagsRead | kCmdFlagsSet | kCmdFlagsSlow);
+      std::make_unique<SDiffCmd>(kCmdNameSDiff, -2, kCmdFlagsWrite | kCmdFlagsSet | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSDiff, std::move(sdiffptr)));
   ////SDiffstoreCmd
   std::unique_ptr<Cmd> sdiffstoreptr =


### PR DESCRIPTION
#2363

Floyd 采用多 RocksDB 实例，每个 Key 可能 Hash 到不同的 RocksDB 实例，与 BlackWidow 不同的是 Floyd 下的 Key 不再以数据类型去区分 RocksDB, 即一个 RocksDB 下可能会存在不同类型的 Key，那么对于 Redis 命令中如：SInter 这种操作多个 Key 的情况下，需要重新设计下确保操作的一致性，对 BlackWidow 来说对于 Sinter 这种命令，由于所有的 Set 类型都在同一个 RocksDB 下，所以对于 SInter 这种读命令不需要进行上 key 锁，只需要在相应的 RocksDB 打一个快照然后进行操作即可，但是在 Floyd 下，多个 Key 可能存在多个 RocksDB 下，对于这种问题我们需要一种解决方式。

![image](https://github.com/OpenAtomFoundation/pika/assets/7959374/6c927480-1842-4aa5-ba62-96a7d0b25892)

经过讨论，我们总结出了三种方案解决：
1. 我们将 `sinter` 这种命令由原来的读命令设置为写命令，在 CMD 层面上 Key 锁，这样就能完美的解决 Floyd 中的多 key 问题，缺点是 `inster` 这种本来是读命令不需要进行上锁操作的会变为写命令，但是能保证数据的一致性
2. 对于 `sinter` 这种操作多 `key` 的命令，我们在 Cmd 层上写锁，然后同时在 `CMD` 层打好每个 `Key` 对应 Hash 到的 `RocksDB` 实例的快照，然后以入参的方式从 `CMD` 层一直传到 `Redis` 层，这样上锁的粒度会比较小，但是代码的改动量会特别大，会对 `CMD`， `Storage` , `Redis` 这三层的接口都需要进行修改，同时还需要对 `Floyd` 的测试也进行修改
3. 在 `Storage` 层上 `Key` 锁，和上面的 `CMD` 层上 `Key` 锁一样，少了 `CMD` 层对 `Storage` 层的 `snapshot` 入参，但是需要在 `Storage` 中所有的写命令接口中全部上 `Key`锁，这样的实现方式在 `Redis`, `CMD` ，`Storage` 层都加上了 `Key` 锁，感觉代码冗余

## 总结
这个 PR 中我们采用了第一种解决方案，这也是改动量最小，并且能解决多 `Key` 操作时的一致性问题