### PR TITLE
fix:slots rebalance error and replication stats error when use pika o…

### DIFF
--- a/tests/integration/replication_test.go
+++ b/tests/integration/replication_test.go
@@ -749,7 +749,7 @@ var _ = Describe("should replication ", func() {
 
 			setkey2 := clientMaster.Set(ctx, "Tnxkey2", "Tnxvalue2", 0)
 			Expect(setkey2.Err()).NotTo(HaveOccurred())
-			Expect(get.Val()).To(Equal("QUEUED"))
+			Expect(setkey2.Val()).To(Equal("QUEUED"))
 
 			r2 := clientMaster.Do(ctx, "EXEC")
 			Expect(r2.Err()).NotTo(HaveOccurred())

--- a/tools/kubeblocks_helm/installdebug.sh
+++ b/tools/kubeblocks_helm/installdebug.sh
@@ -1,0 +1,4 @@
+# helm install pika ./pika && helm install pika-cluster ./pika-cluster
+
+helm template pika ./pika --output-dir ./output/pika
+#helm template pika-cluster ./pika-cluster --output-dir ./output/pika-cluster

--- a/tools/kubeblocks_helm/pika/script/admin.sh
+++ b/tools/kubeblocks_helm/pika/script/admin.sh
@@ -46,7 +46,7 @@ wait_master_registered() {
 }
 
 wait_all_master_registered() {
-  for ((group_id=1; group_id <= GROUP_ID; group_id++)); do
+  for ((group_id = 1; group_id <= GROUP_ID; group_id++)); do
     until $CODIS_ADMIN --list-group | jq -r '.[] | select(.id == '${group_id}') | .servers[] | select(.role == "master") | .server'; do
       echo "Waiting for master to be registered in group $group_id"
       sleep 2

--- a/tools/kubeblocks_helm/pika/script/admin.sh
+++ b/tools/kubeblocks_helm/pika/script/admin.sh
@@ -45,6 +45,15 @@ wait_master_registered() {
   done
 }
 
+wait_all_master_registered() {
+  for ((group_id=1; group_id <= GROUP_ID; group_id++)); do
+    until $CODIS_ADMIN --list-group | jq -r '.[] | select(.id == '${group_id}') | .servers[] | select(.role == "master") | .server'; do
+      echo "Waiting for master to be registered in group $group_id"
+      sleep 2
+    done
+  done
+}
+
 # confirm group has the max index of all groups
 confirm_max_group() {
     max_group_id=0
@@ -72,7 +81,7 @@ reload_until_success() {
 
 register_server() {
   reload_until_success
-  if [ ${POD_ID} -gt 0 ]; then wait_master_registered; fi
+  if [ ${POD_ID} -gt 0 ]; then wait_all_master_registered; fi
   $CODIS_ADMIN --create-group --gid=${GROUP_ID} 1>/dev/null 2>&1
   $CODIS_ADMIN --group-add --gid=${GROUP_ID} --addr=${KB_POD_FQDN}:9221
   $CODIS_ADMIN --sync-action --create --addr=${KB_POD_FQDN}:9221 1>/dev/null 2>&1
@@ -123,6 +132,7 @@ if [ $# -eq 1 ]; then
     wait_dashboard_running
     confirm_max_group
     wait_master_registered
+    wait_all_master_registered
     rebalance
     exit 0
     ;;

--- a/tools/kubeblocks_helm/reinstall.sh
+++ b/tools/kubeblocks_helm/reinstall.sh
@@ -1,0 +1,3 @@
+helm uninstall pika && helm uninstall pika-cluster
+sleep 5
+helm install pika ./pika && helm install pika-cluster ./pika-cluster


### PR DESCRIPTION
1.这个PR主要是修复slotsrebalance可能分配不均衡的问题：
以前是等待最大的group_id的master注册成功后去均衡，现在是等待所有的
2.修复注册之后有的group主从关系绑定失败的问题
3.添加一键部署脚本和部署调试脚本