### PR TITLE
fix: clean-dir tcl

### DIFF
--- a/pikatests.sh
+++ b/pikatests.sh
@@ -2,8 +2,8 @@
 
 # clear the log file
 function cleanup() {
-    rm -rf ./log
-    rm -rf db
+    rm -rf ./log[0-9]*
+    rm -rf ./db[0-9]*
     rm -rf dbsync/
     rm src/redis-server
 }
@@ -70,4 +70,9 @@ if [ $? -ne 0 ]; then
     cleanup
     exit 1
 fi
-cleanup
+
+# You can use './pikatests.sh all clean 'to ensure that the
+# data can be deleted immediately after the test
+if [ "$2" == "clean" ]; then
+   cleanup
+fi


### PR DESCRIPTION
在执行 `./pikatest.sh` 跑 `TCL` 测试的时候，测试过程中产生的数据会存放在相应的文件夹下面，如果你希望在测试完之后立即删除文件夹，可以把 `cleanup` 注释打开，大多数时候在测试过程中发现了问题，我们需要在指定文件夹下面进行问题追溯，所以默认情况下 `cleanup` 是注释掉的，为了区分测试建立的文件夹和平常使用 `Pika` 是建立的 `DB` 文件夹，在 `TCL` 测试中建立的文件夹后面接了数字，例如 `db10233`, 所以删除这部分文件夹的时候使用的通配符避免误删了正常使用 `Pika` 的 `DB` 文件夹

When running the TCL test, the data generated during the test will be stored in the corresponding folder. If you want to delete the temporary folder generated by the test immediately after the test is finished, you can use './pikatest.sh all clean '. Add a clean parameter, most of the time problems are found in the test process, we need to trace the problem under the specified folder, in order to distinguish the folder created in the test and the DB folder created by ordinary Pika, the folder created in the TCL test is followed by a number. For example, db10233, so the wildcard character used when deleting this part of the folder to avoid accidentally deleting the DB folder that normally uses Pika

fix: #2454