### PR TITLE
fix: support removing pika instance from codis dashboard before pod stop

### DIFF
--- a/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
@@ -70,6 +70,13 @@ spec:
             args:
               - "-c"
               - "/script/admin.sh --register-server;tail -f /dev/null"
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                    - "/bin/bash"
+                    - "-c"
+                    - "/script/admin.sh --remove-server"
     - name: etcd
       workloadType: Stateful
       characterType: etcd


### PR DESCRIPTION
fix: support removing pika instance from codis dashboard before pod stop

issue https://github.com/OpenAtomFoundation/pika/issues/1906

问题 7 P0

pika-group 缩容时，可以正常减少 pika 实例，但是 codis-fe 页面仍然显示该 pika 实例，需要在缩容时，调用 codis-dashboard 接口，删除该实例