### PR TITLE
feat: support dynamic change max-total-wal-size

### DIFF
--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -162,6 +162,10 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return max_write_buffer_num_;
   }
+  uint64_t MaxTotalWalSize() {
+    std::shared_lock l(rwlock_);
+    return max_total_wal_size_;
+  } 
   int64_t max_client_response_size() {
     std::shared_lock l(rwlock_);
     return max_client_response_size_;
@@ -670,6 +674,11 @@ class PikaConf : public pstd::BaseConf {
     TryPushDiffCommands("max-write-buffer-num", std::to_string(value));
     max_write_buffer_num_ = value;
   }
+  void SetMaxTotalWalSize(uint64_t value) {
+    std::lock_guard l(rwlock_);
+    TryPushDiffCommands("max-total-wal-size", std::to_string(value));
+    max_total_wal_size_ = value;
+  }
   void SetArenaBlockSize(const int& value) {
     std::lock_guard l(rwlock_);
     TryPushDiffCommands("arena-block-size", std::to_string(value));
@@ -765,6 +774,7 @@ class PikaConf : public pstd::BaseConf {
   int64_t slotmigrate_thread_num_ = 0;
   int64_t thread_migrate_keys_num_ = 0;
   int64_t max_write_buffer_size_ = 0;
+  int64_t max_total_wal_size_ = 0;
   int max_write_buffer_num_ = 0;
   int min_write_buffer_number_to_merge_ = 1;
   int level0_stop_writes_trigger_ =  36;

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1317,6 +1317,7 @@ void PikaServer::InitStorageOptions() {
   storage_options_.options.arena_block_size = g_pika_conf->arena_block_size();
   storage_options_.options.write_buffer_manager =
       std::make_shared<rocksdb::WriteBufferManager>(g_pika_conf->max_write_buffer_size());
+  storage_options_.options.max_total_wal_size = g_pika_conf->MaxTotalWalSize();
   storage_options_.options.max_write_buffer_number = g_pika_conf->max_write_buffer_number();
   storage_options_.options.level0_file_num_compaction_trigger = g_pika_conf->level0_file_num_compaction_trigger();
   storage_options_.options.level0_stop_writes_trigger = g_pika_conf->level0_stop_writes_trigger();


### PR DESCRIPTION
max-total-wal-size用来限制了wal总数据量，默认值是buffer-size * columnfamily_num * write_buffer_number * 4。在不同columnfamily数据写入频率不同的时候，可能存在某一个columnfamily只有少量数据写入无法执行flush导致其对应的wal log一直存在，当进程重启时，recover log的数据量最大为buffer-size * columnfamily_num * write_buffer_number * 4。由于当前是串行启动多个rocksdb，因此导致rocksdb open时间过长。
通过限制rocksdb中的wal文件总数量，减少recover log数据量。