### PR TITLE
fix:slotsrestore

### DIFF
--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -78,6 +78,7 @@ const std::string kCmdNameSlotsMgrtSlotAsync = "slotsmgrtslot-async";
 const std::string kCmdNameSlotsMgrtExecWrapper = "slotsmgrt-exec-wrapper";
 const std::string kCmdNameSlotsMgrtAsyncStatus = "slotsmgrt-async-status";
 const std::string kCmdNameSlotsMgrtAsyncCancel = "slotsmgrt-async-cancel";
+const std::string kCmdNameSlotsrestore = "slotsrestore";
 
 // Kv
 const std::string kCmdNameSet = "set";

--- a/include/pika_slot_command.h
+++ b/include/pika_slot_command.h
@@ -4,6 +4,7 @@
 #include "include/pika_client_conn.h"
 #include "include/pika_command.h"
 #include "net/include/net_cli.h"
+#include "utils/include/pika_redis.h"
 #include "net/include/net_thread.h"
 #include "storage/storage.h"
 #include "strings.h"
@@ -267,5 +268,27 @@ class SlotsCleanupOffCmd : public Cmd {
  private:
   void DoInitial() override;
 };
+
+
+////slotsrestore key ttl(ms) value(rdb)
+struct RestoreKey {
+  std::string key;
+  int64_t ttlms;
+  std::string value;
+};
+
+class SlotsrestoreCmd : public Cmd {
+ public:
+  SlotsrestoreCmd(const std::string& name, int arity, uint32_t flag) : Cmd(name, arity, flag) {}
+  void Do() override;
+  void Split(const HintKeys& hint_keys) override {};
+  void Merge() override {};
+  Cmd* Clone() override { return new SlotsrestoreCmd(*this); }
+
+ private:
+  void DoInitial() override;
+  std::vector<struct RestoreKey> restore_keys_;
+};
+
 
 #endif

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -237,6 +237,11 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(
       std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSlotsCleanupOff, std::move(slotscleanupoffptr)));
 
+  std::unique_ptr<Cmd> slotsrestoreptr =
+      std::make_unique<SlotsrestoreCmd>(kCmdNameSlotsrestore, -4, kCmdFlagsRead | kCmdFlagsAdmin | kCmdFlagsSlow);
+  cmd_table->insert(
+      std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSlotsrestore, std::move(slotsrestoreptr)));
+
   // Kv
   ////SetCmd
   std::unique_ptr<Cmd> setptr =

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required (VERSION 3.18)
+
+set (CMAKE_CXX_STANDARD 17)
+project (utils)
+
+aux_source_directory(./src  DIR_SRCS)
+include_directories(include)
+add_library(utils STATIC ${DIR_SRCS})
+add_dependencies(cache net protobuf glog gflags rediscache utils ${LIBUNWIND_NAME})
+
+target_link_libraries(utils
+        PUBLIC ${GTEST_LIBRARY}
+        PUBLIC pstd
+        PUBLIC ${ROCKSDB_LIBRARY}
+        PUBLIC storage
+        PUBLIC ${GLOG_LIBRARY}
+        PUBLIC ${GFLAGS_LIBRARY}
+        PUBLIC ${LIBUNWIND_LIBRARY}
+        PUBLIC ${REDISCACHE_LIBRARY}
+)

--- a/src/utils/include/pika_lzf.h
+++ b/src/utils/include/pika_lzf.h
@@ -1,0 +1,131 @@
+#ifndef PIKA_LZF_h
+#define PIKA_LZF_h
+
+#define STANDALONE 1 /* at the moment, this is ok. */
+
+#ifndef STANDALONE
+//# include "lzf.h"
+#endif
+
+/*
+ * Size of hashtable is (1 << HLOG) * sizeof (char *)
+ * decompression is independent of the hash table size
+ * the difference between 15 and 14 is very small
+ * for small blocks (and 14 is usually a bit faster).
+ * For a low-memory/faster configuration, use HLOG == 13;
+ * For best compression, use 15 or 16 (or more, up to 23).
+ */
+#ifndef HLOG
+# define HLOG 16
+#endif
+
+/*
+ * Sacrifice very little compression quality in favour of compression speed.
+ * This gives almost the same compression as the default code, and is
+ * (very roughly) 15% faster. This is the preferred mode of operation.
+ */
+#ifndef VERY_FAST
+# define VERY_FAST 1
+#endif
+
+/*
+ * Sacrifice some more compression quality in favour of compression speed.
+ * (roughly 1-2% worse compression for large blocks and
+ * 9-10% for small, redundant, blocks and >>20% better speed in both cases)
+ * In short: when in need for speed, enable this for binary data,
+ * possibly disable this for text data.
+ */
+#ifndef ULTRA_FAST
+# define ULTRA_FAST 0
+#endif
+
+/*
+ * Unconditionally aligning does not cost very much, so do it if unsure
+ */
+#ifndef STRICT_ALIGN
+# define STRICT_ALIGN !(defined(__i386) || defined (__amd64))
+#endif
+
+/*
+ * You may choose to pre-set the hash table (might be faster on some
+ * modern cpus and large (>>64k) blocks, and also makes compression
+ * deterministic/repeatable when the configuration otherwise is the same).
+ */
+#ifndef INIT_HTAB
+# define INIT_HTAB 0
+#endif
+
+/*
+ * Avoid assigning values to errno variable? for some embedding purposes
+ * (linux kernel for example), this is necessary. NOTE: this breaks
+ * the documentation in lzf.h.
+ */
+#ifndef AVOID_ERRNO
+# define AVOID_ERRNO 0
+#endif
+
+/*
+ * Whether to pass the LZF_STATE variable as argument, or allocate it
+ * on the stack. For small-stack environments, define this to 1.
+ * NOTE: this breaks the prototype in lzf.h.
+ */
+#ifndef LZF_STATE_ARG
+# define LZF_STATE_ARG 0
+#endif
+
+/*
+ * Whether to add extra checks for input validity in lzf_decompress
+ * and return EINVAL if the input stream has been corrupted. This
+ * only shields against overflowing the input buffer and will not
+ * detect most corrupted streams.
+ * This check is not normally noticeable on modern hardware
+ * (<1% slowdown), but might slow down older cpus considerably.
+ */
+#ifndef CHECK_INPUT
+# define CHECK_INPUT 1
+#endif
+
+/*****************************************************************************/
+/* nothing should be changed below */
+
+typedef unsigned char u8;
+
+typedef const u8 *LZF_STATE[1 << (HLOG)];
+
+#if !STRICT_ALIGN
+/* for unaligned accesses we need a 16 bit datatype. */
+# include <limits.h>
+# if USHRT_MAX == 65535
+    typedef unsigned short u16;
+# elif UINT_MAX == 65535
+    typedef unsigned int u16;
+# else
+#  undef STRICT_ALIGN
+#  define STRICT_ALIGN 1
+# endif
+#endif
+
+#if ULTRA_FAST
+# if defined(VERY_FAST)
+#  undef VERY_FAST
+# endif
+#endif
+
+#if INIT_HTAB
+# ifdef __cplusplus
+#  include <cstring>
+# else
+#  include <string.h>
+# endif
+#endif
+
+
+
+#define LZF_VERSION 0x0105 /* 1.5, API version */
+    
+unsigned int lzf_decompress (const void *const in_data,  unsigned int in_len,
+                void *out_data, unsigned int out_len);
+
+
+#endif
+

--- a/src/utils/include/pika_redis.h
+++ b/src/utils/include/pika_redis.h
@@ -1,0 +1,140 @@
+#ifndef PIKA_REDIS_H_
+#define PIKA_REDIS_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+//#include <stdint.h>
+#include <arpa/inet.h>
+#include <inttypes.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include "pika_ziplist.h"
+#include "utils/include/pika_lzf.h"
+#include "storage/include/storage/storage.h"
+
+/* Error codes */
+#define REDIS_OK                0
+#define REDIS_ERR               -1
+
+/* The current RDB version. When the format changes in a way that is no longer
+ * backward compatible this number gets incremented. */
+#define REDIS_RDB_VERSION 6
+
+/* Dup object types to RDB object types. Only reason is readability (are we
+ * dealing with RDB types or with in-memory object types?). */
+#define REDIS_RDB_TYPE_STRING 0
+#define REDIS_RDB_TYPE_LIST   1
+#define REDIS_RDB_TYPE_SET    2
+#define REDIS_RDB_TYPE_ZSET   3
+#define REDIS_RDB_TYPE_HASH   4
+
+/* Object types for encoded objects. */
+#define REDIS_RDB_TYPE_HASH_ZIPMAP    9
+#define REDIS_RDB_TYPE_LIST_ZIPLIST  10
+#define REDIS_RDB_TYPE_SET_INTSET    11
+#define REDIS_RDB_TYPE_ZSET_ZIPLIST  12
+#define REDIS_RDB_TYPE_HASH_ZIPLIST  13
+#define REDIS_RDB_TYPE_LIST_QUICKLIST 14
+
+#define REDIS_RDB_6BITLEN 0
+#define REDIS_RDB_14BITLEN 1
+#define REDIS_RDB_32BITLEN 2
+#define REDIS_RDB_ENCVAL 3
+#define REDIS_RDB_LENERR UINT_MAX
+
+#define REDIS_RDB_ENC_INT8 0        /* 8 bit signed integer */
+#define REDIS_RDB_ENC_INT16 1       /* 16 bit signed integer */
+#define REDIS_RDB_ENC_INT32 2       /* 32 bit signed integer */
+#define REDIS_RDB_ENC_LZF 3         /* string compressed with FASTLZ */
+
+/* Test if a type is an object type. */
+#define rdbIsObjectType(t) ((t >= 0 && t <= 4) || (t >= 9 && t <= 14))
+
+struct _rio {
+  /* Backend functions.
+   * Since this functions do not tolerate short writes or reads the return
+   * value is simplified to: zero on error, non zero on complete success. */
+  size_t (*read)(struct _rio *, void *buf, size_t len);
+
+  /* The update_cksum method if not NULL is used to compute the checksum of
+   * all the data that was read or written so far. The method should be
+   * designed so that can be called with the current checksum, and the buf
+   * and len fields pointing to the new block of data to add to the checksum
+   * computation. */
+  void (*update_cksum)(struct _rio *, const void *buf, size_t len);
+
+  /* The current checksum */
+  uint64_t cksum;
+
+  /* number of bytes read or written */
+  size_t processed_bytes;
+
+  /* maximum single read or write chunk size */
+  size_t max_processing_chunk;
+
+  /* Backend-specific vars. */
+  union {
+    /* In-memory buffer target. */
+    struct {
+      const char *ptr;
+      off_t pos;
+      size_t len;
+    } buffer;
+    /* Stdio file pointer target. */
+    struct {
+      FILE *fp;
+      off_t buffered; /* Bytes written since last fsync. */
+      off_t autosync; /* fsync after 'autosync' bytes written. */
+    } file;
+    /* Multiple FDs target (used to write to N sockets). */
+    struct {
+      int *fds;       /* File descriptors. */
+      int *state;     /* Error state of each fd. 0 (if ok) or errno. */
+      int numfds;
+      off_t pos;
+      char *buf;
+    } fdset;
+  } io;
+};
+typedef struct _rio rio;
+
+struct _restore_value{
+  storage::DataType type;
+
+  std::string kvv;
+  std::vector<storage::FieldValue> hashv;
+  std::vector<std::string> listv;
+  std::vector<storage::ScoreMember> zsetv;
+  std::vector<std::string> setv;
+};
+typedef struct _restore_value restore_value;
+
+size_t rioBufferRead(rio *r, void *buf, size_t len);
+
+void rioInitWithBuffer(rio *r, const char *s, size_t len);
+int rdbLoadObjectType(rio *rdb);
+
+uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
+
+int verifyDumpPayload(unsigned char *p, size_t len);
+int rdbLoadObject(int rdbtype, rio *rdb, restore_value *dbvalue);
+uint32_t rdbLoadLen(rio *rdb, int *isencoded);
+
+int rdbLoadDoubleValue(rio *rdb, double *val);
+
+int rdbLoadIntegerObject(rio *rdb, int enctype, std::string *str);
+int rdbLoadLzfStringObject(rio *rdb, std::string *str);
+int rdbLoadStringObject(rio *rdb, std::string *str);
+
+int getZsetFromZiplist(const std::string &aux, restore_value *dbvalue);
+int getListFromZiplist(const std::string &aux, restore_value *dbvalue);
+int getHashFromZiplist(const std::string &aux, restore_value *dbvalue);
+int getSetFromIntset(const std::string &aux, restore_value *dbvalue);
+
+int zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
+int zzlGetString(unsigned char *sptr, std::string *value);
+int zzlGetScore(unsigned char *sptr, double *score);
+
+
+#endif

