### PR TITLE
fix:Revise the value check for max-rsync-parallel-num to prevent a core dump when it is set to a value greater than 4

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -458,6 +458,9 @@ default-slot-num : 1024
 
 # Rsync Rate limiting configuration 200MB/s
 throttle-bytes-per-second : 207200000
+
+# The valid range for max-rsync-parallel-num is [1, 4].
+# If an invalid value is provided, max-rsync-parallel-num will automatically be reset to 4.
 max-rsync-parallel-num : 4
 
 # The synchronization mode of Pika primary/secondary replication is determined by ReplicationID. ReplicationID in one replication_cluster are the same

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -897,7 +897,7 @@ class PikaConf : public pstd::BaseConf {
 
   // Rsync Rate limiting configuration
   int throttle_bytes_per_second_ = 207200000;
-  int max_rsync_parallel_num_ = 4;
+  int max_rsync_parallel_num_ = kMaxRsyncParallelNum;
 };
 
 #endif

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2600,7 +2600,7 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
     g_pika_conf->SetThrottleBytesPerSecond(static_cast<int>(ival));
     res_.AppendStringRaw("+OK\r\n");
   } else if (set_item == "max-rsync-parallel-num") {
-    if ((pstd::string2int(value.data(), value.size(), &ival) == 0) || ival > kMaxRsyncParallelNum) {
+    if ((pstd::string2int(value.data(), value.size(), &ival) == 0) || ival > kMaxRsyncParallelNum || ival <= 0) {
       res_.AppendStringRaw( "-ERR Invalid argument \'" + value + "\' for CONFIG SET 'max-rsync-parallel-num'\r\n");
       return;
     }

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -622,7 +622,7 @@ int PikaConf::Load() {
 
   GetConfInt("max-rsync-parallel-num", &max_rsync_parallel_num_);
   if (max_rsync_parallel_num_ <= 0 || max_rsync_parallel_num_ > kMaxRsyncParallelNum) {
-    max_rsync_parallel_num_ = 4;
+    max_rsync_parallel_num_ = kMaxRsyncParallelNum;
   }
 
   return ret;

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -621,7 +621,7 @@ int PikaConf::Load() {
   }
 
   GetConfInt("max-rsync-parallel-num", &max_rsync_parallel_num_);
-  if (max_rsync_parallel_num_ <= 0) {
+  if (max_rsync_parallel_num_ <= 0 || max_rsync_parallel_num_ > 4) {
     max_rsync_parallel_num_ = 4;
   }
 

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -621,7 +621,7 @@ int PikaConf::Load() {
   }
 
   GetConfInt("max-rsync-parallel-num", &max_rsync_parallel_num_);
-  if (max_rsync_parallel_num_ <= 0 || max_rsync_parallel_num_ > 4) {
+  if (max_rsync_parallel_num_ <= 0 || max_rsync_parallel_num_ > kMaxRsyncParallelNum) {
     max_rsync_parallel_num_ = 4;
   }
 


### PR DESCRIPTION
fix #2594 
Revise the value check for max-rsync-parallel-num to prevent a core dump when it is set to a value greater than 4