### PR TITLE
fix: linux arm64 spelling mistake in Makefile of pika_exporter(#2456)

### DIFF
--- a/tools/pika_exporter/Makefile
+++ b/tools/pika_exporter/Makefile
@@ -67,7 +67,7 @@ build: deps
 ifeq ($(OS), Linux)
 ifeq ($(ARCH), x86_64)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/$(PROJNAME)
-else ifeq ($(ARCH), arm6411)
+else ifeq ($(ARCH), arm64)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/$(PROJNAME)
 endif
 else ifeq ($(OS), Darwin)


### PR DESCRIPTION
fix: linux arm64 spelling mistake in Makefile of pika_exporter(#2456)