--- a/src/utils/include/pika_ziplist.h
+++ b/src/utils/include/pika_ziplist.h
@@ -1,0 +1,21 @@
+#ifndef PIKA_ZIPLIST_h
+#define PIKA_ZIPLIST_h
+
+#define ZIPLIST_HEAD 0
+#define ZIPLIST_TAIL 1
+
+unsigned char *ziplistNew(void);
+unsigned char *ziplistPush(unsigned char *zl, unsigned char *s, unsigned int slen, int where);
+unsigned char *ziplistIndex(unsigned char *zl, int index);
+unsigned char *ziplistNext(unsigned char *zl, unsigned char *p);
+unsigned char *ziplistPrev(unsigned char *zl, unsigned char *p);
+unsigned int ziplistGet(unsigned char *p, unsigned char **sval, unsigned int *slen, long long *lval);
+unsigned char *ziplistInsert(unsigned char *zl, unsigned char *p, unsigned char *s, unsigned int slen);
+unsigned char *ziplistDelete(unsigned char *zl, unsigned char **p);
+unsigned char *ziplistDeleteRange(unsigned char *zl, unsigned int index, unsigned int num);
+unsigned int ziplistCompare(unsigned char *p, unsigned char *s, unsigned int slen);
+unsigned char *ziplistFind(unsigned char *p, unsigned char *vstr, unsigned int vlen, unsigned int skip);
+unsigned int ziplistLen(unsigned char *zl);
+//size_t ziplistBlobLen(unsigned char *zl);
+
+#endif

--- a/src/utils/src/pika_lzf.cc
+++ b/src/utils/src/pika_lzf.cc
@@ -1,0 +1,114 @@
+#include "utils/include/pika_lzf.h"
+
+#if AVOID_ERRNO
+# define SET_ERRNO(n)
+#else
+# include <errno.h>
+# define SET_ERRNO(n) errno = (n)
+#endif
+
+/*
+#if (__i386 || __amd64) && __GNUC__ >= 3
+# define lzf_movsb(dst, src, len)                \
+   asm ("rep movsb"                              \
+        : "=D" (dst), "=S" (src), "=c" (len)     \
+        :  "0" (dst),  "1" (src),  "2" (len));
+#endif
+*/
+
+unsigned int
+lzf_decompress (const void *const in_data,  unsigned int in_len,
+                void             *out_data, unsigned int out_len)
+{
+  u8 const *ip = (const u8 *)in_data;
+  u8       *op = (u8 *)out_data;
+  u8 const *const in_end  = ip + in_len;
+  u8       *const out_end = op + out_len;
+
+  do
+    {
+      unsigned int ctrl = *ip++;
+
+      if (ctrl < (1 << 5)) /* literal run */
+        {
+          ctrl++;
+
+          if (op + ctrl > out_end)
+            {
+              SET_ERRNO (E2BIG);
+              return 0;
+            }
+
+#if CHECK_INPUT
+          if (ip + ctrl > in_end)
+            {
+              SET_ERRNO (EINVAL);
+              return 0;
+            }
+#endif
+
+#ifdef lzf_movsb
+          lzf_movsb (op, ip, ctrl);
+#else
+          do
+            *op++ = *ip++;
+          while (--ctrl);
+#endif
+        }
+      else /* back reference */
+        {
+          unsigned int len = ctrl >> 5;
+
+          u8 *ref = op - ((ctrl & 0x1f) << 8) - 1;
+
+#if CHECK_INPUT
+          if (ip >= in_end)
+            {
+              SET_ERRNO (EINVAL);
+              return 0;
+            }
+#endif
+          if (len == 7)
+            {
+              len += *ip++;
+#if CHECK_INPUT
+              if (ip >= in_end)
+                {
+                  SET_ERRNO (EINVAL);
+                  return 0;
+                }
+#endif
+            }
+
+          ref -= *ip++;
+
+          if (op + len + 2 > out_end)
+            {
+              SET_ERRNO (E2BIG);
+              return 0;
+            }
+
+          if (ref < (u8 *)out_data)
+            {
+              SET_ERRNO (EINVAL);
+              return 0;
+            }
+
+#ifdef lzf_movsb
+          len += 2;
+          lzf_movsb (op, ref, len);
+#else
+          *op++ = *ref++;
+          *op++ = *ref++;
+
+          do
+            *op++ = *ref++;
+          while (--len);
+#endif
+        }
+    }
+  while (ip < in_end);
+
+  return op - (u8 *)out_data;
+}
+

