### PR TITLE
fix: Revert "fix version compare error in ZSetsScoreKeyComparatorImpl"

### DIFF
--- a/src/storage/src/custom_comparator.h
+++ b/src/storage/src/custom_comparator.h
@@ -99,22 +99,14 @@ class ZSetsScoreKeyComparatorImpl : public rocksdb::Comparator {
     auto b_size = static_cast<int32_t>(b.size());
     int32_t key_a_len = DecodeFixed32(ptr_a);
     int32_t key_b_len = DecodeFixed32(ptr_b);
-    rocksdb::Slice key_a_prefix(ptr_a, key_a_len + sizeof(int32_t));
-    rocksdb::Slice key_b_prefix(ptr_b, key_b_len + sizeof(int32_t));
-    ptr_a += key_a_len + sizeof(int32_t);
-    ptr_b += key_b_len + sizeof(int32_t);
+    rocksdb::Slice key_a_prefix(ptr_a, key_a_len + 2 * sizeof(int32_t));
+    rocksdb::Slice key_b_prefix(ptr_b, key_b_len + 2 * sizeof(int32_t));
+    ptr_a += key_a_len + 2 * sizeof(int32_t);
+    ptr_b += key_b_len + 2 * sizeof(int32_t);
     int ret = key_a_prefix.compare(key_b_prefix);
      if (ret) {
       return ret;
     }
-
-    int32_t version_a = DecodeFixed32(ptr_a);
-    int32_t version_b = DecodeFixed32(ptr_b);
-    if (version_a != version_b) {
-      return version_a < version_b ? -1 : 1;
-    }
-    ptr_a += sizeof(int32_t);
-    ptr_b += sizeof(int32_t);
 
     uint64_t a_i = DecodeFixed64(ptr_a);
     uint64_t b_i = DecodeFixed64(ptr_b);

--- a/src/storage/tests/custom_comparator_test.cc
+++ b/src/storage/tests/custom_comparator_test.cc
@@ -143,13 +143,6 @@ TEST(ZSetScoreKeyComparator, FindShortestSeparatorTest) {
   // printf("**********************************************************************\n");
   ASSERT_TRUE(impl.Compare(change_start_9, start_9) >= 0);
   ASSERT_TRUE(impl.Compare(change_start_9, limit_9) < 0);
-
-  // ***************** Group 10 Test *****************
-  ZSetsScoreKey zsets_score_key_start_10("Axlgrep", 1557212502, 3.1415, "abc");
-  ZSetsScoreKey zsets_score_key_limit_10("Axlgrep", 1557212752, 3.1415, "abc");
-  std::string start_10 = zsets_score_key_start_10.Encode().ToString();
-  std::string limit_10 = zsets_score_key_limit_10.Encode().ToString();
-  ASSERT_TRUE(impl.Compare(start_10, limit_10) < 0);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This reverts commit e787effc3b665fe0d042d29ea32bd96ea6b9b69a.

之前发现zsetscorekeycomparatorimpl中直接通过字典序比较version，在小端环境下结果是错误的，提了issue：https://github.com/OpenAtomFoundation/pika/issues/2338，也提了pr修复。
但修复后comparator结果虽然是正确的，但是跟之前不兼容，所以rocksdb在compact时会报错“Compaction sees out-of-order keys.”
所以暂时先回滚该commit，优先保证数据兼容性。