### PR TITLE
feat: stat disk usage in bg thread

### DIFF
--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -272,9 +272,6 @@ class InfoCmd : public Cmd {
   bool rescan_ = false;  // whether to rescan the keyspace
   bool off_ = false;
   std::set<std::string> keyspace_scan_dbs_;
-  time_t db_size_last_time_ = 0;
-  uint64_t db_size_ = 0;
-  uint64_t log_size_ = 0;
   const static std::string kInfoSection;
   const static std::string kAllSection;
   const static std::string kServerSection;

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -262,6 +262,16 @@ class PikaServer : public pstd::noncopyable {
   std::unordered_map<std::string, QpsStatistic> ServerAllDBStat();
 
   /*
+   * Memory and Disk usage statistic
+   */
+  uint64_t GetDBSize() const {
+    return disk_statistic_.db_size_.load();
+  }
+  uint64_t GetLogSize() const {
+    return disk_statistic_.log_size_.load();
+  }
+
+  /*
    * Network Statistic used
    */
   size_t NetInputBytes();
@@ -504,6 +514,7 @@ class PikaServer : public pstd::noncopyable {
   void AutoDeleteExpiredDump();
   void AutoUpdateNetworkMetric();
   void PrintThreadPoolQueueStatus();
+  void StatDiskUsage();
   int64_t GetLastSaveTime(const std::string& dump_dir);
 
   std::string host_;
@@ -609,6 +620,8 @@ class PikaServer : public pstd::noncopyable {
    * Statistic used
    */
   Statistic statistic_;
+
+  DiskStatistic disk_statistic_;
 
   net::BGThread common_bg_thread_;
 

--- a/include/pika_statistic.h
+++ b/include/pika_statistic.h
@@ -57,4 +57,9 @@ struct Statistic {
   std::unordered_map<std::string, QpsStatistic> db_stat;
 };
 
+struct DiskStatistic {
+  std::atomic<uint64_t> db_size_ = 0;
+  std::atomic<uint64_t> log_size_ = 0;
+};
+
 #endif  // PIKA_STATISTIC_H_

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1311,20 +1311,10 @@ void InfoCmd::InfoKeyspace(std::string& info) {
 void InfoCmd::InfoData(std::string& info) {
   std::stringstream tmp_stream;
   std::stringstream db_fatal_msg_stream;
-  uint64_t db_size = 0;
-  time_t current_time_s = time(nullptr);
-  uint64_t log_size = 0;
 
-  if (current_time_s - 60 >= db_size_last_time_) {
-    db_size_last_time_ = current_time_s;
-    db_size = pstd::Du(g_pika_conf->db_path());
-    db_size_ = db_size;
-    log_size = pstd::Du(g_pika_conf->log_path());
-    log_size_ = log_size;
-  } else {
-    db_size = db_size_;
-    log_size = log_size_;
-  }
+  uint64_t db_size = g_pika_server->GetDBSize();
+  uint64_t log_size = g_pika_server->GetLogSize();
+
   tmp_stream << "# Data"
              << "\r\n";
   tmp_stream << "db_size:" << db_size << "\r\n";

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1093,7 +1093,26 @@ void PikaServer::DoTimingTask() {
   UpdateCacheInfo();
   // Print the queue status periodically
   PrintThreadPoolQueueStatus();
+  StatDiskUsage();
+}
 
+void PikaServer::StatDiskUsage() {
+  thread_local uint64_t last_update_time = 0;
+  if (pstd::NowMicros() - last_update_time < 60 * 1000 * 1000) {
+    return;
+  }
+
+  last_update_time = pstd::NowMicros();
+  std::stringstream tmp_stream;
+  std::stringstream db_fatal_msg_stream;
+  uint64_t db_size = 0;
+  time_t current_time_s = time(nullptr);
+  uint64_t log_size = 0;
+
+  db_size = pstd::Du(g_pika_conf->db_path());
+  disk_statistic_.db_size_.store(db_size);
+  log_size = pstd::Du(g_pika_conf->log_path());
+  disk_statistic_.log_size_.store(log_size);
 }
 
 void PikaServer::AutoCompactRange() {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1103,16 +1103,8 @@ void PikaServer::StatDiskUsage() {
   }
 
   last_update_time = pstd::NowMicros();
-  std::stringstream tmp_stream;
-  std::stringstream db_fatal_msg_stream;
-  uint64_t db_size = 0;
-  time_t current_time_s = time(nullptr);
-  uint64_t log_size = 0;
-
-  db_size = pstd::Du(g_pika_conf->db_path());
-  disk_statistic_.db_size_.store(db_size);
-  log_size = pstd::Du(g_pika_conf->log_path());
-  disk_statistic_.log_size_.store(log_size);
+  disk_statistic_.db_size_.store(pstd::Du(g_pika_conf->db_path()));
+  disk_statistic_.log_size_.store(pstd::Du(g_pika_conf->log_path()));
 }
 
 void PikaServer::AutoCompactRange() {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1098,11 +1098,12 @@ void PikaServer::DoTimingTask() {
 
 void PikaServer::StatDiskUsage() {
   thread_local uint64_t last_update_time = 0;
-  if (pstd::NowMicros() - last_update_time < 60 * 1000 * 1000) {
+  auto current_time = pstd::NowMicros();
+  if (current_time - last_update_time < 60 * 1000 * 1000) {
     return;
   }
+  last_update_time = current_time;
 
-  last_update_time = pstd::NowMicros();
   disk_statistic_.db_size_.store(pstd::Du(g_pika_conf->db_path()));
   disk_statistic_.log_size_.store(pstd::Du(g_pika_conf->log_path()));
 }


### PR DESCRIPTION
info all统计磁盘占比的命令，在db中文件较多时，耗时会达到十几ms。
将这一部分统计操作交由后台线程执行，1min执行一次。