### PR TITLE
fix: The role displayed on the first Server in the Group area of the codis-fe is incorrect (#2350)

### DIFF
--- a/codis/cmd/fe/assets/index.html
+++ b/codis/cmd/fe/assets/index.html
@@ -538,7 +538,10 @@
                             </span>
                         </td>
                         <td>
-                            <a ng-href="http://[[codis_addr]]/api/topom/group/info/[[server.server]]" target="_blank" class="btn btn-default btn-xs active" role="button">S</a>
+                            <span ng-switch="$index">
+                                <a ng-switch-when="0" ng-href="http://[[codis_addr]]/api/topom/group/info/[[server.server]]" target="_blank" class="btn btn-default btn-xs active" role="button">Master</a>
+                                <a ng-switch-default ng-href="http://[[codis_addr]]/api/topom/group/info/[[server.server]]" target="_blank" class="btn btn-default btn-xs active" role="button">Slave</a>
+                            </span>
                             <span ng-switch="server.ha_status">
                                 <span ng-switch-when="ha_master" style="color: darkgreen"
                                     data-toggle="tooltip" data-placement="right" title="HA: MASTER">


### PR DESCRIPTION
fix: The role displayed on the first Server in the Group area of the codis-fe is incorrect (#2350 )  