### PR TITLE
fix: Reconstruct slave sync thread model

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -40,7 +40,7 @@ sync-thread-num : 6
 
 # The num of threads to write binlog in slaveNode when replicating,
 # each DB cloud only bind to one sync-binlog-thread to write binlog in maximum
-#[NOTICE] It's highly recommended to set sync_binlog_thread_num_ equal to database_(then each DB cloud have a exclusive thread to write binlog),
+#[NOTICE] It's highly recommended to set sync-binlog-thread-num equal to conf item 'database'(then each DB cloud have a exclusive thread to write binlog),
 # eg. if you use 8 DBs(databases_ is 8), sync-binlog-thread-num is preferable to be 8
 # Valid range of sync-binlog-thread-num is [1, databases], the final value of it is Min(sync-binlog-thread-num, databases)
 sync-binlog-thread-num : 1

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -34,9 +34,16 @@ slow-cmd-thread-pool-size : 1
 # Slow cmd list e.g. hgetall, mset
 slow-cmd-list :
 
-# The number of sync-thread for data replication from master, those are the threads work on slave nodes
-# and are used to execute commands sent from master node when replicating.
+# The number of threads to write DB in slaveNode when replicating.
+# It's preferable to set slave's sync-thread-num value close to master's thread-pool-size.
 sync-thread-num : 6
+
+# The num of threads to write binlog in slaveNode when replicating,
+# each DB cloud only bind to one sync-binlog-thread to write binlog in maximum
+#[NOTICE] It's highly recommended to set sync_binlog_thread_num_ equal to database_(then each DB cloud have a exclusive thread to write binlog),
+# eg. if you use 8 DBs(databases_ is 8), sync-binlog-thread-num is preferable to be 8
+# Valid range of sync-binlog-thread-num is [1, databases], the final value of it is Min(sync-binlog-thread-num, databases)
+sync-binlog-thread-num : 1
 
 # Directory to store log files of Pika, which contains multiple types of logs,
 # Including: INFO, WARNING, ERROR log, as well as binglog(write2fine) file which
@@ -101,6 +108,8 @@ instance-mode : classic
 # The default database id is DB 0. You can select a different one on
 # a per-connection by using SELECT. The db id range is [0, 'databases' value -1].
 # The value range of this parameter is [1, 8].
+# [NOTICE] It's RECOMMENDED to set sync-binlog-thread-num equal to DB num(databases),
+# if you've changed the value of databases, remember to check if the value of sync-binlog-thread-num is proper.
 databases : 1
 
 # The number of followers of a master. Only [0, 1, 2, 3, 4] is valid at present.

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -65,6 +65,10 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return sync_thread_num_;
   }
