### PR TITLE
fix: fix exit

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -44,7 +44,6 @@ jobs:
           key: ${{ runner.os }}-build-ubuntu-${{ hashFiles('**/CMakeLists.txt') }}
           path: |
             ${{ github.workspace }}/buildtrees
-            ${{ github.workspace }}/deps
 
       - name: Build
         # Build your program with the given configuration

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -207,7 +207,6 @@ void PikaServer::Start() {
 
 void PikaServer::Exit() {
   g_pika_server->DisableCompact();
-  exit_mutex_.unlock();
   exit_ = true;
 }
 


### PR DESCRIPTION
`exit_`是原子变量，不需要用锁来保护

<img width="621" alt="截屏2024-03-26 12 30 40" src="https://github.com/OpenAtomFoundation/pika/assets/73943232/086ca911-ddc5-44a8-a912-74aaf40522f5">

在 `shutdown`命令和 `IntSigHandle` 中会调用这个 `Exit` ，发现这把锁在这里解锁是没有意义的