--- a/src/utils/src/pika_redis.cc
+++ b/src/utils/src/pika_redis.cc
@@ -1,0 +1,761 @@
+#include "utils/include/pika_redis.h"
+#include "glog/logging.h"
+
+static const uint64_t crc64_tab[256] = {
+    UINT64_C(0x0000000000000000), UINT64_C(0x7ad870c830358979),
+    UINT64_C(0xf5b0e190606b12f2), UINT64_C(0x8f689158505e9b8b),
+    UINT64_C(0xc038e5739841b68f), UINT64_C(0xbae095bba8743ff6),
+    UINT64_C(0x358804e3f82aa47d), UINT64_C(0x4f50742bc81f2d04),
+    UINT64_C(0xab28ecb46814fe75), UINT64_C(0xd1f09c7c5821770c),
+    UINT64_C(0x5e980d24087fec87), UINT64_C(0x24407dec384a65fe),
+    UINT64_C(0x6b1009c7f05548fa), UINT64_C(0x11c8790fc060c183),
+    UINT64_C(0x9ea0e857903e5a08), UINT64_C(0xe478989fa00bd371),
+    UINT64_C(0x7d08ff3b88be6f81), UINT64_C(0x07d08ff3b88be6f8),
+    UINT64_C(0x88b81eabe8d57d73), UINT64_C(0xf2606e63d8e0f40a),
+    UINT64_C(0xbd301a4810ffd90e), UINT64_C(0xc7e86a8020ca5077),
+    UINT64_C(0x4880fbd87094cbfc), UINT64_C(0x32588b1040a14285),
+    UINT64_C(0xd620138fe0aa91f4), UINT64_C(0xacf86347d09f188d),
+    UINT64_C(0x2390f21f80c18306), UINT64_C(0x594882d7b0f40a7f),
+    UINT64_C(0x1618f6fc78eb277b), UINT64_C(0x6cc0863448deae02),
+    UINT64_C(0xe3a8176c18803589), UINT64_C(0x997067a428b5bcf0),
+    UINT64_C(0xfa11fe77117cdf02), UINT64_C(0x80c98ebf2149567b),
+    UINT64_C(0x0fa11fe77117cdf0), UINT64_C(0x75796f2f41224489),
+    UINT64_C(0x3a291b04893d698d), UINT64_C(0x40f16bccb908e0f4),
+    UINT64_C(0xcf99fa94e9567b7f), UINT64_C(0xb5418a5cd963f206),
+    UINT64_C(0x513912c379682177), UINT64_C(0x2be1620b495da80e),
+    UINT64_C(0xa489f35319033385), UINT64_C(0xde51839b2936bafc),
+    UINT64_C(0x9101f7b0e12997f8), UINT64_C(0xebd98778d11c1e81),
+    UINT64_C(0x64b116208142850a), UINT64_C(0x1e6966e8b1770c73),
+    UINT64_C(0x8719014c99c2b083), UINT64_C(0xfdc17184a9f739fa),
+    UINT64_C(0x72a9e0dcf9a9a271), UINT64_C(0x08719014c99c2b08),
+    UINT64_C(0x4721e43f0183060c), UINT64_C(0x3df994f731b68f75),
+    UINT64_C(0xb29105af61e814fe), UINT64_C(0xc849756751dd9d87),
+    UINT64_C(0x2c31edf8f1d64ef6), UINT64_C(0x56e99d30c1e3c78f),
+    UINT64_C(0xd9810c6891bd5c04), UINT64_C(0xa3597ca0a188d57d),
+    UINT64_C(0xec09088b6997f879), UINT64_C(0x96d1784359a27100),
+    UINT64_C(0x19b9e91b09fcea8b), UINT64_C(0x636199d339c963f2),
+    UINT64_C(0xdf7adabd7a6e2d6f), UINT64_C(0xa5a2aa754a5ba416),
+    UINT64_C(0x2aca3b2d1a053f9d), UINT64_C(0x50124be52a30b6e4),
+    UINT64_C(0x1f423fcee22f9be0), UINT64_C(0x659a4f06d21a1299),
+    UINT64_C(0xeaf2de5e82448912), UINT64_C(0x902aae96b271006b),
+    UINT64_C(0x74523609127ad31a), UINT64_C(0x0e8a46c1224f5a63),
+    UINT64_C(0x81e2d7997211c1e8), UINT64_C(0xfb3aa75142244891),
+    UINT64_C(0xb46ad37a8a3b6595), UINT64_C(0xceb2a3b2ba0eecec),
+    UINT64_C(0x41da32eaea507767), UINT64_C(0x3b024222da65fe1e),
+    UINT64_C(0xa2722586f2d042ee), UINT64_C(0xd8aa554ec2e5cb97),
+    UINT64_C(0x57c2c41692bb501c), UINT64_C(0x2d1ab4dea28ed965),
+    UINT64_C(0x624ac0f56a91f461), UINT64_C(0x1892b03d5aa47d18),
+    UINT64_C(0x97fa21650afae693), UINT64_C(0xed2251ad3acf6fea),
+    UINT64_C(0x095ac9329ac4bc9b), UINT64_C(0x7382b9faaaf135e2),
+    UINT64_C(0xfcea28a2faafae69), UINT64_C(0x8632586aca9a2710),
+    UINT64_C(0xc9622c4102850a14), UINT64_C(0xb3ba5c8932b0836d),
+    UINT64_C(0x3cd2cdd162ee18e6), UINT64_C(0x460abd1952db919f),
+    UINT64_C(0x256b24ca6b12f26d), UINT64_C(0x5fb354025b277b14),
+    UINT64_C(0xd0dbc55a0b79e09f), UINT64_C(0xaa03b5923b4c69e6),
+    UINT64_C(0xe553c1b9f35344e2), UINT64_C(0x9f8bb171c366cd9b),
+    UINT64_C(0x10e3202993385610), UINT64_C(0x6a3b50e1a30ddf69),
+    UINT64_C(0x8e43c87e03060c18), UINT64_C(0xf49bb8b633338561),
+    UINT64_C(0x7bf329ee636d1eea), UINT64_C(0x012b592653589793),
+    UINT64_C(0x4e7b2d0d9b47ba97), UINT64_C(0x34a35dc5ab7233ee),
+    UINT64_C(0xbbcbcc9dfb2ca865), UINT64_C(0xc113bc55cb19211c),
+    UINT64_C(0x5863dbf1e3ac9dec), UINT64_C(0x22bbab39d3991495),
+    UINT64_C(0xadd33a6183c78f1e), UINT64_C(0xd70b4aa9b3f20667),
+    UINT64_C(0x985b3e827bed2b63), UINT64_C(0xe2834e4a4bd8a21a),
+    UINT64_C(0x6debdf121b863991), UINT64_C(0x1733afda2bb3b0e8),
+    UINT64_C(0xf34b37458bb86399), UINT64_C(0x8993478dbb8deae0),
+    UINT64_C(0x06fbd6d5ebd3716b), UINT64_C(0x7c23a61ddbe6f812),
+    UINT64_C(0x3373d23613f9d516), UINT64_C(0x49aba2fe23cc5c6f),
+    UINT64_C(0xc6c333a67392c7e4), UINT64_C(0xbc1b436e43a74e9d),
+    UINT64_C(0x95ac9329ac4bc9b5), UINT64_C(0xef74e3e19c7e40cc),
+    UINT64_C(0x601c72b9cc20db47), UINT64_C(0x1ac40271fc15523e),
+    UINT64_C(0x5594765a340a7f3a), UINT64_C(0x2f4c0692043ff643),
+    UINT64_C(0xa02497ca54616dc8), UINT64_C(0xdafce7026454e4b1),
+    UINT64_C(0x3e847f9dc45f37c0), UINT64_C(0x445c0f55f46abeb9),
+    UINT64_C(0xcb349e0da4342532), UINT64_C(0xb1eceec59401ac4b),
+    UINT64_C(0xfebc9aee5c1e814f), UINT64_C(0x8464ea266c2b0836),
+    UINT64_C(0x0b0c7b7e3c7593bd), UINT64_C(0x71d40bb60c401ac4),
+    UINT64_C(0xe8a46c1224f5a634), UINT64_C(0x927c1cda14c02f4d),
+    UINT64_C(0x1d148d82449eb4c6), UINT64_C(0x67ccfd4a74ab3dbf),
+    UINT64_C(0x289c8961bcb410bb), UINT64_C(0x5244f9a98c8199c2),
+    UINT64_C(0xdd2c68f1dcdf0249), UINT64_C(0xa7f41839ecea8b30),
+    UINT64_C(0x438c80a64ce15841), UINT64_C(0x3954f06e7cd4d138),
+    UINT64_C(0xb63c61362c8a4ab3), UINT64_C(0xcce411fe1cbfc3ca),
+    UINT64_C(0x83b465d5d4a0eece), UINT64_C(0xf96c151de49567b7),
+    UINT64_C(0x76048445b4cbfc3c), UINT64_C(0x0cdcf48d84fe7545),
+    UINT64_C(0x6fbd6d5ebd3716b7), UINT64_C(0x15651d968d029fce),
+    UINT64_C(0x9a0d8ccedd5c0445), UINT64_C(0xe0d5fc06ed698d3c),
+    UINT64_C(0xaf85882d2576a038), UINT64_C(0xd55df8e515432941),
+    UINT64_C(0x5a3569bd451db2ca), UINT64_C(0x20ed197575283bb3),
+    UINT64_C(0xc49581ead523e8c2), UINT64_C(0xbe4df122e51661bb),
+    UINT64_C(0x3125607ab548fa30), UINT64_C(0x4bfd10b2857d7349),
+    UINT64_C(0x04ad64994d625e4d), UINT64_C(0x7e7514517d57d734),
+    UINT64_C(0xf11d85092d094cbf), UINT64_C(0x8bc5f5c11d3cc5c6),
+    UINT64_C(0x12b5926535897936), UINT64_C(0x686de2ad05bcf04f),
+    UINT64_C(0xe70573f555e26bc4), UINT64_C(0x9ddd033d65d7e2bd),
+    UINT64_C(0xd28d7716adc8cfb9), UINT64_C(0xa85507de9dfd46c0),
+    UINT64_C(0x273d9686cda3dd4b), UINT64_C(0x5de5e64efd965432),
+    UINT64_C(0xb99d7ed15d9d8743), UINT64_C(0xc3450e196da80e3a),
+    UINT64_C(0x4c2d9f413df695b1), UINT64_C(0x36f5ef890dc31cc8),
+    UINT64_C(0x79a59ba2c5dc31cc), UINT64_C(0x037deb6af5e9b8b5),
+    UINT64_C(0x8c157a32a5b7233e), UINT64_C(0xf6cd0afa9582aa47),
+    UINT64_C(0x4ad64994d625e4da), UINT64_C(0x300e395ce6106da3),
+    UINT64_C(0xbf66a804b64ef628), UINT64_C(0xc5bed8cc867b7f51),
+    UINT64_C(0x8aeeace74e645255), UINT64_C(0xf036dc2f7e51db2c),
+    UINT64_C(0x7f5e4d772e0f40a7), UINT64_C(0x05863dbf1e3ac9de),
+    UINT64_C(0xe1fea520be311aaf), UINT64_C(0x9b26d5e88e0493d6),
+    UINT64_C(0x144e44b0de5a085d), UINT64_C(0x6e963478ee6f8124),
+    UINT64_C(0x21c640532670ac20), UINT64_C(0x5b1e309b16452559),
+    UINT64_C(0xd476a1c3461bbed2), UINT64_C(0xaeaed10b762e37ab),
+    UINT64_C(0x37deb6af5e9b8b5b), UINT64_C(0x4d06c6676eae0222),
+    UINT64_C(0xc26e573f3ef099a9), UINT64_C(0xb8b627f70ec510d0),
+    UINT64_C(0xf7e653dcc6da3dd4), UINT64_C(0x8d3e2314f6efb4ad),
+    UINT64_C(0x0256b24ca6b12f26), UINT64_C(0x788ec2849684a65f),
+    UINT64_C(0x9cf65a1b368f752e), UINT64_C(0xe62e2ad306bafc57),
+    UINT64_C(0x6946bb8b56e467dc), UINT64_C(0x139ecb4366d1eea5),
+    UINT64_C(0x5ccebf68aecec3a1), UINT64_C(0x2616cfa09efb4ad8),
+    UINT64_C(0xa97e5ef8cea5d153), UINT64_C(0xd3a62e30fe90582a),
+    UINT64_C(0xb0c7b7e3c7593bd8), UINT64_C(0xca1fc72bf76cb2a1),
+    UINT64_C(0x45775673a732292a), UINT64_C(0x3faf26bb9707a053),
+    UINT64_C(0x70ff52905f188d57), UINT64_C(0x0a2722586f2d042e),
+    UINT64_C(0x854fb3003f739fa5), UINT64_C(0xff97c3c80f4616dc),
+    UINT64_C(0x1bef5b57af4dc5ad), UINT64_C(0x61372b9f9f784cd4),
+    UINT64_C(0xee5fbac7cf26d75f), UINT64_C(0x9487ca0fff135e26),
+    UINT64_C(0xdbd7be24370c7322), UINT64_C(0xa10fceec0739fa5b),
+    UINT64_C(0x2e675fb4576761d0), UINT64_C(0x54bf2f7c6752e8a9),
+    UINT64_C(0xcdcf48d84fe75459), UINT64_C(0xb71738107fd2dd20),
+    UINT64_C(0x387fa9482f8c46ab), UINT64_C(0x42a7d9801fb9cfd2),
+    UINT64_C(0x0df7adabd7a6e2d6), UINT64_C(0x772fdd63e7936baf),
+    UINT64_C(0xf8474c3bb7cdf024), UINT64_C(0x829f3cf387f8795d),
+    UINT64_C(0x66e7a46c27f3aa2c), UINT64_C(0x1c3fd4a417c62355),
+    UINT64_C(0x935745fc4798b8de), UINT64_C(0xe98f353477ad31a7),
+    UINT64_C(0xa6df411fbfb21ca3), UINT64_C(0xdc0731d78f8795da),
+    UINT64_C(0x536fa08fdfd90e51), UINT64_C(0x29b7d047efec8728),
+};
+
+uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l) {
+    uint64_t j;
+
+    for (j = 0; j < l; j++) {
+        uint8_t byte = s[j];
+        crc = crc64_tab[(uint8_t)crc ^ byte] ^ (crc >> 8);
+    }
+    return crc;
+}
+
+//for intset
+#define INTSET_ENC_INT16 (sizeof(int16_t))
+#define INTSET_ENC_INT32 (sizeof(int32_t))
+#define INTSET_ENC_INT64 (sizeof(int64_t))
+typedef struct intset {
+    uint32_t encoding;
+    uint32_t length;
+    int8_t contents[];
+} intset;
+
+
+static uint8_t intsetGet(intset *is, uint32_t pos, int64_t *value) {
+    int64_t v64;
+    int32_t v32;
+    int16_t v16;
+    uint8_t enc;
+    if (is == NULL || value == NULL){
+        return 0;
+    }
+
+    enc = is->encoding;   
+    //if (pos < intrev32ifbe(is->length)) {
+    if (pos < is->length) {
+        if (enc == INTSET_ENC_INT64) {
+            memcpy(&v64,((int64_t*)is->contents)+pos,sizeof(v64));
+            //memrev64ifbe(&v64);
+            *value = v64;
+        } else if (enc == INTSET_ENC_INT32) {
+            memcpy(&v32,((int32_t*)is->contents)+pos,sizeof(v32));
+            //memrev32ifbe(&v32);
+            *value =  v32;
+        } else {
+            memcpy(&v16,((int16_t*)is->contents)+pos,sizeof(v16));
+            //memrev16ifbe(&v16);
+            *value =  v16;
+        }
+
+        return 1;
+    }
+
+    return 0;
+}
+
+//rio
+/* Returns 1 or 0 for success/failure. */
+size_t rioBufferRead(rio *r, void *buf, size_t len) {
+    if (r == NULL || buf == NULL){
+        return 0;
+    }
+
+    if (r->io.buffer.len - r->io.buffer.pos < len){
+        return 0; /* not enough buffer to return len bytes. */
+    }
+
+    memcpy(buf, r->io.buffer.ptr + r->io.buffer.pos, len);
+    r->io.buffer.pos += len;
+
+    return 1;
+}
+
+void rioInitWithBuffer(rio *r, const char *s, size_t len) {
+    const rio rioBufferIO = {
+      rioBufferRead,
+      NULL,           /* update_checksum */
+      0,              /* current checksum */
+      0,              /* bytes read or written */
+      0,              /* read/write chunk size */
+      { { NULL, 0, 0 } } /* union for io-specific vars */
+    };
+
+    *r = rioBufferIO;
+    r->io.buffer.ptr = s;
+    r->io.buffer.pos = 0;
+    r->io.buffer.len = len;
+}
+
+
+static inline size_t rioRead(rio *r, void *buf, size_t len) {
+    if (r == NULL || buf == NULL){
+        return 0;
+    }
+    while (len) {
+        size_t bytes_to_read = (r->max_processing_chunk && r->max_processing_chunk < len) ? r->max_processing_chunk : len;
+        if (r->read(r,buf,bytes_to_read) == 0)
+            return 0;
+
+        if (r->update_cksum) r->update_cksum(r,buf,bytes_to_read);
+
+        buf = (char*)buf + bytes_to_read;
+        len -= bytes_to_read;
+        r->processed_bytes += bytes_to_read;
+    }
+
+    return 1;
+}
+
+/* Load a "type" in RDB format, that is a one byte unsigned integer.
+ * This function is not only used to load object types, but also special
+ * "types" like the end-of-file type, the EXPIRE type, and so forth. */
+static int rdbLoadType(rio *rdb) {
+    unsigned char type;
+    if (rioRead(rdb,&type,1) == 0) return -1;
+    return type;
+}
+
+/* Use rdbLoadType() to load a TYPE in RDB format, but returns -1 if the
+ * type is not specifically a valid Object Type. */
+int rdbLoadObjectType(rio *rdb) {
+    int type;
+    if ((type = rdbLoadType(rdb)) == -1) return -1;
+    if (!rdbIsObjectType(type)) return -1;
+    return type;
+}
+
+
+/* Verify that the RDB version of the dump payload matches the one of this Redis
+ * instance and that the checksum is ok.
+ * If the DUMP payload looks valid REDIS_OK is returned, otherwise REDIS_ERR
+ * is returned. */
+int verifyDumpPayload(unsigned char *p, size_t len) {
+    unsigned char *footer;
+    uint16_t rdbver;
+    uint64_t crc;
+
+    /* At least 2 bytes of RDB version and 8 of CRC64 should be present. */
+    if (len < 10) return REDIS_ERR;
+    footer = p+(len-10);
+
+    /* Verify RDB version */
+    rdbver = (footer[1] << 8) | footer[0];
+    // if (rdbver != REDIS_RDB_VERSION) return REDIS_ERR;
+
+    // fix: just support migrage redis3.2 to pika
+    if (rdbver > 7) return REDIS_ERR;
+
+    /* Verify CRC64 */
+    crc = crc64(0,p,len-8);
+    //memrev64ifbe(&crc);   //default LITTLE_ENDIAN
+    return (memcmp(&crc,footer+2,8) == 0) ? REDIS_OK : REDIS_ERR;
+}
+
+/* Load an encoded length. The "isencoded" argument is set to 1 if the length
+ * is not actually a length but an "encoding type". See the REDIS_RDB_ENC_*
+ * definitions in rdb.h for more information. */
+uint32_t rdbLoadLen(rio *rdb, int *isencoded) {
+    unsigned char buf[2];
+    uint32_t len;
+    int type;
+
+    if (isencoded) *isencoded = 0;
+
+    if (rioRead(rdb,buf,1) == 0) return REDIS_RDB_LENERR;
+    type = (buf[0]&0xC0)>>6;
+    if (type == REDIS_RDB_ENCVAL) {
+        /* Read a 6 bit encoding type. */
+        if (isencoded) *isencoded = 1;
+        return buf[0]&0x3F;
+    } else if (type == REDIS_RDB_6BITLEN) {
+        /* Read a 6 bit len. */
+        return buf[0]&0x3F;
+    } else if (type == REDIS_RDB_14BITLEN) {
+        /* Read a 14 bit len. */
+        if (rioRead(rdb,buf+1,1) == 0) return REDIS_RDB_LENERR;
+        return ((buf[0]&0x3F)<<8)|buf[1];
+    } else {
+        /* Read a 32 bit len. */
+        if (rioRead(rdb,&len,4) == 0) return REDIS_RDB_LENERR;
+        return ntohl(len);
+    }
+}
+
+/* Load a Redis object of the specified type from the specified file.
+ * On success REDIS_OK is returned, otherwise return REDIS_ERR. */
+int rdbLoadObject(int rdbtype, rio *rdb, restore_value *dbvalue) {
+
+    if (rdbtype == REDIS_RDB_TYPE_STRING) {
+        /* Read string value */
+        dbvalue->type = storage::kStrings;
+        std::string value;
+        if (rdbLoadStringObject(rdb, &value) != REDIS_OK){
+            LOG(ERROR) << "rdbLoadEncodedStringObject : error";
+            return REDIS_ERR;
+        } 
+
+        //the value may be ""
+        dbvalue->kvv = value;
+    }else if (rdbtype == REDIS_RDB_TYPE_LIST) {
+        /* Read list value */
+        size_t len;
+        dbvalue->type = storage::kLists;
+        if ((len = rdbLoadLen(rdb,NULL)) == REDIS_RDB_LENERR){
+            LOG(ERROR) << "REDIS_RDB_TYPE_LIST : get len error";
+            return REDIS_ERR;
+        } 
+
+        /* Load every single element of the list */
+        while(len--) {
+            std::string ele;
+            if (rdbLoadStringObject(rdb, &ele) != REDIS_OK){
+                LOG(ERROR) << "rdbLoadEncodedStringObject : error";
+                return REDIS_ERR;
+            } 
+
+            dbvalue->listv.push_back(ele);
+        }
+    }else if (rdbtype == REDIS_RDB_TYPE_SET) {
+        /* Read list/set value */
+        size_t len;
+        dbvalue->type = storage::kSets;
+        if ((len = rdbLoadLen(rdb,NULL)) == REDIS_RDB_LENERR){
+            LOG(ERROR) << "REDIS_RDB_TYPE_SET : get len error";
+            return REDIS_ERR;
+        }
+
+        /* Load every single element of the list/set */
+        while (len--) {
+            std::string ele;
+            if (rdbLoadStringObject(rdb, &ele) != REDIS_OK){
+                LOG(ERROR) << "rdbLoadEncodedStringObject : error";
+                return REDIS_ERR;
+            }
+
+            dbvalue->setv.push_back(ele);
+        }
+    }else if (rdbtype == REDIS_RDB_TYPE_ZSET) {
+        /* Read list/set value */
+        size_t len;
+        dbvalue->type = storage::kZSets;
+        if ((len = rdbLoadLen(rdb, NULL)) == REDIS_RDB_LENERR){
+            LOG(ERROR) << "REDIS_RDB_TYPE_SET : get len error";
+            return REDIS_ERR;
+        }
+
+        /* Load every single element of the list/set */
+        while(len--) {
+            std::string member;
+            double score;
+
+            if (rdbLoadStringObject(rdb, &member) != REDIS_OK){
+                LOG(ERROR) << "rdbLoadEncodedStringObject : error";
+                return REDIS_ERR;
+            }
+
+            if (rdbLoadDoubleValue(rdb, &score) != REDIS_OK){
+                LOG(ERROR) << "rdbLoadDoubleValue : error";
+                return REDIS_ERR;
+            }
+
+            dbvalue->zsetv.push_back({score, member});
+        }
+    } else if (rdbtype == REDIS_RDB_TYPE_HASH) {
+        size_t len;
+        dbvalue->type = storage::kHashes;
+        if ((len = rdbLoadLen(rdb, NULL)) == REDIS_RDB_LENERR){
+            LOG(ERROR) << "REDIS_RDB_TYPE_SET : get len error";
+            return REDIS_ERR;
+        }
+
+        /* Load remaining fields and values into the hash table */
+        while (len--) {
+            std::string field;
+            std::string value;
+            /* Load raw strings */
+            if (rdbLoadStringObject(rdb, &field) != REDIS_OK){
+                LOG(ERROR) << "rdbLoadEncodedStringObject : error";
+                return REDIS_ERR;
+            }
+
+            if (rdbLoadStringObject(rdb, &value) != REDIS_OK){
+                LOG(ERROR) << "rdbLoadStringObject : error";
+                return REDIS_ERR;
+            }
+
+            /* Add pair to hash table */
+            dbvalue->hashv.push_back({field, value});
+        }
+    } else if (rdbtype == REDIS_RDB_TYPE_HASH_ZIPMAP  ||
+               rdbtype == REDIS_RDB_TYPE_LIST_ZIPLIST ||
+               rdbtype == REDIS_RDB_TYPE_SET_INTSET   ||
+               rdbtype == REDIS_RDB_TYPE_ZSET_ZIPLIST ||
+               rdbtype == REDIS_RDB_TYPE_HASH_ZIPLIST)
+    {
+        std::string aux;
+        if (rdbLoadStringObject(rdb, &aux) != REDIS_OK){
+            LOG(ERROR) << "rdbLoadStringObject : error";
+            return REDIS_ERR;
+        }
+
+        switch(rdbtype) {
+            case REDIS_RDB_TYPE_LIST_ZIPLIST:
+                {
+                    return  getListFromZiplist(aux, dbvalue);
+                }
+                break;
+            case REDIS_RDB_TYPE_ZSET_ZIPLIST:
+                {
+                    return  getZsetFromZiplist(aux, dbvalue);
+                }
+                break;
+            case REDIS_RDB_TYPE_HASH_ZIPLIST:
+                {
+                    return  getHashFromZiplist(aux, dbvalue);
+                }
+                break;
+            case REDIS_RDB_TYPE_SET_INTSET:
+                {
+                    return  getSetFromIntset(aux, dbvalue);
+                }
+                break;
+            case REDIS_RDB_TYPE_HASH_ZIPMAP:
+                {
+                    //this encoding has be deprecated since redis 2.6
+                    LOG(ERROR) << "dont support REDIS_RDB_TYPE_HASH_ZIPMAP encoding";
+                    return REDIS_ERR;
+                }
+                break;
+            default:
+                LOG(ERROR) << "Unknown encoding";
+                return REDIS_ERR;
+        }
+    }else{
+        dbvalue->type = storage::kNONE_DB;
+    }
+
+    return REDIS_OK;
+}
+
+int rdbLoadIntegerObject(rio *rdb, int enctype, std::string *str) {
+    unsigned char enc[4];
+    long long val;
+
+    if (enctype == REDIS_RDB_ENC_INT8) {
+        if (rioRead(rdb,enc,1) == 0) return REDIS_ERR;
+        val = (signed char)enc[0];
+    } else if (enctype == REDIS_RDB_ENC_INT16) {
+        uint16_t v;
+        if (rioRead(rdb,enc,2) == 0) return REDIS_ERR;
+        v = enc[0]|(enc[1]<<8);
+        val = (int16_t)v;
+    } else if (enctype == REDIS_RDB_ENC_INT32) {
+        uint32_t v;
+        if (rioRead(rdb,enc,4) == 0) return REDIS_ERR;
+        v = enc[0]|(enc[1]<<8)|(enc[2]<<16)|(enc[3]<<24);
+        val = (int32_t)v;
+    } else {
+        //val = 0; /* anti-warning */
+        LOG(ERROR) << "Unknown RDB integer encoding type";
+        return REDIS_ERR;
+    }
+
+    *str = std::to_string(val);
+    
+    return REDIS_OK;
+}
+
+int rdbLoadLzfStringObject(rio *rdb, std::string *str) {
+    unsigned int len, clen;
+    unsigned char *c = NULL;
+    char *val = NULL;
+
+    if ((clen = rdbLoadLen(rdb,NULL)) == REDIS_RDB_LENERR) return REDIS_ERR;
+    if ((len = rdbLoadLen(rdb,NULL)) == REDIS_RDB_LENERR) return REDIS_ERR;
+    if ((c = (unsigned char *)malloc(clen)) == NULL) goto err;
+    if ((val = (char *)malloc(len)) == NULL) goto err;
+    if (rioRead(rdb,c,clen) == 0) goto err;
+    if (lzf_decompress(c,clen,val,len) == 0) goto err;
+
+    str->assign(val, len);
+
+    free(c);
+    free(val);
+
+    return REDIS_OK;
+err:
+    free(c);
+    free(val);
+    return REDIS_ERR;
+}
+
+int rdbLoadStringObject(rio *rdb, std::string *str) {
+    int isencoded;
+    uint32_t len;
+    char *buf = NULL;
+
+    len = rdbLoadLen(rdb, &isencoded);
+
+    if (isencoded) {
+        switch(len) {
+        case REDIS_RDB_ENC_INT8:
+        case REDIS_RDB_ENC_INT16:
+        case REDIS_RDB_ENC_INT32:
+            return rdbLoadIntegerObject(rdb, len, str);
+        case REDIS_RDB_ENC_LZF:
+            return rdbLoadLzfStringObject(rdb, str);
+        default:
+            LOG(ERROR) << "Unknown RDB encoding type";
+            return REDIS_ERR;
+        }
+    }
+
+    //when len is 0, the value is ""
+    if (len == REDIS_RDB_LENERR) return REDIS_ERR;
+
+    buf = (char *)malloc( len );
+    if(buf == NULL){
+        return REDIS_ERR;
+    }
+
+    if (len && rioRead(rdb, buf, len) == 0) {
+        free(buf);
+        return REDIS_ERR;
+    }
+
+    //len may be 0
+    str->assign(buf, len);
+    free(buf);
+
+    return REDIS_OK;
+}
+
+/* For information about double serialization check rdbSaveDoubleValue() */
+int rdbLoadDoubleValue(rio *rdb, double *val) {
+    char buf[256];
+    unsigned char len;
+
+    double R_Zero, R_PosInf, R_NegInf, R_Nan;
+    R_Zero = 0.0;
+    R_PosInf = 1.0/R_Zero;
+    R_NegInf = -1.0/R_Zero;
+    R_Nan = R_Zero/R_Zero;
+
+    if (rioRead(rdb,&len,1) == 0) return REDIS_ERR;
+    switch(len) {
+    case 255: *val = R_NegInf; return REDIS_OK;
+    case 254: *val = R_PosInf; return REDIS_OK;
+    case 253: *val = R_Nan; return REDIS_OK;
+    default:
+        if (rioRead(rdb,buf,len) == 0) return REDIS_ERR;
+        buf[len] = '\0';
+        sscanf(buf, "%lg", val);
+        return REDIS_OK;
+    }
+}
+
+int getZsetFromZiplist(const std::string &aux, restore_value *dbvalue)
+{
+    unsigned char *zl = (unsigned char *)aux.data();
+    std::string ele;
+    double score;
+    unsigned char *eptr = NULL, *sptr = NULL;
+
+    dbvalue->type = storage::kZSets;
+
+    eptr = ziplistIndex(zl,0);
+    if (eptr == NULL) {
+        return REDIS_ERR;
+    }
+
+    sptr = ziplistNext(zl,eptr);
+
+
+    while (eptr != NULL && sptr != NULL) {
+        if (zzlGetScore(sptr, &score) == REDIS_ERR || zzlGetString(eptr, &ele) == REDIS_ERR){
+            return REDIS_ERR;
+        }
+
+        dbvalue->zsetv.push_back({score, ele});
+
+        if (zzlNext(zl,&eptr,&sptr) == REDIS_ERR){
+            return REDIS_ERR;
+        }
+    }
+
+    return REDIS_OK;
+}
+
+int getListFromZiplist(const std::string &aux, restore_value *dbvalue)
+{
+    unsigned char *zl = (unsigned char *)aux.data();
+    std::string ele;
+    unsigned char *eptr = NULL;
+
+    dbvalue->type = storage::kLists;
+
+    eptr = ziplistIndex(zl,0);
+    if (eptr == NULL) {
+        return REDIS_ERR;
+    }
+
+    while (eptr != NULL) {
+        if (zzlGetString(eptr, &ele) == REDIS_ERR){
+            return REDIS_ERR;
+        }
+
+        dbvalue->listv.push_back(ele);
+
+        eptr = ziplistNext(zl, eptr);
+    }
+
+    return REDIS_OK;
+}
+
+int getHashFromZiplist(const std::string &aux, restore_value *dbvalue)
+{
+    unsigned char *zl = (unsigned char *)aux.data();
+    std::string field;
+    std::string value;
+    unsigned char *fptr = NULL, *vptr = NULL;
+
+    dbvalue->type = storage::kHashes;
+
+    fptr = ziplistIndex(zl,0);
+    if (fptr == NULL) {
+        return REDIS_ERR;
+    }
+
+    while (fptr != NULL) {
+        vptr = ziplistNext(zl,fptr);
+        if (vptr == NULL){
+            return REDIS_ERR;
+        }
+
+        if (zzlGetString(fptr, &field) == REDIS_ERR){
+            return REDIS_ERR;
+        }
+
+        if (zzlGetString(vptr, &value) == REDIS_ERR){
+            return REDIS_ERR;
+        }
+
+        dbvalue->hashv.push_back({field, value});
+
+        fptr = ziplistNext(zl,vptr);
+    }
+
+    return REDIS_OK;
+}
+
+int getSetFromIntset(const std::string &aux, restore_value *dbvalue)
+{
+    unsigned char *ptr = (unsigned char *)aux.data();
+    int64_t     intele;
+    uint32_t    index = 0;
+
+    dbvalue->type = storage::kSets;
+
+    while (intsetGet((intset *)ptr, index, &intele)) {
+        dbvalue->setv.push_back(std::to_string(intele));
+
+        index++;
+    }
+
+    return REDIS_OK;
+}
+
+int zzlGetScore(unsigned char *sptr, double *score) {
+    unsigned char *vstr;
+    unsigned int vlen;
+    long long vlong;
+    char buf[128];
+
+    if (sptr == NULL || ziplistGet(sptr,&vstr,&vlen,&vlong) == 0){
+        return REDIS_ERR;
+    }
+
+    if (vstr) {
+        memcpy(buf,vstr,vlen);
+        buf[vlen] = '\0';
+        *score = strtod(buf,NULL);
+    } else {
+        *score = vlong;
+    }
+
+    return REDIS_OK;
+}
+
+int zzlGetString(unsigned char *sptr, std::string *value) {
+    unsigned char *vstr;
+    unsigned int vlen;
+    long long vlong;
+
+    if (sptr == NULL || ziplistGet(sptr,&vstr,&vlen,&vlong) == 0){
+        return REDIS_ERR;
+    }
+
+    if (vstr == NULL)
+        *value = std::to_string(vlong);
+    else
+        (*value).assign((char*)vstr, vlen);
+
+    return REDIS_OK;
+}
+
+/* Move to next entry based on the values in eptr and sptr. Both are set to
+ * NULL when there is no next entry. */
+int zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr) {
+    unsigned char *_eptr, *_sptr;
+    if (*eptr == NULL || *sptr == NULL){
+        return REDIS_ERR;
+    }
+
+    _eptr = ziplistNext(zl,*sptr);
+    if (_eptr != NULL) {
+        _sptr = ziplistNext(zl,_eptr);
+        if (_sptr == NULL){
+            return REDIS_ERR;
+        }
+    } else {
+        /* No next entry. */
+        _sptr = NULL;
+    }
+
+    *eptr = _eptr;
+    *sptr = _sptr;
+
+    return REDIS_OK;
+}

