### PR TITLE
fix:  for auto-failover, correct master-slave replication relationship automatically after master or slave pika restarted (#2373, #2038, #1950,#1967,#2351)

### DIFF
--- a/codis/config/dashboard.toml
+++ b/codis/config/dashboard.toml
@@ -33,9 +33,10 @@ migration_async_numkeys = 500
 migration_timeout = "30s"
 
 # Set configs for redis sentinel.
-sentinel_check_server_state_interval = "5s"
-sentinel_check_master_failover_interval = "1s"
-sentinel_master_dead_check_times = 5
+sentinel_check_server_state_interval = "10s"
+sentinel_check_master_failover_interval = "2s"
+sentinel_master_dead_check_times = 10
+sentinel_check_offline_server_interval = "2s"
 sentinel_client_timeout = "10s"
 sentinel_quorum = 2
 sentinel_parallel_syncs = 1

--- a/codis/pkg/models/action.go
+++ b/codis/pkg/models/action.go
@@ -11,4 +11,7 @@ const (
 	ActionMigrating = "migrating"
 	ActionFinished  = "finished"
 	ActionSyncing   = "syncing"
+	ActionSynced    = "synced"
+
+	ActionSyncedFailed = "synced_failed"
 )

--- a/codis/pkg/models/group.go
+++ b/codis/pkg/models/group.go
@@ -25,12 +25,51 @@ func (g *Group) GetServersMap() map[string]*GroupServer {
 	return results
 }
 
+// SelectNewMaster choose a new master node in the group
+func (g *Group) SelectNewMaster() (string, int) {
+	var newMasterServer *GroupServer
+	var newMasterIndex = -1
+
+	for index, server := range g.Servers {
+		if index == 0 || server.State != GroupServerStateNormal {
+			continue
+		}
+
+		if newMasterServer == nil {
+			newMasterServer = server
+			newMasterIndex = index
+		} else if server.DbBinlogFileNum > newMasterServer.DbBinlogFileNum {
+			// Select the slave node with the latest offset as the master node
+			newMasterServer = server
+			newMasterIndex = index
+		} else if server.DbBinlogFileNum == newMasterServer.DbBinlogFileNum {
+			if server.DbBinlogOffset > newMasterServer.DbBinlogOffset {
+				newMasterServer = server
+				newMasterIndex = index
+			}
+		}
+	}
+
+	if newMasterServer == nil {
+		return "", newMasterIndex
+	}
+
+	return newMasterServer.Addr, newMasterIndex
+}
+
 type GroupServerState int8
 
 const (
 	GroupServerStateNormal GroupServerState = iota
 	GroupServerStateSubjectiveOffline
 	GroupServerStateOffline
+)
+
+type GroupServerRole string
+
+const (
+	RoleMaster GroupServerRole = "master"
+	RoleSlave  GroupServerRole = "slave"
 )
 
 type GroupServer struct {
@@ -43,9 +82,11 @@ type GroupServer struct {
 	} `json:"action"`
 
 	// master or slave
-	Role string `json:"role"`
+	Role GroupServerRole `json:"role"`
 	// If it is a master node, take the master_repl_offset field, otherwise take the slave_repl_offset field
-	ReplyOffset int `json:"reply_offset"`
+	DbBinlogFileNum uint64 `json:"binlog_file_num"` // db0
+	DbBinlogOffset  uint64 `json:"binlog_offset"`   // db0
+
 	// Monitoring status, 0 normal, 1 subjective offline, 2 actual offline
 	// If marked as 2 , no service is provided
 	State GroupServerState `json:"state"`

--- a/codis/pkg/topom/config.go
+++ b/codis/pkg/topom/config.go
@@ -50,9 +50,10 @@ migration_async_numkeys = 500
 migration_timeout = "30s"
 
 # Set configs for redis sentinel.
-sentinel_check_server_state_interval = "5s"
-sentinel_check_master_failover_interval = "1s"
-sentinel_master_dead_check_times = 5
+sentinel_check_server_state_interval = "10s"
+sentinel_check_master_failover_interval = "2s"
+sentinel_master_dead_check_times = 10
+sentinel_check_offline_server_interval = "2s"
 sentinel_client_timeout = "10s"
 sentinel_quorum = 2
 sentinel_parallel_syncs = 1
@@ -86,6 +87,7 @@ type Config struct {
 	SentinelCheckServerStateInterval    timesize.Duration `toml:"sentinel_check_server_state_interval" json:"sentinel_client_timeout"`
 	SentinelCheckMasterFailoverInterval timesize.Duration `toml:"sentinel_check_master_failover_interval" json:"sentinel_check_master_failover_interval"`
 	SentinelMasterDeadCheckTimes        int8              `toml:"sentinel_master_dead_check_times" json:"sentinel_master_dead_check_times"`
+	SentinelCheckOfflineServerInterval  timesize.Duration `toml:"sentinel_check_offline_server_interval" json:"sentinel_check_offline_server_interval"`
 	SentinelClientTimeout               timesize.Duration `toml:"sentinel_client_timeout" json:"sentinel_client_timeout"`
 	SentinelQuorum                      int               `toml:"sentinel_quorum" json:"sentinel_quorum"`
 	SentinelParallelSyncs               int               `toml:"sentinel_parallel_syncs" json:"sentinel_parallel_syncs"`

--- a/codis/pkg/topom/context.go
+++ b/codis/pkg/topom/context.go
@@ -40,7 +40,7 @@ func (ctx *context) getSlotMapping(sid int) (*models.SlotMapping, error) {
 }
 
 func (ctx *context) getSlotMappingsByGroupId(gid int) []*models.SlotMapping {
-	var slots = []*models.SlotMapping{}
+	var slots []*models.SlotMapping
 	for _, m := range ctx.slots {
 		if m.GroupId == gid || m.Action.TargetId == gid {
 			slots = append(slots, m)

--- a/codis/pkg/topom/topom_group.go
+++ b/codis/pkg/topom/topom_group.go
@@ -302,18 +302,7 @@ func (s *Topom) GroupPromoteServer(gid int, addr string) error {
 		if err := s.storeUpdateGroup(g); err != nil {
 			return err
 		}
-
-		var (
-			master = slice[0].Addr
-			client *redis.Client
-		)
-		if client, err = redis.NewClient(master, s.config.ProductAuth, time.Second); err != nil {
-			log.WarnErrorf(err, "create redis client to %s failed", master)
-		}
-		defer client.Close()
-		if err = client.SetMaster("NO:ONE"); err != nil {
-			log.WarnErrorf(err, "redis %s set master to NO:ONE failed", master)
-		}
+		_ = promoteServerToNewMaster(slice[0].Addr, s.config.ProductAuth)
 		fallthrough
 
 	case models.ActionFinished:
@@ -341,129 +330,243 @@ func (s *Topom) GroupPromoteServer(gid int, addr string) error {
 	}
 }
 
-func (s *Topom) trySwitchGroupMaster(gid int, cache *redis.InfoCache) error {
-	ctx, err := s.newContext()
-	if err != nil {
-		return err
-	}
-	g, err := ctx.getGroup(gid)
-	if err != nil {
-		return err
-	}
-
-	master := s.selectNextMaster(g.Servers)
-
-	if master == "" {
-		servers, _ := json.Marshal(g)
-		log.Errorf("group %d donn't has any slaves to switch master, %s", gid, servers)
-		return errors.Errorf("cann't switch slave to master")
-	}
-
-	return s.doSwitchGroupMaster(gid, master, cache)
-}
-
-// Choose to change to the next master node in the group
-func (s *Topom) selectNextMaster(servers []*models.GroupServer) string {
-	if len(servers) == 0 {
-		return ""
-	}
-
-	var masterServer *models.GroupServer
-
-	for _, server := range servers {
-		if server.State != models.GroupServerStateNormal {
+func (s *Topom) tryFixReplicationRelationships(ctx *context, recoveredGroupServers []*redis.ReplicationState) {
+	for _, state := range recoveredGroupServers {
+		log.Infof("group-[%d] try to fix server[%v-%v] replication relationship", state.GroupID, state.Index, state.Addr)
+		group, err := ctx.getGroup(state.GroupID)
+		if err != nil {
+			log.Error(err)
 			continue
 		}
 
-		// If there is already a master node in the group working normally, return directly
-		if server.Role == "master" {
-			return server.Addr
+		group.OutOfSync = true
+		err = s.storeUpdateGroup(group)
+		if err != nil {
+			s.dirtyGroupCache(group.Id)
+			continue
 		}
 
-		if masterServer == nil {
-			masterServer = server
-		} else if server.ReplyOffset > masterServer.ReplyOffset {
-			// Select the slave node with the latest offset as the master node
-			masterServer = server
+		err = s.tryFixReplicationRelationship(group, state.Server, state)
+		if err != nil {
+			log.Warnf("group-[%d] fix server[%v] replication relationship failed, err: %v", group.Id, state.Addr, err)
+			continue
+		}
+
+		// Notify all servers to update slot information
+		slots := ctx.getSlotMappingsByGroupId(group.Id)
+		if err = s.resyncSlotMappings(ctx, slots...); err != nil {
+			log.Warnf("group-[%d] notify all proxy failed, %v", group.Id, err)
+			continue
+		} else {
+			group.OutOfSync = false
+			_ = s.storeUpdateGroup(group)
+			s.dirtyGroupCache(group.Id)
 		}
 	}
-
-	if masterServer == nil {
-		return ""
-	}
-
-	return masterServer.Addr
 }
 
-func (s *Topom) doSwitchGroupMaster(gid int, master string, cache *redis.InfoCache) error {
-	ctx, err := s.newContext()
-	if err != nil {
-		return err
-	}
-	g, err := ctx.getGroup(gid)
-	if err != nil {
-		return err
+// tryFixReplicationRelationship
+//
+// master or slave have already recovered service, fix its master-slave replication relationship.
+// only fix which the old state of GroupServer is GroupServerStateOffline.
+// It will only update the state of GroupServer to GroupServerStateNormal, If the GroupServer have right
+// master-slave replication relationship.
+func (s *Topom) tryFixReplicationRelationship(group *models.Group, groupServer *models.GroupServer, state *redis.ReplicationState) (err error) {
+	curMasterAddr := group.Servers[0].Addr
+	if isGroupMaster(state, group) {
+		// current server is master,
+		if models.GroupServerRole(state.Replication.Role) == models.RoleMaster {
+			return nil
+		}
+
+		// execute the command `slaveof no one`
+		if err = promoteServerToNewMaster(state.Addr, s.config.ProductAuth); err != nil {
+			return err
+		}
+	} else {
+		// skip if it has right replication relationship
+		if state.Replication.GetMasterAddr() == curMasterAddr {
+			return nil
+		}
+
+		// current server is slave, execute the command `slaveof [new master ip] [new master port]`
+		if err = updateMasterToNewOne(groupServer.Addr, curMasterAddr, s.config.ProductAuth); err != nil {
+			return err
+		}
 	}
 
-	var index = func() int {
-		for i, x := range g.Servers {
-			if x.Addr == master {
-				return i
-			}
+	groupServer.State = models.GroupServerStateNormal
+	groupServer.ReCallTimes = 0
+	groupServer.ReplicaGroup = true
+	groupServer.Role = models.GroupServerRole(state.Replication.Role)
+	groupServer.DbBinlogFileNum = state.Replication.DbBinlogFileNum
+	groupServer.DbBinlogOffset = state.Replication.DbBinlogOffset
+	groupServer.Action.State = models.ActionSynced
+	err = s.storeUpdateGroup(group)
+	// clean cache whether err is nil or not
+	s.dirtyGroupCache(group.Id)
+	return err
+}
+
+func isGroupMaster(state *redis.ReplicationState, g *models.Group) bool {
+	return state.Index == 0 && g.Servers[0].Addr == state.Addr
+}
+
+func (s *Topom) updateSlaveOfflineGroups(ctx *context, offlineGroups []*models.Group) {
+	for _, group := range offlineGroups {
+		log.Infof("group-[%d] update slave offline state", group.Id)
+		group.OutOfSync = true
+		err := s.storeUpdateGroup(group)
+		if err != nil {
+			s.dirtyGroupCache(group.Id)
+			continue
 		}
-		for i, x := range g.Servers {
-			rid1 := cache.GetRunId(master)
-			rid2 := cache.GetRunId(x.Addr)
-			if rid1 != "" && rid1 == rid2 {
-				return i
-			}
+
+		// Notify all servers to update slot information
+		slots := ctx.getSlotMappingsByGroupId(group.Id)
+		if err := s.resyncSlotMappings(ctx, slots...); err != nil {
+			log.Warnf("group-[%d] notify all proxy failed, %v", group.Id, err)
+			continue
 		}
-		return -1
-	}()
-	if index == -1 {
-		return errors.Errorf("group-[%d] doesn't have server %s with runid = '%s'", g.Id, master, cache.GetRunId(master))
 	}
-	if index == 0 {
+}
+
+// trySwitchGroupsToNewMaster
+//
+// the master have already been offline, and it will select and switch to a new master from the Group
+func (s *Topom) trySwitchGroupsToNewMaster(ctx *context, masterOfflineGroups []*models.Group) {
+	for _, group := range masterOfflineGroups {
+		log.Infof("group-[%d] try to switch new master", group.Id)
+		group.OutOfSync = true
+		err := s.storeUpdateGroup(group)
+		if err != nil {
+			s.dirtyGroupCache(group.Id)
+			continue
+		}
+
+		// try to switch to new master
+		if err := s.trySwitchGroupMaster(group); err != nil {
+			log.Errorf("group-[%d] switch master failed, %v", group.Id, err)
+			continue
+		}
+
+		// Notify all servers to update slot information
+		slots := ctx.getSlotMappingsByGroupId(group.Id)
+		if err := s.resyncSlotMappings(ctx, slots...); err != nil {
+			log.Warnf("group-[%d] notify all proxy failed, %v", group.Id, err)
+			continue
+		} else {
+			group.OutOfSync = false
+			_ = s.storeUpdateGroup(group)
+			s.dirtyGroupCache(group.Id)
+		}
+	}
+}
+
+func (s *Topom) trySwitchGroupMaster(group *models.Group) error {
+	newMasterAddr, newMasterIndex := group.SelectNewMaster()
+	if newMasterAddr == "" {
+		servers, _ := json.Marshal(group)
+		log.Errorf("group %d don't has any slaves to switch master, %s", group.Id, servers)
+		return errors.Errorf("can't switch slave to master")
+	}
+
+	// TODO liuchengyu check new master is available
+	//available := isAvailableAsNewMaster(masterServer, s.Config())
+	//if !available {
+	//	return ""
+	//}
+
+	return s.doSwitchGroupMaster(group, newMasterAddr, newMasterIndex)
+}
+
+func isAvailableAsNewMaster(groupServer *models.GroupServer, conf *Config) bool {
+	rc, err := redis.NewClient(groupServer.Addr, conf.ProductAuth, 500*time.Millisecond)
+	if err != nil {
+		log.Warnf("connect GroupServer[%v] failed!, error:%v", groupServer.Addr, err)
+		return false
+	}
+	defer rc.Close()
+
+	info, err := rc.InfoReplication()
+	if err != nil {
+		log.Warnf("get InfoReplication from GroupServer[%v] failed!, error:%v", groupServer.Addr, err)
+		return false
+	}
+
+	if info.MasterLinkStatus == "down" {
+		// down state means the slave does not finished full sync from master
+		log.Warnf("the master_link_status of GroupServer[%v] is down state. it cannot be selected as master", groupServer.Addr)
+		return false
+	}
+
+	return true
+}
+
+func (s *Topom) doSwitchGroupMaster(g *models.Group, newMasterAddr string, newMasterIndex int) (err error) {
+	if newMasterIndex <= 0 || newMasterAddr == "" {
 		return nil
 	}
-	defer s.dirtyGroupCache(g.Id)
 
-	log.Warnf("group-[%d] will switch master to server[%d] = %s", g.Id, index, g.Servers[index].Addr)
-
+	log.Warnf("group-[%d] will switch master to server[%d] = %s", g.Id, newMasterIndex, newMasterAddr)
 	// Set the slave node as the new master node
-	var client *redis.Client
-	if client, err = redis.NewClient(master, s.config.ProductAuth, 100*time.Millisecond); err != nil {
-		log.WarnErrorf(err, "create redis client to %s failed", master)
-		return err
+	if err = promoteServerToNewMaster(newMasterAddr, s.config.ProductAuth); err != nil {
+		return errors.Errorf("promote server[%v] to new master failed, err:%v", newMasterAddr, err)
 	}
 
-	defer client.Close()
-	if err = client.SetMaster("NO:ONE"); err != nil {
-		log.WarnErrorf(err, "redis %s set master to NO:ONE failed", master)
-		return err
-	}
+	g.Servers[newMasterIndex].Role = models.RoleMaster
+	g.Servers[newMasterIndex].Action.State = models.ActionSynced
+	g.Servers[0], g.Servers[newMasterIndex] = g.Servers[newMasterIndex], g.Servers[0]
+	defer func() {
+		err = s.storeUpdateGroup(g)
+		// clean cache whether err is nil or not
+		s.dirtyGroupCache(g.Id)
+	}()
 
 	// Set other nodes in the group as slave nodes of the new master node
 	for _, server := range g.Servers {
-		if server.State != models.GroupServerStateNormal || server.Addr == master {
+		if server.State != models.GroupServerStateNormal || server.Addr == newMasterAddr {
 			continue
 		}
-		var client2 *redis.Client
-		if client2, err = redis.NewClient(server.Addr, s.config.ProductAuth, 100*time.Millisecond); err != nil {
-			log.WarnErrorf(err, "create redis client to %s failed", master)
-			return err
-		}
-		defer client2.Close()
-		if err = client2.SetMaster(master); err != nil {
-			log.WarnErrorf(err, "redis %s set master to %s failed", server.Addr, master)
-			return err
+
+		err = updateMasterToNewOne(server.Addr, newMasterAddr, s.config.ProductAuth)
+		if err != nil {
+			// skip err, and retry to update master-slave replication relationship through next heartbeat check
+			err = nil
+			server.Action.State = models.ActionSyncedFailed
+			server.State = models.GroupServerStateOffline
+			log.Warnf("group-[%d] update server[%d] replication relationship failed, new master: %s", g.Id, newMasterIndex, newMasterAddr)
+		} else {
+			server.Action.State = models.ActionSynced
+			server.Role = models.RoleSlave
 		}
 	}
 
-	g.Servers[0], g.Servers[index] = g.Servers[index], g.Servers[0]
-	g.Servers[0].Role = "master"
-	g.OutOfSync = true
-	return s.storeUpdateGroup(g)
+	return err
+}
+
+func updateMasterToNewOne(serverAddr, masterAddr string, auth string) (err error) {
+	return setNewRedisMaster(serverAddr, masterAddr, auth, false)
+}
+
+func promoteServerToNewMaster(serverAddr, auth string) (err error) {
+	return setNewRedisMaster(serverAddr, "NO:ONE", auth, false)
+}
+
+func updateMasterToNewOneForcefully(serverAddr, masterAddr string, auth string) (err error) {
+	return setNewRedisMaster(serverAddr, masterAddr, auth, true)
+}
+
+func setNewRedisMaster(serverAddr, masterAddr string, auth string, force bool) (err error) {
+	var rc *redis.Client
+	if rc, err = redis.NewClient(serverAddr, auth, 500*time.Millisecond); err != nil {
+		return errors.Errorf("create redis client to %s failed, err:%v", serverAddr, err)
+	}
+	defer rc.Close()
+	if err = rc.SetMaster(masterAddr, force); err != nil {
+		return errors.Errorf("server[%s] set master to %s failed, force:%v err:%v", serverAddr, masterAddr, force, err)
+	}
+	return err
 }
 
 func (s *Topom) EnableReplicaGroups(gid int, addr string, value bool) error {
@@ -640,11 +743,14 @@ func (s *Topom) SyncActionComplete(addr string, failed bool) error {
 
 	var state string
 	if !failed {
-		state = "synced"
+		state = models.ActionSynced
 	} else {
-		state = "synced_failed"
+		state = models.ActionSyncedFailed
 	}
 	g.Servers[index].Action.State = state
+	// check whether the master is offline through heartbeat, if so, select a new master
+	g.Servers[index].State = models.GroupServerStateOffline
+
 	return s.storeUpdateGroup(g)
 }
 
@@ -665,21 +771,16 @@ func (s *Topom) newSyncActionExecutor(addr string) (func() error, error) {
 		return nil, nil
 	}
 
-	var master = "NO:ONE"
+	var masterAddr string
 	if index != 0 {
-		master = g.Servers[0].Addr
+		masterAddr = g.Servers[0].Addr
 	}
+
 	return func() error {
-		c, err := redis.NewClient(addr, s.config.ProductAuth, time.Minute*30)
-		if err != nil {
-			log.WarnErrorf(err, "create redis client to %s failed", addr)
-			return err
+		if index != 0 {
+			return updateMasterToNewOne(addr, masterAddr, s.config.ProductAuth)
+		} else {
+			return promoteServerToNewMaster(addr, s.config.ProductAuth)
 		}
-		defer c.Close()
-		if err := c.SetMaster(master); err != nil {
-			log.WarnErrorf(err, "redis %s set master to %s failed", addr, master)
-			return err
-		}
-		return nil
 	}, nil
 }

--- a/codis/pkg/topom/topom_sentinel.go
+++ b/codis/pkg/topom/topom_sentinel.go
@@ -4,14 +4,11 @@
 package topom
 
 import (
-	"time"
-
 	"pika/codis/v2/pkg/models"
-	"pika/codis/v2/pkg/utils/log"
 	"pika/codis/v2/pkg/utils/redis"
 )
 
-func (s *Topom) CheckAndSwitchSlavesAndMasters(filter func(index int, g *models.GroupServer) bool) error {
+func (s *Topom) CheckStateAndSwitchSlavesAndMasters(filter func(index int, g *models.GroupServer) bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	ctx, err := s.newContext()
@@ -19,110 +16,114 @@ func (s *Topom) CheckAndSwitchSlavesAndMasters(filter func(index int, g *models.
 		return err
 	}
 
-	config := &redis.MonitorConfig{
-		Quorum:               s.config.SentinelQuorum,
-		ParallelSyncs:        s.config.SentinelParallelSyncs,
-		DownAfter:            s.config.SentinelDownAfter.Duration(),
-		FailoverTimeout:      s.config.SentinelFailoverTimeout.Duration(),
-		NotificationScript:   s.config.SentinelNotificationScript,
-		ClientReconfigScript: s.config.SentinelClientReconfigScript,
-	}
-
-	sentinel := redis.NewCodisSentinel(s.config.ProductName, s.config.ProductAuth)
-	gs := make(map[int][]*models.GroupServer)
-	for gid, servers := range ctx.getGroupServers() {
-		for i, server := range servers {
-			if filter(i, server) {
-				if val, ok := gs[gid]; ok {
-					gs[gid] = append(val, server)
-				} else {
-					gs[gid] = []*models.GroupServer{server}
-				}
-			}
-		}
-	}
-	if len(gs) == 0 {
+	groupServers := filterGroupServer(ctx.getGroupServers(), filter)
+	if len(groupServers) == 0 {
 		return nil
 	}
 
-	states := sentinel.RefreshMastersAndSlavesClient(config.ParallelSyncs, gs)
-
-	var pending []*models.Group
-
+	states := checkGroupServersReplicationState(s.Config(), groupServers)
+	var slaveOfflineGroups []*models.Group
+	var masterOfflineGroups []*models.Group
+	var recoveredGroupServersState []*redis.ReplicationState
+	var group *models.Group
 	for _, state := range states {
-		var g *models.Group
-		if g, err = ctx.getGroup(state.GroupID); err != nil {
+		group, err = ctx.getGroup(state.GroupID)
+		if err != nil {
 			return err
 		}
 
-		serversMap := g.GetServersMap()
-		if len(serversMap) == 0 {
-			continue
-		}
-
-		// It was the master node before, the master node hangs up, and it is currently the master node
-		if state.Index == 0 && state.Err != nil && g.Servers[0].Addr == state.Addr {
-			if g.Servers[0].State == models.GroupServerStateNormal {
-				g.Servers[0].State = models.GroupServerStateSubjectiveOffline
-			} else {
-				// update retries
-				g.Servers[0].ReCallTimes++
-
-				// Retry more than config times, start election
-				if g.Servers[0].ReCallTimes >= s.Config().SentinelMasterDeadCheckTimes {
-					// Mark enters objective offline state
-					g.Servers[0].State = models.GroupServerStateOffline
-					g.Servers[0].ReplicaGroup = false
-				}
-				// Start the election master node
-				if g.Servers[0].State == models.GroupServerStateOffline {
-					pending = append(pending, g)
-				}
-			}
-		}
-
-		// Update the offset information of the state and role nodes
-		if val, ok := serversMap[state.Addr]; ok {
-			if state.Err != nil {
-				if val.State == models.GroupServerStateNormal {
-					val.State = models.GroupServerStateSubjectiveOffline
-				}
-				continue
-			}
-
-			val.State = models.GroupServerStateNormal
-			val.ReCallTimes = 0
-			val.Role = state.Replication.Role
-			if val.Role == "master" {
-				val.ReplyOffset = state.Replication.MasterReplOffset
-			} else {
-				val.ReplyOffset = state.Replication.SlaveReplOffset
-			}
-		}
+		s.checkAndUpdateGroupServerState(s.Config(), group, state.Server, state, &slaveOfflineGroups,
+			&masterOfflineGroups, &recoveredGroupServersState)
 	}
 
-	if len(pending) == 0 {
-		return nil
+	if len(slaveOfflineGroups) > 0 {
+		// slave has been offline, and update state
+		s.updateSlaveOfflineGroups(ctx, slaveOfflineGroups)
 	}
 
-	cache := &redis.InfoCache{
-		Auth: s.config.ProductAuth, Timeout: time.Millisecond * 100,
+	if len(masterOfflineGroups) > 0 {
+		// old master offline already, auto switch to new master
+		s.trySwitchGroupsToNewMaster(ctx, masterOfflineGroups)
 	}
-	// Try to switch master slave
-	for _, g := range pending {
-		if err = s.trySwitchGroupMaster(g.Id, cache); err != nil {
-			log.Errorf("gid-[%d] switch master failed, %v", g.Id, err)
-			continue
-		}
 
-		slots := ctx.getSlotMappingsByGroupId(g.Id)
-		// Notify all servers to update slot information
-		if err = s.resyncSlotMappings(ctx, slots...); err != nil {
-			log.Warnf("group-[%d] resync-rollback to preparing", g.Id)
-			continue
-		}
-		s.dirtyGroupCache(g.Id)
+	if len(recoveredGroupServersState) > 0 {
+		// offline GroupServer's service has recovered, check and fix it's master-slave replication relationship
+		s.tryFixReplicationRelationships(ctx, recoveredGroupServersState)
 	}
 
 	return nil
+}
+
+func (s *Topom) checkAndUpdateGroupServerState(conf *Config, group *models.Group, groupServer *models.GroupServer,
+	state *redis.ReplicationState, slaveOfflineGroups *[]*models.Group, masterOfflineGroups *[]*models.Group,
+	recoveredGroupServers *[]*redis.ReplicationState) {
+	if state.Err != nil {
+		if groupServer.State == models.GroupServerStateNormal {
+			// pre offline
+			groupServer.State = models.GroupServerStateSubjectiveOffline
+		} else {
+			// update retries
+			groupServer.ReCallTimes++
+
+			// Retry more than config times, start election
+			if groupServer.ReCallTimes >= conf.SentinelMasterDeadCheckTimes {
+				// Mark enters objective offline state
+				groupServer.State = models.GroupServerStateOffline
+				groupServer.Action.State = models.ActionNothing
+				groupServer.ReplicaGroup = false
+			}
+
+			// Start the election master node
+			if groupServer.State == models.GroupServerStateOffline && isGroupMaster(state, group) {
+				*masterOfflineGroups = append(*masterOfflineGroups, group)
+			} else {
+				*slaveOfflineGroups = append(*slaveOfflineGroups, group)
+			}
+		}
+	} else {
+		if groupServer.State == models.GroupServerStateOffline {
+			*recoveredGroupServers = append(*recoveredGroupServers, state)
+			// update GroupServer to GroupServerStateNormal state later
+		} else {
+			// Update the offset information of the state and role nodes
+			groupServer.State = models.GroupServerStateNormal
+			groupServer.ReCallTimes = 0
+			groupServer.ReplicaGroup = true
+			groupServer.Role = models.GroupServerRole(state.Replication.Role)
+			groupServer.DbBinlogFileNum = state.Replication.DbBinlogFileNum
+			groupServer.DbBinlogOffset = state.Replication.DbBinlogOffset
+			groupServer.Action.State = models.ActionSynced
+		}
+	}
+}
+
+func checkGroupServersReplicationState(conf *Config, gs map[int][]*models.GroupServer) []*redis.ReplicationState {
+	config := &redis.MonitorConfig{
+		Quorum:               conf.SentinelQuorum,
+		ParallelSyncs:        conf.SentinelParallelSyncs,
+		DownAfter:            conf.SentinelDownAfter.Duration(),
+		FailoverTimeout:      conf.SentinelFailoverTimeout.Duration(),
+		NotificationScript:   conf.SentinelNotificationScript,
+		ClientReconfigScript: conf.SentinelClientReconfigScript,
+	}
+
+	sentinel := redis.NewCodisSentinel(conf.ProductName, conf.ProductAuth)
+	return sentinel.RefreshMastersAndSlavesClient(config.ParallelSyncs, gs)
+}
+
+func filterGroupServer(groupServers map[int][]*models.GroupServer,
+	filter func(index int, gs *models.GroupServer) bool) map[int][]*models.GroupServer {
+	filteredGroupServers := make(map[int][]*models.GroupServer)
+	for gid, servers := range groupServers {
+		for i, server := range servers {
+			if filter(i, server) {
+				if val, ok := filteredGroupServers[gid]; ok {
+					filteredGroupServers[gid] = append(val, server)
+				} else {
+					filteredGroupServers[gid] = []*models.GroupServer{server}
+				}
+			}
+		}
+	}
+	return filteredGroupServers
 }

--- a/codis/pkg/topom/topom_stats.go
+++ b/codis/pkg/topom/topom_stats.go
@@ -167,7 +167,7 @@ func (s *Topom) newMastersAndSlavesStats(timeout time.Duration, filter func(inde
 
 	go func() {
 		defer close(ch)
-		err := s.CheckAndSwitchSlavesAndMasters(filter)
+		err := s.CheckStateAndSwitchSlavesAndMasters(filter)
 		if err != nil {
 			log.Errorf("refresh masters and slaves failed, %v", err)
 			stats.Error = err
@@ -189,19 +189,31 @@ func (s *Topom) CheckMastersAndSlavesState(timeout time.Duration) (*sync.WaitGro
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go s.newMastersAndSlavesStats(timeout, func(index int, g *models.GroupServer) bool {
-		return index != 0 || g.State == models.GroupServerStateNormal
+		return g.State == models.GroupServerStateNormal
 	}, wg)
 	return wg, nil
 }
 
-func (s *Topom) CheckPreOffineMastersState(timeout time.Duration) (*sync.WaitGroup, error) {
+func (s *Topom) CheckPreOfflineMastersState(timeout time.Duration) (*sync.WaitGroup, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go s.newMastersAndSlavesStats(timeout, func(index int, g *models.GroupServer) bool {
-		return index == 0 && g.State != models.GroupServerStateNormal
+		return g.State == models.GroupServerStateSubjectiveOffline
+	}, wg)
+	return wg, nil
+}
+
+func (s *Topom) CheckOfflineMastersAndSlavesState(timeout time.Duration) (*sync.WaitGroup, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go s.newMastersAndSlavesStats(timeout, func(index int, g *models.GroupServer) bool {
+		return g.State == models.GroupServerStateOffline
 	}, wg)
 	return wg, nil
 }

--- a/codis/pkg/utils/redis/codis_sentinel.go
+++ b/codis/pkg/utils/redis/codis_sentinel.go
@@ -108,6 +108,7 @@ func (s *CodisSentinel) RefreshMastersAndSlavesClient(parallel int, groupServers
 					Index:       index,
 					GroupID:     gid,
 					Addr:        server.Addr,
+					Server:      server,
 					Replication: info,
 					Err:         err,
 				}


### PR DESCRIPTION
fix: automatic fix master-slave replication relationship after master or slave service restarted (#2373, #2038, #1950,#1967,#2351)

the design proposal: https://github.com/OpenAtomFoundation/pika/discussions/2367