### PR TITLE
fix: Ensure gperftools linked to libunwind in deps when local libunwind exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     LOG_INSTALL
     1
     CONFIGURE_COMMAND
-    <SOURCE_DIR>/configure --prefix=${STAGED_INSTALL_PREFIX} --enable-minidebuginfo=no --enable-zlibdebuginfo=no --enable-shared=no
+    <SOURCE_DIR>/configure --prefix=${STAGED_INSTALL_PREFIX} --enable-minidebuginfo=no --enable-zlibdebuginfo=no --enable-shared=no --with-pic
     BUILD_IN_SOURCE
     1
     BUILD_COMMAND
@@ -488,8 +488,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
     -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
     -DGPERFTOOLS_BUILD_STATIC=ON
-    -DEFAULT_BUILD_MINIMAL=ON
+    -DDEFAULT_BUILD_MINIMAL=ON
     -Dgperftools_build_benchmark=OFF
+    -DCMAKE_PREFIX_PATH=${INSTALL_LIBDIR}
     BUILD_COMMAND
     make -j${CPU_CORE}
   )


### PR DESCRIPTION
Fix compilation failed in ubuntu 22.04 where local libunwind exist. In ubuntu 22.04, if user has libunwind in local env with latest version 1.3.2:

❯ pkg-config --modversion libunwind
1.3.2

❯ apt-cache madison libunwind-dev
libunwind-dev | 1.3.2-2build2.1 | https://mirrors.tuna.tsinghua.edu.cn/ubuntu jammy-updates/main amd64 Packages

The gperftools will linked to libunwind in /usr/local/lib first, which lack of some necessary symbols like:

undefined reference to `_Ux86_64_getcontext'

❯ nm /usr/local/lib/libunwind.a| grep _Ux86_64_getcontext

In unwind we build, the symbol exists:

❯ nm deps/lib/libunwind.a| grep _Ux86_64_getcontext
                 U _Ux86_64_getcontext
                 U _Ux86_64_getcontext_trace
0000000000000000 T _Ux86_64_getcontext
0000000000000071 T _Ux86_64_getcontext_trace

So let's link to unwind we build, and add fPIC to unwind building.

Also fix -DDefaultxxx instead of -Default, maybe a typo.