### PR TITLE
feat: let pika slave support Redis transaction

### DIFF
--- a/include/pika_dispatch_thread.h
+++ b/include/pika_dispatch_thread.h
@@ -23,6 +23,7 @@ class PikaDispatchThread {
   void SetQueueLimit(int queue_limit) { thread_rep_->SetQueueLimit(queue_limit); }
 
   void UnAuthUserAndKillClient(const std::set<std::string> &users, const std::shared_ptr<User>& defaultUser);
+  net::ServerThread* server_thread() { return thread_rep_; }
 
  private:
   class ClientConnFactory : public net::ConnFactory {

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -105,6 +105,9 @@ class PikaServer : public pstd::noncopyable {
   void SetForceFullSync(bool v);
   void SetDispatchQueueLimit(int queue_limit);
   storage::StorageOptions storage_options();
+  std::unique_ptr<PikaDispatchThread>& pika_dispatch_thread() {
+    return pika_dispatch_thread_;
+  }
 
   /*
    * DB use

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -114,6 +114,11 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   }
 
   if (IsInTxn() && opt != kCmdNameExec && opt != kCmdNameWatch && opt != kCmdNameDiscard && opt != kCmdNameMulti) {
+    if (c_ptr->is_write() && g_pika_server->readonly(current_db_)) {
+      SetTxnInitFailState(true);
+      c_ptr->res().SetRes(CmdRes::kErrOther, "READONLY You can't write against a read only replica.");
+      return c_ptr;
+    }
     PushCmdToQue(c_ptr);
     c_ptr->res().SetRes(CmdRes::kTxnQueued);
     return c_ptr;
@@ -158,8 +163,8 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
       c_ptr->res().SetRes(CmdRes::kErrOther, "Internal ERROR");
       return c_ptr;
     }
-    if (g_pika_server->readonly(current_db_)) {
-      c_ptr->res().SetRes(CmdRes::kErrOther, "Server in read-only");
+    if (g_pika_server->readonly(current_db_) && opt != kCmdNameExec) {
+      c_ptr->res().SetRes(CmdRes::kErrOther, "READONLY You can't write against a read only replica.");
       return c_ptr;
     }
   } else if (c_ptr->is_read() && c_ptr->flag_ == 0) {

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -238,6 +238,24 @@ void PikaReplBgWorker::HandleBGWorkerWriteDB(void* arg) {
   if (!c_ptr->IsSuspend()) {
     c_ptr->GetDB()->DBUnlockShared();
   }
+
+  if (c_ptr->res().ok()
+      && c_ptr->is_write()
+      && c_ptr->name() != kCmdNameFlushdb
+      && c_ptr->name() != kCmdNameFlushall
+      && c_ptr->name() != kCmdNameExec) {
+    auto table_keys = c_ptr->current_key();
+    for (auto& key : table_keys) {
+      key = c_ptr->db_name().append(key);
+    }
+    auto dispatcher = dynamic_cast<net::DispatchThread*>(g_pika_server->pika_dispatch_thread()->server_thread());
+    auto involved_conns = dispatcher->GetInvolvedTxn(table_keys);
+    for (auto& conn : involved_conns) {
+      auto c = std::dynamic_pointer_cast<PikaClientConn>(conn);
+      c->SetTxnWatchFailState(true);
+    }
+  }
+
   record_lock.Unlock(c_ptr->current_key());
   if (g_pika_conf->slowlog_slower_than() >= 0) {
     auto start_time = static_cast<int32_t>(start_us / 1000000);

--- a/src/pika_transaction.cc
+++ b/src/pika_transaction.cc
@@ -25,7 +25,7 @@ void MultiCmd::Do() {
     return;
   }
   if (client_conn->IsInTxn()) {
-    res_.SetRes(CmdRes::kErrOther, "ERR MULTI calls can not be nested");
+    res_.SetRes(CmdRes::kErrOther, "MULTI calls can not be nested");
     return;
   }
   client_conn->SetTxnStartState(true);
@@ -93,7 +93,7 @@ void ExecCmd::Execute() {
     return;
   }
   if (!client_conn->IsInTxn()) {
-    res_.SetRes(CmdRes::kErrOther, "ERR EXEC without MULTI");
+    res_.SetRes(CmdRes::kErrOther, "EXEC without MULTI");
     return;
   }
   if (IsTxnFailedAndSetState()) {
@@ -238,7 +238,7 @@ void WatchCmd::Do() {
     return;
   }
   if (client_conn->IsInTxn()) {
-    res_.SetRes(CmdRes::CmdRet::kErrOther, "ERR WATCH inside MULTI is not allowed");
+    res_.SetRes(CmdRes::CmdRet::kErrOther, "WATCH inside MULTI is not allowed");
     return;
   }
   client_conn->AddKeysToWatch(db_keys_);
@@ -301,7 +301,7 @@ void DiscardCmd::Do() {
     return;
   }
   if (!client_conn->IsInTxn()) {
-    res_.SetRes(CmdRes::kErrOther, "ERR DISCARD without MULTI");
+    res_.SetRes(CmdRes::kErrOther, "DISCARD without MULTI");
     return;
   }
   client_conn->ExitTxn();


### PR DESCRIPTION
修复 issuse：https://github.com/OpenAtomFoundation/pika/issues/2422

另外，测试发现 pika slave 执行 watch 后，与 redis 预期也不同。

- redis slave上执行 watch 的测试结果
```
127.0.0.1:6378> get a
"a"
127.0.0.1:6378> watch a
OK
127.0.0.1:6378> multi
OK
127.0.0.1:6378> get a
QUEUED
127.0.0.1:6378> get b
QUEUED
127.0.0.1:6378> exec
(nil)
```

- pika slave 上执行 watch 的测试结果
```
127.0.0.1:9222> get a
"ddd"
127.0.0.1:9222> watch a
OK
127.0.0.1:9222> multi
OK
127.0.0.1:9222> get a
QUEUED
127.0.0.1:9222> get b
QUEUED
127.0.0.1:9222> exec
1) "ddds"
2) (nil)

```

目前推测是主从复制时没有调用 `SetTxnFailedFromKeys` 导致，需要确认下这个问题是否需要在此pr一同修复？