### PR TITLE
fix: support saving pika config to hostpath

### DIFF
--- a/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
+++ b/tools/kubeblocks_helm/pika/templates/clusterdefinition.yaml
@@ -46,6 +46,20 @@ spec:
         scriptSpecSelectors:
           - name: pika-script
       podSpec:
+        initContainers:
+          - name: init-config
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                if [ ! -f "/data/pika.conf" ];then cp /etc/pika/pika.conf /data/pika.conf; fi
+            volumeMounts:
+              - name: config
+                mountPath: /etc/pika
+              - name: data
+                mountPath: /data
         containers:
           - name: pika
             ports:
@@ -60,7 +74,7 @@ spec:
               - "/pika/bin/pika"
             args:
               - "-c"
-              - "/etc/pika/pika.conf"
+              - "/data/pika.conf"
           - name: codis-admin
             volumeMounts:
               - name: script


### PR DESCRIPTION
fix: support saving pika config to hostpath

issue https://github.com/OpenAtomFoundation/pika/issues/1906

问题 4 P0

pika 配置文件只是写在容器内部，如果容器发生重启，pika 配置文件如果发生过更改，那更改的配置将会丢失