+  int sync_binlog_thread_num() {
+    std::shared_lock l(rwlock_);
+    return sync_binlog_thread_num_;
+  }
   std::string log_path() {
     std::shared_lock l(rwlock_);
     return log_path_;
@@ -784,6 +788,7 @@ class PikaConf : public pstd::BaseConf {
   int slow_cmd_thread_pool_size_ = 0;
   std::unordered_set<std::string> slow_cmd_set_;
   int sync_thread_num_ = 0;
+  int sync_binlog_thread_num_ = 0;
   int expire_dump_days_ = 3;
   int db_sync_speed_ = 0;
   std::string slaveof_;

--- a/include/pika_define.h
+++ b/include/pika_define.h
@@ -30,6 +30,8 @@
 #define PIKA_SERVER_ID_MAX 65535
 
 class PikaServer;
+/* Global Const */
+constexpr int MAX_DB_NUM = 8;
 
 /* Port shift */
 const int kPortShiftRSync = 1000;

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -65,6 +65,7 @@ class PikaReplClient {
   pstd::Status Close(const std::string& ip, int port);
 
   void Schedule(net::TaskFunc func, void* arg);
+  void ScheduleByDBName(net::TaskFunc func, void* arg, const std::string& db_name);
   void ScheduleWriteBinlogTask(const std::string& db_name, const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                const std::shared_ptr<net::PbConn>& conn, void* res_private_data);
   void ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const LogOffset& offset, const std::string& db_name);
@@ -80,6 +81,7 @@ class PikaReplClient {
   pstd::Status SendRemoveSlaveNode(const std::string& ip, uint32_t port, const std::string& db_name, const std::string& local_ip);
 
  private:
+  size_t GetBinlogWorkerIndexByDBName(const std::string &db_name);
   size_t GetHashIndexByKey(const std::string& key);
   void UpdateNextAvail() { next_avail_ = (next_avail_ + 1) % static_cast<int32_t>(write_binlog_workers_.size()); }
 

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -80,13 +80,14 @@ class PikaReplClient {
   pstd::Status SendRemoveSlaveNode(const std::string& ip, uint32_t port, const std::string& db_name, const std::string& local_ip);
 
  private:
-  size_t GetHashIndex(const std::string& key, bool upper_half);
-  void UpdateNextAvail() { next_avail_ = (next_avail_ + 1) % static_cast<int32_t>(bg_workers_.size()); }
+  size_t GetHashIndexByKey(const std::string& key);
+  void UpdateNextAvail() { next_avail_ = (next_avail_ + 1) % static_cast<int32_t>(write_binlog_workers_.size()); }
 
   std::unique_ptr<PikaReplClientThread> client_thread_;
   int next_avail_ = 0;
   std::hash<std::string> str_hash;
-  std::vector<std::unique_ptr<PikaReplBgWorker>> bg_workers_;
+  std::vector<std::unique_ptr<PikaReplBgWorker>> write_binlog_workers_;
+  std::vector<std::unique_ptr<PikaReplBgWorker>> write_db_workers_;
 };
 
 #endif

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -182,6 +182,7 @@ class PikaReplicaManager {
                                const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                const std::shared_ptr<net::PbConn>& conn, void* res_private_data);
   void ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const LogOffset& offset, const std::string& db_name);
+  void ScheduleReplClientBGTaskByDBName(net::TaskFunc , void* arg, const std::string &db_name);
   void ReplServerRemoveClientConn(int fd);
   void ReplServerUpdateClientConnMap(const std::string& ip_port, int fd);
 

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -971,6 +971,7 @@ void InfoCmd::InfoServer(std::string& info) {
   tmp_stream << "tcp_port:" << g_pika_conf->port() << "\r\n";
   tmp_stream << "thread_num:" << g_pika_conf->thread_num() << "\r\n";
   tmp_stream << "sync_thread_num:" << g_pika_conf->sync_thread_num() << "\r\n";
+  tmp_stream << "sync_binlog_thread_num:" << g_pika_conf->sync_binlog_thread_num() << "\r\n";
   tmp_stream << "uptime_in_seconds:" << (current_time_s - g_pika_server->start_time_s()) << "\r\n";
   tmp_stream << "uptime_in_days:" << (current_time_s / (24 * 3600) - g_pika_server->start_time_s() / (24 * 3600) + 1)
              << "\r\n";
@@ -1515,6 +1516,12 @@ void ConfigCmd::ConfigGet(std::string& ret) {
     EncodeString(&config_body, "sync-thread-num");
     EncodeNumber(&config_body, g_pika_conf->sync_thread_num());
   }
+
+  if (pstd::stringmatch(pattern.data(), "sync-binlog-thread-num", 1) != 0) {
+     elements += 2;
+     EncodeString(&config_body, "sync-binlog-thread-num");
+     EncodeNumber(&config_body, g_pika_conf->sync_binlog_thread_num());
+    }
 
   if (pstd::stringmatch(pattern.data(), "log-path", 1) != 0) {
     elements += 2;

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -185,6 +185,15 @@ int PikaConf::Load() {
   }
   default_db_ = db_structs_[0].db_name;
 
+  // sync_binlog_thread_num_ must be set after the setting of databases_
+  GetConfInt("sync-binlog-thread-num", &sync_binlog_thread_num_);
+  if (sync_binlog_thread_num_ <= 0){
+      sync_binlog_thread_num_ = databases_;
+  }else {
+      // final value is MIN(sync_binlog_thread_num, databases_)
+      sync_binlog_thread_num_ = sync_binlog_thread_num_ > databases_ ?  databases_ : sync_binlog_thread_num_;
+  }
+
   int tmp_replication_num = 0;
   GetConfInt("replication-num", &tmp_replication_num);
   if (tmp_replication_num > 4 || tmp_replication_num < 0) {

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -176,7 +176,7 @@ int PikaConf::Load() {
 
   if (classic_mode_.load()) {
     GetConfInt("databases", &databases_);
-    if (databases_ < 1 || databases_ > 8) {
+    if (databases_ < 1 || databases_ > MAX_DB_NUM) {
       LOG(FATAL) << "config databases error, limit [1 ~ 8], the actual is: " << databases_;
     }
     for (int idx = 0; idx < databases_; ++idx) {
@@ -187,9 +187,9 @@ int PikaConf::Load() {
 
   // sync_binlog_thread_num_ must be set after the setting of databases_
   GetConfInt("sync-binlog-thread-num", &sync_binlog_thread_num_);
-  if (sync_binlog_thread_num_ <= 0){
+  if (sync_binlog_thread_num_ <= 0) {
       sync_binlog_thread_num_ = databases_;
-  }else {
+  } else {
       // final value is MIN(sync_binlog_thread_num, databases_)
       sync_binlog_thread_num_ = sync_binlog_thread_num_ > databases_ ?  databases_ : sync_binlog_thread_num_;
   }

--- a/src/pika_repl_client.cc
+++ b/src/pika_repl_client.cc
@@ -27,8 +27,11 @@ extern std::unique_ptr<PikaReplicaManager> g_pika_rm;
 PikaReplClient::PikaReplClient(int cron_interval, int keepalive_timeout)  {
   client_thread_ = std::make_unique<PikaReplClientThread>(cron_interval, keepalive_timeout);
   client_thread_->set_thread_name("PikaReplClient");
-  for (int i = 0; i < 2 * g_pika_conf->sync_thread_num(); ++i) {
-    bg_workers_.push_back(std::make_unique<PikaReplBgWorker>(PIKA_SYNC_BUFFER_SIZE));
+  for(int i = 0; i < g_pika_conf->databases(); i++){
+      write_binlog_workers_.push_back(std::make_unique<PikaReplBgWorker>(PIKA_SYNC_BUFFER_SIZE));
+  }
+  for (int i = 0; i < g_pika_conf->sync_thread_num(); ++i) {
+    write_db_workers_.push_back(std::make_unique<PikaReplBgWorker>(PIKA_SYNC_BUFFER_SIZE));
   }
 }
 
@@ -43,49 +46,66 @@ int PikaReplClient::Start() {
     LOG(FATAL) << "Start ReplClient ClientThread Error: " << res
                << (res == net::kCreateThreadError ? ": create thread error " : ": other error");
   }
-  for (auto & bg_worker : bg_workers_) {
-    res = bg_worker->StartThread();
+  for (auto & binlog_worker : write_binlog_workers_) {
+    res = binlog_worker->StartThread();
     if (res != net::kSuccess) {
-      LOG(FATAL) << "Start Pika Repl Worker Thread Error: " << res
+      LOG(FATAL) << "Start Pika Repl Write Binlog Worker Thread Error: " << res
                  << (res == net::kCreateThreadError ? ": create thread error " : ": other error");
     }
   }
+  for (auto & binlog_worker : write_db_workers_) {
+        res = binlog_worker->StartThread();
+        if (res != net::kSuccess) {
+            LOG(FATAL) << "Start Pika Repl Write DB Worker Thread Error: " << res
+                       << (res == net::kCreateThreadError ? ": create thread error " : ": other error");
+        }
+    }
   return res;
 }
 
 int PikaReplClient::Stop() {
   client_thread_->StopThread();
-  for (auto & bg_worker : bg_workers_) {
-    bg_worker->StopThread();
+  for (auto & binlog_worker : write_binlog_workers_) {
+    binlog_worker->StopThread();
+  }
+  for (auto &db_worker: write_db_workers_) {
+    db_worker->StopThread();
   }
   return 0;
 }
 
 void PikaReplClient::Schedule(net::TaskFunc func, void* arg) {
-  bg_workers_[next_avail_]->Schedule(func, arg);
+  write_binlog_workers_[next_avail_]->Schedule(func, arg);
   UpdateNextAvail();
 }
 
 void PikaReplClient::ScheduleWriteBinlogTask(const std::string& db_name,
                                              const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                              const std::shared_ptr<net::PbConn>& conn, void* res_private_data) {
-  size_t index = GetHashIndex(db_name, true);
-  auto task_arg = new ReplClientWriteBinlogTaskArg(res, conn, res_private_data, bg_workers_[index].get());
-  bg_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteBinlog, static_cast<void*>(task_arg));
+  char db_num = db_name.back();
+  int index = db_num - '0';
+  if (index < 0 || index > write_binlog_workers_.size()) {
+      LOG(ERROR)
+              << "Corruption in cosuming binlog: the last char of the db_name(extracted from binlog) is not a valid db num, the extracted db_num/worker_index is "
+              << index << " while write_binlog_workers.size() is " << write_binlog_workers_.size();
+      return;
+  }
+  auto task_arg = new ReplClientWriteBinlogTaskArg(res, conn, res_private_data, write_binlog_workers_[index].get());
+  write_binlog_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteBinlog, static_cast<void*>(task_arg));
 }
 
 void PikaReplClient::ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const LogOffset& offset,
                                          const std::string& db_name) {
   const PikaCmdArgsType& argv = cmd_ptr->argv();
   std::string dispatch_key = argv.size() >= 2 ? argv[1] : argv[0];
-  size_t index = GetHashIndex(dispatch_key, false);
+  size_t index = GetHashIndexByKey(dispatch_key);
   auto task_arg = new ReplClientWriteDBTaskArg(cmd_ptr, offset, db_name);
-  bg_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg));
+  write_db_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg));
 }
 
-size_t PikaReplClient::GetHashIndex(const std::string& key, bool upper_half) {
-  size_t hash_base = bg_workers_.size() / 2;
-  return (str_hash(key) % hash_base) + (upper_half ? 0 : hash_base);
+size_t PikaReplClient::GetHashIndexByKey(const std::string& key) {
+  size_t hash_base = write_db_workers_.size();
+  return (str_hash(key) % hash_base);
 }
 
 Status PikaReplClient::Write(const std::string& ip, const int port, const std::string& msg) {

--- a/src/pika_repl_client_conn.cc
+++ b/src/pika_repl_client_conn.cc
@@ -63,9 +63,12 @@ int PikaReplClientConn::DealMessage() {
       break;
     }
     case InnerMessage::kTrySync: {
+      const std::string& db_name = response->try_sync().slot().db_name();
+      //TrySync resp must contain db_name
+      assert(!db_name.empty());
       auto task_arg =
           new ReplClientTaskArg(response, std::dynamic_pointer_cast<PikaReplClientConn>(shared_from_this()));
-      g_pika_rm->ScheduleReplClientBGTask(&PikaReplClientConn::HandleTrySyncResponse, static_cast<void*>(task_arg));
+      g_pika_rm->ScheduleReplClientBGTaskByDBName(&PikaReplClientConn::HandleTrySyncResponse, static_cast<void*>(task_arg), db_name);
       break;
     }
     case InnerMessage::kBinlogSync: {
@@ -193,7 +196,6 @@ void PikaReplClientConn::HandleTrySyncResponse(void* arg) {
     LOG(WARNING) << "TrySync Failed: " << reply;
     return;
   }
-
   const InnerMessage::InnerResponse_TrySync& try_sync_response = response->try_sync();
   const InnerMessage::Slot& db_response = try_sync_response.slot();
   std::string db_name = db_response.db_name();

--- a/src/pika_rm.cc
+++ b/src/pika_rm.cc
@@ -659,6 +659,10 @@ void PikaReplicaManager::ScheduleReplClientBGTask(net::TaskFunc func, void* arg)
   pika_repl_client_->Schedule(func, arg);
 }
 
+void PikaReplicaManager::ScheduleReplClientBGTaskByDBName(net::TaskFunc func, void* arg, const std::string &db_name) {
+  pika_repl_client_->ScheduleByDBName(func, arg, db_name);
+}
+
 void PikaReplicaManager::ScheduleWriteBinlogTask(const std::string& db,
                                                  const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                                  const std::shared_ptr<net::PbConn>& conn, void* res_private_data) {

--- a/tests/integration/replication_test.go
+++ b/tests/integration/replication_test.go
@@ -558,6 +558,7 @@ var _ = Describe("should replication ", func() {
 
 			log.Println("randomSpopstore test start")
 			execute(&ctx, clientMaster, 4, randomSpopstroeThread)
+			time.Sleep(10 * time.Second)
 			master_spopstore_set := clientMaster.SMembers(ctx, "set1")
 			Expect(master_spopstore_set.Err()).NotTo(HaveOccurred())
 			slave_spopstore_set := clientSlave.SMembers(ctx, "set1")


### PR DESCRIPTION
**这个PR做了哪些事**：

**1 Slave端主从同步线程模型的重构**（fix #2637 ）：
- **1.1** 将Slave端的WriteBinlogWorker和WriteDBWorker分开为两个vector存储，允许用户对write_binlog_worker数量与write_db_worker数量分开配置。具体地，配置项“sync-thread-num”将直接控制从节点消费binlog时用于WriteDB的worker数量（write_db_worker的数量），“sync-binlog-thread-num”决定了write_binlog_worker的数量。
- **1.2**  每个db建议都配一个write_binlog_worker,但也允许用户给出的write_binlog_worker数量小于db数量，此时db会直接取模决定自己使用哪个binlogWorker, 如果用户给出的write_binlog_worker数量大于DB数量，Pika会直接使用db_num作为write_binlog_worker的最终值
- **1.3**  所有DB共用同一个WriteDBWorker Pool来做WriteDB(依旧使用key做hash来选取worker)。

**2 修复了主从超时重连场景下, 因为Slave连续发送两次TrySync Req而导致的Sync Win崩溃问题（fix #2655 ）**
- **2.1 针对#2655 最终确定的修补方案是：将Slave端对TrySync Resp的处理从异步改成同步**（使用DB对应的BinlogWorker来处理，确保在主从发生超时重连的场景下，所有过期的Binlog任务都已经被丢弃后Slave才会处理TrySync Resp，这样就能避免Slave消费到SessionID不匹配的过期Binlog任务，进而引发第二次TrySync Req的发送而导致Sync Win Corruption）
- **2.2 引发Issue #2655 的原因简述：**

1.  直接原因：Slave在超时重连时，在短时间内连续发出了2次一模一样的TrySync请求（参数中携带的BinlogOfft都一样），Master端会对这2条TrySync请求做同样的处理（每次都会清空WriteQueue和SyncWin，然后从TrySync请求中携带的Binlog偏移量位置开始发送Binlog），在这时间附近的某些BInlog会被发送2次，Slave也会对这些Binlog消费2次，进而导致了Slave返回的BinlogACK被Master认为不合法。

2. 为什么Slave会连续发出2次TrySync: Slave端消费Binlog的Worker线程的任务队列在发出第一次TrySync时依旧还有上一次主从连接期间积压的写Binlog任务（Slave端超时断联，转入TryConnect状态时，会去一条一条丢弃此时WorkerThread中积压的写Binlog任务，这里的问题是丢得太慢了或者说下一次TrySync发的太快了），当Slave收到第一条TrySync请求的响应，会进入Connected状态，于是会开始消费之前积压的，来自前一次主从连接的写Binlog任务，而这些BInlog的SeesionID对不上，就会触发错误处理分支，将Slave转到TrySync状态，所以slave紧接着发出了第二条TrySync请求。

  
**3 修复了“某个Binlog任务阻塞Slave很久，导致超时重连后Master从错误的起始位置续传Binlog”的问题（fix #2659 ）**
- **3.1** 将Slave端对TrySync Resp的处理从异步改成同步(针对Issue #2655 的修复方案)，也同时能修复 Issue #2659 

**4** 合并本PR以后，Slave对TrySync Reps的处理改成了同步（相较于消费Binlog）处理，那么在某些极端情况下（Slave阻塞比较严重），主从建联可能会延迟，Slave将停留在WaitReply的时间会延长，此时master_link_status也为down，所以另提了 PR #2656 ,给运维增加了更细粒度的监控指标 repl_connect_status以便在master_link_status为down时进一步判断情况。关于repl_connect_status的详细解释以及如何使用，请见Disscussion #2689

**What does this PR do**:

**1. Refactoring of the thread model** (fix #2637):
- **1.1** The WriteBinlogWorker and WriteDBWorker on the Slave side are separated into two vectors, allowing users to configure the number of write_binlog_worker and write_db_worker separately. Specifically, the configuration item "sync-thread-num" will directly control the number of write_db_worker used for WriteDB when consuming binlog from the slave node, while "sync-binlog-thread-num" determines the number of write_binlog_worker.
- **1.2** Each DB is recommended to have a write_binlog_worker, but it also allows the number of write_binlog_worker provided by the user to be less than the number of DBs. In this case, the DB will use modulus to decide which binlog it will use. If the number of write_binlog_worker provided by the user is greater than the number of DBs, Pika will use the db_num as the final value for write_binlog_worker.
- **1.3** All DBs share the same WriteDBWorker Pool for WriteDB (still using key hashing to select the worker).

**2. Fixed the issue of Sync Win crash caused by Slave sending two consecutive TrySync Req in the scenario of master-slave timeout reconnection** (fix #2655):
- **2.1** The final solution for #2655 is to change the handling of TrySync Resp on the Slave side from asynchronous to synchronous (using the DB corresponding BinlogWorker to ensure that in the scenario of master-slave timeout reconnection, all expired Binlog tasks are discarded before the Slave processes the TrySync Resp. This avoids the Slave consuming expired Binlog tasks with mismatched SessionIDs, which would trigger the sending of a second TrySync Req and cause Sync Win Corruption).
- **2.2** Brief description of the cause of Issue #2655:

1. Direct cause: When the Slave times out and reconnects, it sends two identical TrySync requests in a short period (with the same BinlogOfft parameter). The Master will handle these two TrySync requests in the same way (each time clearing the WriteQueue and SyncWin, then sending Binlog from the offset position carried in the TrySync request). Some Binlogs near this time will be sent twice, and the Slave will consume these Binlogs twice, causing the BinlogACK returned by the Slave to be considered invalid by the Master.

2. Why does the Slave send two consecutive TrySync: The task queue of the Slave's Binlog-consuming Worker thread still has the write Binlog tasks accumulated during the last master-slave connection when the first TrySync is sent. When the Slave times out and disconnects, entering the TryConnect state, it discards the accumulated write Binlog tasks one by one. The problem is that this process is too slow, or the next TrySync is sent too quickly. When the Slave receives the response to the first TrySync request, it enters the Connected state and starts consuming the previously accumulated write Binlog tasks. Since the SessionIDs of these Binlogs do not match, it triggers the error handling branch, sending the Slave back to the TrySync state, thus sending the second TrySync request.

**3. Fixed the issue of "a certain Binlog task blocking the Slave for a long time, causing the Master to resume Binlog transmission from the wrong starting position after a timeout reconnection"** (fix #2659):
- **3.1** Changing the handling of TrySync Resp on the Slave side from asynchronous to synchronous (the solution for Issue #2655) also fixes Issue #2659.

**4**. After merging this PR, the handling of TrySync Reps by the Slave has been changed to synchronous (compared to consuming Binlog). Therefore, in some extreme cases (severe Slave blocking), the master-slave connection may be delayed, causing the Slave to stay in the WaitReply state for an extended period. During this time, the master_link_status will also be down. Therefore, PR #2656 has been proposed to add a more granular monitoring metric for operations: repl_connect_status.

