### PR TITLE
fix: fix data race around PikaServer::statistic_::server_stat::exec_count_db

### DIFF
--- a/src/pika.cc
+++ b/src/pika.cc
@@ -211,7 +211,8 @@ int main(int argc, char* argv[]) {
   g_pika_rm = std::make_unique<PikaReplicaManager>();
   g_network_statistic = std::make_unique<net::NetworkStatistic>();
   g_pika_server->InitDBStruct();
-
+  //the cmd table of g_pika_cmd_table_manager must be inited before calling PikaServer::InitStatistic(CmdTable* )
+  g_pika_server->InitStatistic(g_pika_cmd_table_manager->GetCmdTable());
   auto status = g_pika_server->InitAcl();
   if (!status.ok()) {
     LOG(FATAL) << status.ToString();


### PR DESCRIPTION
**该PR修复了 Issue #2670** 
**Issue #2670 发生的原因**：
     在PikaServer::statistic_::server_stat::exec_count_db 这个map上有高度并发，但是map本身没有mutex保护，第一批命令打到Pika时，这个map的insert会被并发调用。
**该PR所做的修复**：
    在Pika启动时对这个map进行主动insert，确保所有的cmd_name在该map内部都有个对应pair，这样后面针对该map进行并发时，就只会触发其查询接口，而不会调用Insert, 这样就算没有额外加锁，也是线程安全的。

**This PR fixes Issue #2670**  
**Cause of Issue #2670**:  
There is high concurrency on the map `PikaServer::statistic_::server_stat::exec_count_db`, but the map itself lacks mutex protection. When the first batch of commands hits Pika, the insert operation on this map is called concurrently.

**Fix implemented in this PR**:  
During Pika startup, proactively insert into this map to ensure that every `cmd_name` has a corresponding pair within the map. This way, subsequent concurrent operations on the map will only trigger its query interface instead of calling insert. This approach ensures thread safety even without additional locking.

