### PR TITLE
fix: add a user-friendly repl metric "repl_connect_status" in the resp of info command

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1080,7 +1080,7 @@ void InfoCmd::InfoReplication(std::string& info) {
   int host_role = g_pika_server->role();
   std::stringstream tmp_stream;
   std::stringstream out_of_sync;
-
+  std::stringstream repl_connect_status;
   bool all_db_sync = true;
   std::shared_lock db_rwl(g_pika_server->dbs_rw_);
   for (const auto& db_item : g_pika_server->GetDB()) {
@@ -1090,27 +1090,39 @@ void InfoCmd::InfoReplication(std::string& info) {
       out_of_sync << "(" << db_item.first << ": InternalError)";
       continue;
     }
+    repl_connect_status << db_item.first << ":";
     if (slave_db->State() != ReplState::kConnected) {
       all_db_sync = false;
       out_of_sync << "(" << db_item.first << ":";
       if (slave_db->State() == ReplState::kNoConnect) {
         out_of_sync << "NoConnect)";
+        repl_connect_status << "no_connect";
       } else if (slave_db->State() == ReplState::kWaitDBSync) {
         out_of_sync << "WaitDBSync)";
+        repl_connect_status << "syncing_full";
       } else if (slave_db->State() == ReplState::kError) {
         out_of_sync << "Error)";
+        repl_connect_status << "error";
       } else if (slave_db->State() == ReplState::kWaitReply) {
         out_of_sync << "kWaitReply)";
+        repl_connect_status << "connecting";
       } else if (slave_db->State() == ReplState::kTryConnect) {
         out_of_sync << "kTryConnect)";
+        repl_connect_status << "try_to_incr_sync";
       } else if (slave_db->State() == ReplState::kTryDBSync) {
         out_of_sync << "kTryDBSync)";
+        repl_connect_status << "try_to_full_sync";
       } else if (slave_db->State() == ReplState::kDBNoConnect) {
         out_of_sync << "kDBNoConnect)";
+        repl_connect_status << "no_connect";
       } else {
         out_of_sync << "Other)";
+        repl_connect_status << "error";
       }
+    } else { //slave_db->State() equal to kConnected
+        repl_connect_status << "connected";
     }
+    repl_connect_status << "\r\n";
   }
 
   tmp_stream << "# Replication(";
@@ -1138,6 +1150,7 @@ void InfoCmd::InfoReplication(std::string& info) {
       tmp_stream << "master_link_status:"
                  << (((g_pika_server->repl_state() == PIKA_REPL_META_SYNC_DONE) && all_db_sync) ? "up" : "down")
                  << "\r\n";
+      tmp_stream << "repl_connect_status:\r\n"  << repl_connect_status.str();
       tmp_stream << "slave_priority:" << g_pika_conf->slave_priority() << "\r\n";
       tmp_stream << "slave_read_only:" << g_pika_conf->slave_read_only() << "\r\n";
       if (!all_db_sync) {
@@ -1150,6 +1163,7 @@ void InfoCmd::InfoReplication(std::string& info) {
       tmp_stream << "master_link_status:"
                  << (((g_pika_server->repl_state() == PIKA_REPL_META_SYNC_DONE) && all_db_sync) ? "up" : "down")
                  << "\r\n";
+      tmp_stream << "repl_connect_status:\r\n"  << repl_connect_status.str();
       tmp_stream << "slave_read_only:" << g_pika_conf->slave_read_only() << "\r\n";
       if (!all_db_sync) {
         tmp_stream << "db_repl_state:" << out_of_sync.str() << "\r\n";


### PR DESCRIPTION
Due to the merge of #2638（Changed the processing of TrySync Resp from asynchronous to synchronous.） , slave may stay in WaitReply state for a while(in some extreme scenario, WaitReply state could last even 1-2 minutes), during the period of slave being "WaitReply" state， the metric "master_link_status"(which is fetched by info command) is down, which might trigger monitoring alerts set by the operations personnel. 
So it's needed to provide an more granular metric for the user/operations personnel to know what is going on when master_link_status is down. And that's why the following monitoring metric is added by this PR:
metirc name: repl_connect_status
value range: {no_connect, try_to_incr_sync, try_to_full_sync, syncing_full, connecting, error}

由于 #2638  的合并（将TrySync Resp的处理由异步改成了同步），slave可能会在WaitReply状态下停留一段时间（在某些极端情况下，WaitReply状态可能会持续1-2分钟），在slave处于“WaitReply”状态期间，通过info命令获取的“master_link_status”指标会显示为down，这可能会触发运维人员设置的监控警报。
因此，需要提供一个更细粒度的指标，以便用户/运维人员在master_link_status为down时了解实际情况。这也是为什么通过这个PR添加了以下监控指标：
指标名称：repl_connect_status
值范围：{no_connect, try_to_incr_sync, try_to_full_sync, syncing_full, connecting, connected, error}

关于该值如何使用：请见 Disscussion #2689