--- a/src/utils/src/pika_ziplist.cc
+++ b/src/utils/src/pika_ziplist.cc
@@ -1,0 +1,933 @@
+/* The ziplist is a specially encoded dually linked list that is designed
+ * to be very memory efficient. It stores both strings and integer values,
+ * where integers are encoded as actual integers instead of a series of
+ * characters. It allows push and pop operations on either side of the list
+ * in O(1) time. However, because every operation requires a reallocation of
+ * the memory used by the ziplist, the actual complexity is related to the
+ * amount of memory used by the ziplist.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * ZIPLIST OVERALL LAYOUT:
+ * The general layout of the ziplist is as follows:
+ * <zlbytes><zltail><zllen><entry><entry><zlend>
+ *
+ * <zlbytes> is an unsigned integer to hold the number of bytes that the
+ * ziplist occupies. This value needs to be stored to be able to resize the
+ * entire structure without the need to traverse it first.
+ *
+ * <zltail> is the offset to the last entry in the list. This allows a pop
+ * operation on the far side of the list without the need for full traversal.
+ *
+ * <zllen> is the number of entries.When this value is larger than 2**16-2,
+ * we need to traverse the entire list to know how many items it holds.
+ *
+ * <zlend> is a single byte special value, equal to 255, which indicates the
+ * end of the list.
+ *
+ * ZIPLIST ENTRIES:
+ * Every entry in the ziplist is prefixed by a header that contains two pieces
+ * of information. First, the length of the previous entry is stored to be
+ * able to traverse the list from back to front. Second, the encoding with an
+ * optional string length of the entry itself is stored.
+ *
+ * The length of the previous entry is encoded in the following way:
+ * If this length is smaller than 254 bytes, it will only consume a single
+ * byte that takes the length as value. When the length is greater than or
+ * equal to 254, it will consume 5 bytes. The first byte is set to 254 to
+ * indicate a larger value is following. The remaining 4 bytes take the
+ * length of the previous entry as value.
+ *
+ * The other header field of the entry itself depends on the contents of the
+ * entry. When the entry is a string, the first 2 bits of this header will hold
+ * the type of encoding used to store the length of the string, followed by the
+ * actual length of the string. When the entry is an integer the first 2 bits
+ * are both set to 1. The following 2 bits are used to specify what kind of
+ * integer will be stored after this header. An overview of the different
+ * types and encodings is as follows:
+ *
+ * |00pppppp| - 1 byte
+ *      String value with length less than or equal to 63 bytes (6 bits).
+ * |01pppppp|qqqqqqqq| - 2 bytes
+ *      String value with length less than or equal to 16383 bytes (14 bits).
+ * |10______|qqqqqqqq|rrrrrrrr|ssssssss|tttttttt| - 5 bytes
+ *      String value with length greater than or equal to 16384 bytes.
+ * |11000000| - 1 byte
+ *      Integer encoded as int16_t (2 bytes).
+ * |11010000| - 1 byte
+ *      Integer encoded as int32_t (4 bytes).
+ * |11100000| - 1 byte
+ *      Integer encoded as int64_t (8 bytes).
+ * |11110000| - 1 byte
+ *      Integer encoded as 24 bit signed (3 bytes).
+ * |11111110| - 1 byte
+ *      Integer encoded as 8 bit signed (1 byte).
+ * |1111xxxx| - (with xxxx between 0000 and 1101) immediate 4 bit integer.
+ *      Unsigned integer from 0 to 12. The encoded value is actually from
+ *      1 to 13 because 0000 and 1111 can not be used, so 1 should be
+ *      subtracted from the encoded 4 bit value to obtain the right value.
+ * |11111111| - End of ziplist.
+ *
+ * All the integers are represented in little endian byte order.
+ *
+ * ----------------------------------------------------------------------------
+ */
+
+#include "utils/include/pika_ziplist.h"
+#include <assert.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cstddef>
+#include "pstd/include/pstd_string.h"
+
+#define ZIP_END 255
+#define ZIP_BIGLEN 254
+
+/* Different encoding/length possibilities */
+#define ZIP_STR_MASK 0xc0
+#define ZIP_INT_MASK 0x30
+#define ZIP_STR_06B (0 << 6)
+#define ZIP_STR_14B (1 << 6)
+#define ZIP_STR_32B (2 << 6)
+#define ZIP_INT_16B (0xc0 | 0<<4)
+#define ZIP_INT_32B (0xc0 | 1<<4)
+#define ZIP_INT_64B (0xc0 | 2<<4)
+#define ZIP_INT_24B (0xc0 | 3<<4)
+#define ZIP_INT_8B 0xfe
+/* 4 bit integer immediate encoding */
+#define ZIP_INT_IMM_MASK 0x0f
+#define ZIP_INT_IMM_MIN 0xf1    /* 11110001 */
+#define ZIP_INT_IMM_MAX 0xfd    /* 11111101 */
+#define ZIP_INT_IMM_VAL(v) (v & ZIP_INT_IMM_MASK)
+
+#define INT24_MAX 0x7fffff
+#define INT24_MIN (-INT24_MAX - 1)
+
+/* Macro to determine type */
+#define ZIP_IS_STR(enc) (((enc) & ZIP_STR_MASK) < ZIP_STR_MASK)
+
+/* Utility macros */
+#define ZIPLIST_BYTES(zl)       (*((uint32_t*)(zl)))
+#define ZIPLIST_TAIL_OFFSET(zl) (*((uint32_t*)((zl)+sizeof(uint32_t))))
+#define ZIPLIST_LENGTH(zl)      (*((uint16_t*)((zl)+sizeof(uint32_t)*2)))
+#define ZIPLIST_HEADER_SIZE     (sizeof(uint32_t)*2+sizeof(uint16_t))
+#define ZIPLIST_ENTRY_HEAD(zl)  ((zl)+ZIPLIST_HEADER_SIZE)
+#define ZIPLIST_ENTRY_TAIL(zl)  ((zl)+intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl)))
+#define ZIPLIST_ENTRY_END(zl)   ((zl)+intrev32ifbe(ZIPLIST_BYTES(zl))-1)
+
+
+//only support LITTLE_ENDIAN
+#define memrev16ifbe(p)
+#define memrev32ifbe(p)
+#define memrev64ifbe(p)
+#define intrev16ifbe(v) (v)
+#define intrev32ifbe(v) (v)
+#define intrev64ifbe(v) (v)
+
+/* We know a positive increment can only be 1 because entries can only be
+ * pushed one at a time. */
+#define ZIPLIST_INCR_LENGTH(zl,incr) { \
+    if (ZIPLIST_LENGTH(zl) < UINT16_MAX) \
+        ZIPLIST_LENGTH(zl) = intrev16ifbe(intrev16ifbe(ZIPLIST_LENGTH(zl))+incr); \
+}
+
+typedef struct zlentry {
+    unsigned int prevrawlensize, prevrawlen;
+    unsigned int lensize, len;
+    unsigned int headersize;
+    unsigned char encoding;
+    unsigned char *p;
+} zlentry;
+
+/* Extract the encoding from the byte pointed by 'ptr' and set it into
+ * 'encoding'. */
+#define ZIP_ENTRY_ENCODING(ptr, encoding) do {  \
+    (encoding) = (ptr[0]); \
+    if ((encoding) < ZIP_STR_MASK) (encoding) &= ZIP_STR_MASK; \
+} while(0)
+
+/* Return bytes needed to store integer encoded by 'encoding' */
+static unsigned int zipIntSize(unsigned char encoding) {
+    switch(encoding) {
+    case ZIP_INT_8B:  return 1;
+    case ZIP_INT_16B: return 2;
+    case ZIP_INT_24B: return 3;
+    case ZIP_INT_32B: return 4;
+    case ZIP_INT_64B: return 8;
+    default: return 0; /* 4 bit immediate */
+    }
+    assert(NULL);
+    return 0;
+}
+
+/* Encode the length 'rawlen' writing it in 'p'. If p is NULL it just returns
+ * the amount of bytes required to encode such a length. */
+static unsigned int zipEncodeLength(unsigned char *p, unsigned char encoding, unsigned int rawlen) {
+    unsigned char len = 1, buf[5];
+
+    if (ZIP_IS_STR(encoding)) {
+        /* Although encoding is given it may not be set for strings,
+         * so we determine it here using the raw length. */
+        if (rawlen <= 0x3f) {
+            if (!p) return len;
+            buf[0] = ZIP_STR_06B | rawlen;
+        } else if (rawlen <= 0x3fff) {
+            len += 1;
+            if (!p) return len;
+            buf[0] = ZIP_STR_14B | ((rawlen >> 8) & 0x3f);
+            buf[1] = rawlen & 0xff;
+        } else {
+            len += 4;
+            if (!p) return len;
+            buf[0] = ZIP_STR_32B;
+            buf[1] = (rawlen >> 24) & 0xff;
+            buf[2] = (rawlen >> 16) & 0xff;
+            buf[3] = (rawlen >> 8) & 0xff;
+            buf[4] = rawlen & 0xff;
+        }
+    } else {
+        /* Implies integer encoding, so length is always 1. */
+        if (!p) return len;
+        buf[0] = encoding;
+    }
+
+    /* Store this length at p */
+    memcpy(p,buf,len);
+    return len;
+}
+
+/* Decode the length encoded in 'ptr'. The 'encoding' variable will hold the
+ * entries encoding, the 'lensize' variable will hold the number of bytes
+ * required to encode the entries length, and the 'len' variable will hold the
+ * entries length. */
+#define ZIP_DECODE_LENGTH(ptr, encoding, lensize, len) do {                    \
+    ZIP_ENTRY_ENCODING((ptr), (encoding));                                     \
+    if ((encoding) < ZIP_STR_MASK) {                                           \
+        if ((encoding) == ZIP_STR_06B) {                                       \
+            (lensize) = 1;                                                     \
+            (len) = (ptr)[0] & 0x3f;                                           \
+        } else if ((encoding) == ZIP_STR_14B) {                                \
+            (lensize) = 2;                                                     \
+            (len) = (((ptr)[0] & 0x3f) << 8) | (ptr)[1];                       \
+        } else if (encoding == ZIP_STR_32B) {                                  \
+            (lensize) = 5;                                                     \
+            (len) = ((ptr)[1] << 24) |                                         \
+                    ((ptr)[2] << 16) |                                         \
+                    ((ptr)[3] <<  8) |                                         \
+                    ((ptr)[4]);                                                \
+        } else {                                                               \
+            assert(NULL);                                                      \
+        }                                                                      \
+    } else {                                                                   \
+        (lensize) = 1;                                                         \
+        (len) = zipIntSize(encoding);                                          \
+    }                                                                          \
+} while(0);
+
+/* Encode the length of the previous entry and write it to "p". Return the
+ * number of bytes needed to encode this length if "p" is NULL. */
+static unsigned int zipPrevEncodeLength(unsigned char *p, unsigned int len) {
+    if (p == NULL) {
+        return (len < ZIP_BIGLEN) ? 1 : sizeof(len)+1;
+    } else {
+        if (len < ZIP_BIGLEN) {
+            p[0] = len;
+            return 1;
+        } else {
+            p[0] = ZIP_BIGLEN;
+            memcpy(p+1,&len,sizeof(len));
+            memrev32ifbe(p+1);
+            return 1+sizeof(len);
+        }
+    }
+}
+
+/* Encode the length of the previous entry and write it to "p". This only
+ * uses the larger encoding (required in __ziplistCascadeUpdate). */
+static void zipPrevEncodeLengthForceLarge(unsigned char *p, unsigned int len) {
+    if (p == NULL) return;
+    p[0] = ZIP_BIGLEN;
+    memcpy(p+1,&len,sizeof(len));
+    memrev32ifbe(p+1);
+}
+
+/* Decode the number of bytes required to store the length of the previous
+ * element, from the perspective of the entry pointed to by 'ptr'. */
+#define ZIP_DECODE_PREVLENSIZE(ptr, prevlensize) do {                          \
+    if ((ptr)[0] < ZIP_BIGLEN) {                                               \
+        (prevlensize) = 1;                                                     \
+    } else {                                                                   \
+        (prevlensize) = 5;                                                     \
+    }                                                                          \
+} while(0);
+
+/* Decode the length of the previous element, from the perspective of the entry
+ * pointed to by 'ptr'. */
+#define ZIP_DECODE_PREVLEN(ptr, prevlensize, prevlen) do {                     \
+    ZIP_DECODE_PREVLENSIZE(ptr, prevlensize);                                  \
+    if ((prevlensize) == 1) {                                                  \
+        (prevlen) = (ptr)[0];                                                  \
+    } else if ((prevlensize) == 5) {                                           \
+        assert(sizeof((prevlensize)) == 4);                                    \
+        memcpy(&(prevlen), ((char*)(ptr)) + 1, 4);                             \
+        memrev32ifbe(&prevlen);                                                \
+    }                                                                          \
+} while(0);
+
+/* Return the difference in number of bytes needed to store the length of the
+ * previous element 'len', in the entry pointed to by 'p'. */
+static int zipPrevLenByteDiff(unsigned char *p, unsigned int len) {
+    unsigned int prevlensize;
+    ZIP_DECODE_PREVLENSIZE(p, prevlensize);
+    return zipPrevEncodeLength(NULL, len) - prevlensize;
+}
+
+/* Return the total number of bytes used by the entry pointed to by 'p'. */
+static unsigned int zipRawEntryLength(unsigned char *p) {
+    unsigned int prevlensize, encoding, lensize = 0, len = 0;
+    ZIP_DECODE_PREVLENSIZE(p, prevlensize);
+    ZIP_DECODE_LENGTH(p + prevlensize, encoding, lensize, len);
+    return prevlensize + lensize + len;
+}
+
+/* Check if string pointed to by 'entry' can be encoded as an integer.
+ * Stores the integer value in 'v' and its encoding in 'encoding'. */
+static int zipTryEncoding(unsigned char *entry, unsigned int entrylen, long long *v, unsigned char *encoding) {
+    long long value;
+
+    if (entrylen >= 32 || entrylen == 0) return 0;
+    if (pstd::string2int((char*)entry,entrylen,&value)) {
+        /* Great, the string can be encoded. Check what's the smallest
+         * of our encoding types that can hold this value. */
+        if (value >= 0 && value <= 12) {
+            *encoding = ZIP_INT_IMM_MIN+value;
+        } else if (value >= INT8_MIN && value <= INT8_MAX) {
+            *encoding = ZIP_INT_8B;
+        } else if (value >= INT16_MIN && value <= INT16_MAX) {
+            *encoding = ZIP_INT_16B;
+        } else if (value >= INT24_MIN && value <= INT24_MAX) {
+            *encoding = ZIP_INT_24B;
+        } else if (value >= INT32_MIN && value <= INT32_MAX) {
+            *encoding = ZIP_INT_32B;
+        } else {
+            *encoding = ZIP_INT_64B;
+        }
+        *v = value;
+        return 1;
+    }
+    return 0;
+}
+
+/* Store integer 'value' at 'p', encoded as 'encoding' */
+static void zipSaveInteger(unsigned char *p, int64_t value, unsigned char encoding) {
+    int16_t i16;
+    int32_t i32;
+    int64_t i64;
+    if (encoding == ZIP_INT_8B) {
+        ((int8_t*)p)[0] = (int8_t)value;
+    } else if (encoding == ZIP_INT_16B) {
+        i16 = value;
+        memcpy(p,&i16,sizeof(i16));
+        memrev16ifbe(p);
+    } else if (encoding == ZIP_INT_24B) {
+        i32 = value<<8;
+        memrev32ifbe(&i32);
+        memcpy(p,((uint8_t*)&i32)+1,sizeof(i32)-sizeof(uint8_t));
+    } else if (encoding == ZIP_INT_32B) {
+        i32 = value;
+        memcpy(p,&i32,sizeof(i32));
+        memrev32ifbe(p);
+    } else if (encoding == ZIP_INT_64B) {
+        i64 = value;
+        memcpy(p,&i64,sizeof(i64));
+        memrev64ifbe(p);
+    } else if (encoding >= ZIP_INT_IMM_MIN && encoding <= ZIP_INT_IMM_MAX) {
+        /* Nothing to do, the value is stored in the encoding itself. */
+    } else {
+        assert(NULL);
+    }
+}
+
+/* Read integer encoded as 'encoding' from 'p' */
+static int64_t zipLoadInteger(unsigned char *p, unsigned char encoding) {
+    int16_t i16;
+    int32_t i32;
+    int64_t i64, ret = 0;
+    if (encoding == ZIP_INT_8B) {
+        ret = ((int8_t*)p)[0];
+    } else if (encoding == ZIP_INT_16B) {
+        memcpy(&i16,p,sizeof(i16));
+        memrev16ifbe(&i16);
+        ret = i16;
+    } else if (encoding == ZIP_INT_32B) {
+        memcpy(&i32,p,sizeof(i32));
+        memrev32ifbe(&i32);
+        ret = i32;
+    } else if (encoding == ZIP_INT_24B) {
+        i32 = 0;
+        memcpy(((uint8_t*)&i32)+1,p,sizeof(i32)-sizeof(uint8_t));
+        memrev32ifbe(&i32);
+        ret = i32>>8;
+    } else if (encoding == ZIP_INT_64B) {
+        memcpy(&i64,p,sizeof(i64));
+        memrev64ifbe(&i64);
+        ret = i64;
+    } else if (encoding >= ZIP_INT_IMM_MIN && encoding <= ZIP_INT_IMM_MAX) {
+        ret = (encoding & ZIP_INT_IMM_MASK)-1;
+    } else {
+        assert(NULL);
+    }
+    return ret;
+}
+
+/* Return a struct with all information about an entry. */
+static zlentry zipEntry(unsigned char *p) {
+    zlentry e;
+
+    ZIP_DECODE_PREVLEN(p, e.prevrawlensize, e.prevrawlen);
+    ZIP_DECODE_LENGTH(p + e.prevrawlensize, e.encoding, e.lensize, e.len);
+    e.headersize = e.prevrawlensize + e.lensize;
+    e.p = p;
+    return e;
+}
+
+/* Create a new empty ziplist. */
+unsigned char *ziplistNew(void) {
+    unsigned int bytes = ZIPLIST_HEADER_SIZE+1;
+    unsigned char *zl = (unsigned char *)malloc(bytes);
+    ZIPLIST_BYTES(zl) = intrev32ifbe(bytes);
+    ZIPLIST_TAIL_OFFSET(zl) = intrev32ifbe(ZIPLIST_HEADER_SIZE);
+    ZIPLIST_LENGTH(zl) = 0;
+    zl[bytes-1] = ZIP_END;
+    return zl;
+}
+
+/* Resize the ziplist. */
+static unsigned char *ziplistResize(unsigned char *zl, unsigned int len) {
+    zl = (unsigned char *)realloc(zl,len);
+    ZIPLIST_BYTES(zl) = intrev32ifbe(len);
+    zl[len-1] = ZIP_END;
+    return zl;
+}
+
+/* When an entry is inserted, we need to set the prevlen field of the next
+ * entry to equal the length of the inserted entry. It can occur that this
+ * length cannot be encoded in 1 byte and the next entry needs to be grow
+ * a bit larger to hold the 5-byte encoded prevlen. This can be done for free,
+ * because this only happens when an entry is already being inserted (which
+ * causes a realloc and memmove). However, encoding the prevlen may require
+ * that this entry is grown as well. This effect may cascade throughout
+ * the ziplist when there are consecutive entries with a size close to
+ * ZIP_BIGLEN, so we need to check that the prevlen can be encoded in every
+ * consecutive entry.
+ *
+ * Note that this effect can also happen in reverse, where the bytes required
+ * to encode the prevlen field can shrink. This effect is deliberately ignored,
+ * because it can cause a "flapping" effect where a chain prevlen fields is
+ * first grown and then shrunk again after consecutive inserts. Rather, the
+ * field is allowed to stay larger than necessary, because a large prevlen
+ * field implies the ziplist is holding large entries anyway.
+ *
+ * The pointer "p" points to the first entry that does NOT need to be
+ * updated, i.e. consecutive fields MAY need an update. */
+static unsigned char *__ziplistCascadeUpdate(unsigned char *zl, unsigned char *p) {
+    size_t curlen = intrev32ifbe(ZIPLIST_BYTES(zl)), rawlen, rawlensize;
+    size_t offset, noffset, extra;
+    unsigned char *np;
+    zlentry cur, next;
+
+    while (p[0] != ZIP_END) {
+        cur = zipEntry(p);
+        rawlen = cur.headersize + cur.len;
+        rawlensize = zipPrevEncodeLength(NULL,rawlen);
+
+        /* Abort if there is no next entry. */
+        if (p[rawlen] == ZIP_END) break;
+        next = zipEntry(p+rawlen);
+
+        /* Abort when "prevlen" has not changed. */
+        if (next.prevrawlen == rawlen) break;
+
+        if (next.prevrawlensize < rawlensize) {
+            /* The "prevlen" field of "next" needs more bytes to hold
+             * the raw length of "cur". */
+            offset = p-zl;
+            extra = rawlensize-next.prevrawlensize;
+            zl = ziplistResize(zl,curlen+extra);
+            p = zl+offset;
+
+            /* Current pointer and offset for next element. */
+            np = p+rawlen;
+            noffset = np-zl;
+
+            /* Update tail offset when next element is not the tail element. */
+            if ((zl+intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))) != np) {
+                ZIPLIST_TAIL_OFFSET(zl) =
+                    intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+extra);
+            }
+
+            /* Move the tail to the back. */
+            memmove(np+rawlensize,
+                np+next.prevrawlensize,
+                curlen-noffset-next.prevrawlensize-1);
+            zipPrevEncodeLength(np,rawlen);
+
+            /* Advance the cursor */
+            p += rawlen;
+            curlen += extra;
+        } else {
+            if (next.prevrawlensize > rawlensize) {
+                /* This would result in shrinking, which we want to avoid.
+                 * So, set "rawlen" in the available bytes. */
+                zipPrevEncodeLengthForceLarge(p+rawlen,rawlen);
+            } else {
+                zipPrevEncodeLength(p+rawlen,rawlen);
+            }
+
+            /* Stop here, as the raw length of "next" has not changed. */
+            break;
+        }
+    }
+    return zl;
+}
+
+/* Delete "num" entries, starting at "p". Returns pointer to the ziplist. */
+static unsigned char *__ziplistDelete(unsigned char *zl, unsigned char *p, unsigned int num) {
+    unsigned int i, totlen, deleted = 0;
+    size_t offset;
+    int nextdiff = 0;
+    zlentry first, tail;
+
+    first = zipEntry(p);
+    for (i = 0; p[0] != ZIP_END && i < num; i++) {
+        p += zipRawEntryLength(p);
+        deleted++;
+    }
+
+    totlen = p-first.p;
+    if (totlen > 0) {
+        if (p[0] != ZIP_END) {
+            /* Storing `prevrawlen` in this entry may increase or decrease the
+             * number of bytes required compare to the current `prevrawlen`.
+             * There always is room to store this, because it was previously
+             * stored by an entry that is now being deleted. */
+            nextdiff = zipPrevLenByteDiff(p,first.prevrawlen);
+            p -= nextdiff;
+            zipPrevEncodeLength(p,first.prevrawlen);
+
+            /* Update offset for tail */
+            ZIPLIST_TAIL_OFFSET(zl) =
+                intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))-totlen);
+
+            /* When the tail contains more than one entry, we need to take
+             * "nextdiff" in account as well. Otherwise, a change in the
+             * size of prevlen doesn't have an effect on the *tail* offset. */
+            tail = zipEntry(p);
+            if (p[tail.headersize+tail.len] != ZIP_END) {
+                ZIPLIST_TAIL_OFFSET(zl) =
+                   intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+nextdiff);
+            }
+
+            /* Move tail to the front of the ziplist */
+            memmove(first.p,p,
+                intrev32ifbe(ZIPLIST_BYTES(zl))-(p-zl)-1);
+        } else {
+            /* The entire tail was deleted. No need to move memory. */
+            ZIPLIST_TAIL_OFFSET(zl) =
+                intrev32ifbe((first.p-zl)-first.prevrawlen);
+        }
+
+        /* Resize and update length */
+        offset = first.p-zl;
+        zl = ziplistResize(zl, intrev32ifbe(ZIPLIST_BYTES(zl))-totlen+nextdiff);
+        ZIPLIST_INCR_LENGTH(zl,-deleted);
+        p = zl+offset;
+
+        /* When nextdiff != 0, the raw length of the next entry has changed, so
+         * we need to cascade the update throughout the ziplist */
+        if (nextdiff != 0)
+            zl = __ziplistCascadeUpdate(zl,p);
+    }
+    return zl;
+}
+
+/* Insert item at "p". */
+static unsigned char *__ziplistInsert(unsigned char *zl, unsigned char *p, unsigned char *s, unsigned int slen) {
+    size_t curlen = intrev32ifbe(ZIPLIST_BYTES(zl)), reqlen;
+    unsigned int prevlensize, prevlen = 0;
+    size_t offset;
+    int nextdiff = 0;
+    unsigned char encoding = 0;
+    long long value = 123456789; /* initialized to avoid warning. Using a value
+                                    that is easy to see if for some reason
+                                    we use it uninitialized. */
+    zlentry tail;
+
+    /* Find out prevlen for the entry that is inserted. */
+    if (p[0] != ZIP_END) {
+        ZIP_DECODE_PREVLEN(p, prevlensize, prevlen);
+    } else {
+        unsigned char *ptail = ZIPLIST_ENTRY_TAIL(zl);
+        if (ptail[0] != ZIP_END) {
+            prevlen = zipRawEntryLength(ptail);
+        }
+    }
+
+    /* See if the entry can be encoded */
+    if (zipTryEncoding(s,slen,&value,&encoding)) {
+        /* 'encoding' is set to the appropriate integer encoding */
+        reqlen = zipIntSize(encoding);
+    } else {
+        /* 'encoding' is untouched, however zipEncodeLength will use the
+         * string length to figure out how to encode it. */
+        reqlen = slen;
+    }
+    /* We need space for both the length of the previous entry and
+     * the length of the payload. */
+    reqlen += zipPrevEncodeLength(NULL,prevlen);
+    reqlen += zipEncodeLength(NULL,encoding,slen);
+
+    /* When the insert position is not equal to the tail, we need to
+     * make sure that the next entry can hold this entry's length in
+     * its prevlen field. */
+    nextdiff = (p[0] != ZIP_END) ? zipPrevLenByteDiff(p,reqlen) : 0;
+
+    /* Store offset because a realloc may change the address of zl. */
+    offset = p-zl;
+    zl = ziplistResize(zl,curlen+reqlen+nextdiff);
+    p = zl+offset;
+
+    /* Apply memory move when necessary and update tail offset. */
+    if (p[0] != ZIP_END) {
+        /* Subtract one because of the ZIP_END bytes */
+        memmove(p+reqlen,p-nextdiff,curlen-offset-1+nextdiff);
+
+        /* Encode this entry's raw length in the next entry. */
+        zipPrevEncodeLength(p+reqlen,reqlen);
+
+        /* Update offset for tail */
+        ZIPLIST_TAIL_OFFSET(zl) =
+            intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+reqlen);
+
+        /* When the tail contains more than one entry, we need to take
+         * "nextdiff" in account as well. Otherwise, a change in the
+         * size of prevlen doesn't have an effect on the *tail* offset. */
+        tail = zipEntry(p+reqlen);
+        if (p[reqlen+tail.headersize+tail.len] != ZIP_END) {
+            ZIPLIST_TAIL_OFFSET(zl) =
+                intrev32ifbe(intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl))+nextdiff);
+        }
+    } else {
+        /* This element will be the new tail. */
+        ZIPLIST_TAIL_OFFSET(zl) = intrev32ifbe(p-zl);
+    }
+
+    /* When nextdiff != 0, the raw length of the next entry has changed, so
+     * we need to cascade the update throughout the ziplist */
+    if (nextdiff != 0) {
+        offset = p-zl;
+        zl = __ziplistCascadeUpdate(zl,p+reqlen);
+        p = zl+offset;
+    }
+
+    /* Write the entry */
+    p += zipPrevEncodeLength(p,prevlen);
+    p += zipEncodeLength(p,encoding,slen);
+    if (ZIP_IS_STR(encoding)) {
+        memcpy(p,s,slen);
+    } else {
+        zipSaveInteger(p,value,encoding);
+    }
+    ZIPLIST_INCR_LENGTH(zl,1);
+    return zl;
+}
+
+unsigned char *ziplistPush(unsigned char *zl, unsigned char *s, unsigned int slen, int where) {
+    unsigned char *p;
+    p = (where == ZIPLIST_HEAD) ? ZIPLIST_ENTRY_HEAD(zl) : ZIPLIST_ENTRY_END(zl);
+    return __ziplistInsert(zl,p,s,slen);
+}
+
+/* Returns an offset to use for iterating with ziplistNext. When the given
+ * index is negative, the list is traversed back to front. When the list
+ * doesn't contain an element at the provided index, NULL is returned. */
+unsigned char *ziplistIndex(unsigned char *zl, int index) {
+    unsigned char *p;
+    unsigned int prevlensize, prevlen = 0;
+    if (index < 0) {
+        index = (-index)-1;
+        p = ZIPLIST_ENTRY_TAIL(zl);
+        if (p[0] != ZIP_END) {
+            ZIP_DECODE_PREVLEN(p, prevlensize, prevlen);
+            while (prevlen > 0 && index--) {
+                p -= prevlen;
+                ZIP_DECODE_PREVLEN(p, prevlensize, prevlen);
+            }
+        }
+    } else {
+        p = ZIPLIST_ENTRY_HEAD(zl);
+        while (p[0] != ZIP_END && index--) {
+            p += zipRawEntryLength(p);
+        }
+    }
+    return (p[0] == ZIP_END || index > 0) ? NULL : p;
+}
+
+/* Return pointer to next entry in ziplist.
+ *
+ * zl is the pointer to the ziplist
+ * p is the pointer to the current element
+ *
+ * The element after 'p' is returned, otherwise NULL if we are at the end. */
+unsigned char *ziplistNext(unsigned char *zl, unsigned char *p) {
+    ((void) zl);
+
+    /* "p" could be equal to ZIP_END, caused by ziplistDelete,
+     * and we should return NULL. Otherwise, we should return NULL
+     * when the *next* element is ZIP_END (there is no next entry). */
+    if (p[0] == ZIP_END) {
+        return NULL;
+    }
+
+    p += zipRawEntryLength(p);
+    if (p[0] == ZIP_END) {
+        return NULL;
+    }
+
+    return p;
+}
+
+/* Return pointer to previous entry in ziplist. */
+unsigned char *ziplistPrev(unsigned char *zl, unsigned char *p) {
+    unsigned int prevlensize, prevlen = 0;
+
+    /* Iterating backwards from ZIP_END should return the tail. When "p" is
+     * equal to the first element of the list, we're already at the head,
+     * and should return NULL. */
+    if (p[0] == ZIP_END) {
+        p = ZIPLIST_ENTRY_TAIL(zl);
+        return (p[0] == ZIP_END) ? NULL : p;
+    } else if (p == ZIPLIST_ENTRY_HEAD(zl)) {
+        return NULL;
+    } else {
+        ZIP_DECODE_PREVLEN(p, prevlensize, prevlen);
+        assert(prevlen > 0);
+        return p-prevlen;
+    }
+}
+
+/* Get entry pointed to by 'p' and store in either '*sstr' or 'sval' depending
+ * on the encoding of the entry. '*sstr' is always set to NULL to be able
+ * to find out whether the string pointer or the integer value was set.
+ * Return 0 if 'p' points to the end of the ziplist, 1 otherwise. */
+unsigned int ziplistGet(unsigned char *p, unsigned char **sstr, unsigned int *slen, long long *sval) {
+    zlentry entry;
+    if (p == NULL || p[0] == ZIP_END) return 0;
+    if (sstr) *sstr = NULL;
+
+    entry = zipEntry(p);
+    if (ZIP_IS_STR(entry.encoding)) {
+        if (sstr) {
+            *slen = entry.len;
+            *sstr = p+entry.headersize;
+        }
+    } else {
+        if (sval) {
+            *sval = zipLoadInteger(p+entry.headersize,entry.encoding);
+        }
+    }
+    return 1;
+}
+
+/* Insert an entry at "p". */
+unsigned char *ziplistInsert(unsigned char *zl, unsigned char *p, unsigned char *s, unsigned int slen) {
+    return __ziplistInsert(zl,p,s,slen);
+}
+
+/* Delete a single entry from the ziplist, pointed to by *p.
+ * Also update *p in place, to be able to iterate over the
+ * ziplist, while deleting entries. */
+unsigned char *ziplistDelete(unsigned char *zl, unsigned char **p) {
+    size_t offset = *p-zl;
+    zl = __ziplistDelete(zl,*p,1);
+
+    /* Store pointer to current element in p, because ziplistDelete will
+     * do a realloc which might result in a different "zl"-pointer.
+     * When the delete direction is back to front, we might delete the last
+     * entry and end up with "p" pointing to ZIP_END, so check this. */
+    *p = zl+offset;
+    return zl;
+}
+
+/* Delete a range of entries from the ziplist. */
+unsigned char *ziplistDeleteRange(unsigned char *zl, unsigned int index, unsigned int num) {
+    unsigned char *p = ziplistIndex(zl,index);
+    return (p == NULL) ? zl : __ziplistDelete(zl,p,num);
+}
+
+/* Compare entry pointer to by 'p' with 'sstr' of length 'slen'. */
+/* Return 1 if equal. */
+unsigned int ziplistCompare(unsigned char *p, unsigned char *sstr, unsigned int slen) {
+    zlentry entry;
+    unsigned char sencoding;
+    long long zval, sval;
+    if (p[0] == ZIP_END) return 0;
+
+    entry = zipEntry(p);
+    if (ZIP_IS_STR(entry.encoding)) {
+        /* Raw compare */
+        if (entry.len == slen) {
+            return memcmp(p+entry.headersize,sstr,slen) == 0;
+        } else {
+            return 0;
+        }
+    } else {
+        /* Try to compare encoded values. Don't compare encoding because
+         * different implementations may encoded integers differently. */
+        if (zipTryEncoding(sstr,slen,&sval,&sencoding)) {
+          zval = zipLoadInteger(p+entry.headersize,entry.encoding);
+          return zval == sval;
+        }
+    }
+    return 0;
+}
+
+/* Find pointer to the entry equal to the specified entry. Skip 'skip' entries
+ * between every comparison. Returns NULL when the field could not be found. */
+unsigned char *ziplistFind(unsigned char *p, unsigned char *vstr, unsigned int vlen, unsigned int skip) {
+    int skipcnt = 0;
+    unsigned char vencoding = 0;
+    long long vll = 0;
+
+    while (p[0] != ZIP_END) {
+        unsigned int prevlensize, encoding, lensize = 0, len = 0;
+        unsigned char *q;
+
+        ZIP_DECODE_PREVLENSIZE(p, prevlensize);
+        ZIP_DECODE_LENGTH(p + prevlensize, encoding, lensize, len);
+        q = p + prevlensize + lensize;
+
+        if (skipcnt == 0) {
+            /* Compare current entry with specified entry */
+            if (ZIP_IS_STR(encoding)) {
+                if (len == vlen && memcmp(q, vstr, vlen) == 0) {
+                    return p;
+                }
+            } else {
+                /* Find out if the searched field can be encoded. Note that
+                 * we do it only the first time, once done vencoding is set
+                 * to non-zero and vll is set to the integer value. */
+                if (vencoding == 0) {
+                    if (!zipTryEncoding(vstr, vlen, &vll, &vencoding)) {
+                        /* If the entry can't be encoded we set it to
+                         * UCHAR_MAX so that we don't retry again the next
+                         * time. */
+                        vencoding = UCHAR_MAX;
+                    }
+                    /* Must be non-zero by now */
+                    assert(vencoding);
+                }
+
+                /* Compare current entry with specified entry, do it only
+                 * if vencoding != UCHAR_MAX because if there is no encoding
+                 * possible for the field it can't be a valid integer. */
+                if (vencoding != UCHAR_MAX) {
+                    long long ll = zipLoadInteger(q, encoding);
+                    if (ll == vll) {
+                        return p;
+                    }
+                }
+            }
+
+            /* Reset skip count */
+            skipcnt = skip;
+        } else {
+            /* Skip entry */
+            skipcnt--;
+        }
+
+        /* Move to next entry */
+        p = q + len;
+    }
+
+    return NULL;
+}
+
+/* Return length of ziplist. */
+unsigned int ziplistLen(unsigned char *zl) {
+    unsigned int len = 0;
+    if (intrev16ifbe(ZIPLIST_LENGTH(zl)) < UINT16_MAX) {
+        len = intrev16ifbe(ZIPLIST_LENGTH(zl));
+    } else {
+        unsigned char *p = zl+ZIPLIST_HEADER_SIZE;
+        while (*p != ZIP_END) {
+            p += zipRawEntryLength(p);
+            len++;
+        }
+
+        /* Re-store length if small enough */
+        if (len < UINT16_MAX) ZIPLIST_LENGTH(zl) = intrev16ifbe(len);
+    }
+    return len;
+}
+
+/* Return ziplist blob size in bytes. */
+size_t ziplistBlobLen(unsigned char *zl) {
+    return intrev32ifbe(ZIPLIST_BYTES(zl));
+}
+
+void ziplistRepr(unsigned char *zl) {
+    unsigned char *p;
+    int index = 0;
+    zlentry entry;
+
+    printf(
+        "{total bytes %d} "
+        "{length %u}\n"
+        "{tail offset %u}\n",
+        intrev32ifbe(ZIPLIST_BYTES(zl)),
+        intrev16ifbe(ZIPLIST_LENGTH(zl)),
+        intrev32ifbe(ZIPLIST_TAIL_OFFSET(zl)));
+    p = ZIPLIST_ENTRY_HEAD(zl);
+    while(*p != ZIP_END) {
+        entry = zipEntry(p);
+        printf(
+            "{"
+                "addr 0x%08lx, "
+                "index %2d, "
+                "offset %5ld, "
+                "rl: %5u, "
+                "hs %2u, "
+                "pl: %5u, "
+                "pls: %2u, "
+                "payload %5u"
+            "} ",
+            (long unsigned)p,
+            index,
+            (unsigned long) (p-zl),
+            entry.headersize+entry.len,
+            entry.headersize,
+            entry.prevrawlen,
+            entry.prevrawlensize,
+            entry.len);
+        p += entry.headersize;
+        if (ZIP_IS_STR(entry.encoding)) {
+            if (entry.len > 40) {
+                if (fwrite(p,40,1,stdout) == 0) perror("fwrite");
+                printf("...");
+            } else {
+                if (entry.len &&
+                    fwrite(p,entry.len,1,stdout) == 0) perror("fwrite");
+            }
+        } else {
+            printf("%lld", (long long) zipLoadInteger(p,entry.encoding));
+        }
+        printf("\n");
+        p += entry.len;
+        index++;
+    }
+    printf("{end}\n\n");
+}


### PR DESCRIPTION
slotsrestore功能主要用于扩容后清理数据用，扩容后检查更新，防止在机器重启或者各种异常场景下出现数据未做清理的场景出现，清理非该slot上的key的数据用的