### PR TITLE
fix: remove an unnecessary unlock operation in rsync throttle

### DIFF
--- a/src/throttle.cc
+++ b/src/throttle.cc
@@ -41,7 +41,6 @@ size_t Throttle::ThrottledByThroughput(size_t bytes) {
     available_size = bytes;
     cur_throughput_bytes_ += available_size;
   }
-  keys_mutex_.unlock();
   return available_size;
 }
 


### PR DESCRIPTION
In the ThrottledByThroughput function, keys_mutex is already managed by unique_lock, so there's no need to manually unlock it.

在ThrottledByThroughput函数中，keys_mutex已经被unique_lock托管，没必要手动解锁。