### PR TITLE
fix: fix ExpectedStale error when expired type is string

### DIFF
--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -406,19 +406,16 @@ class Redis {
     auto meta_type = static_cast<enum DataType>(static_cast<uint8_t>(meta_value[0]));
     if (meta_type == DataType::kZSets || meta_type == DataType::kSets || meta_type == DataType::kHashes) {
       ParsedBaseMetaValue parsed_meta_value(meta_value);
-      if (parsed_meta_value.IsStale() || parsed_meta_value.Count() == 0) {
-        return true;
-      }
+      return (parsed_meta_value.IsStale() || parsed_meta_value.Count() == 0);
     } else if (meta_type == DataType::kLists) {
       ParsedListsMetaValue parsed_lists_meta_value(meta_value);
-      if (parsed_lists_meta_value.IsStale() || parsed_lists_meta_value.Count() == 0) {
-        return true;
-      }
+      return (parsed_lists_meta_value.IsStale() || parsed_lists_meta_value.Count() == 0);
+    } else if (meta_type == DataType::kStrings) {
+      ParsedStringsValue parsed_strings_value(meta_value);
+      return parsed_strings_value.IsStale();
     } else if (meta_type == DataType::kStreams) {
       StreamMetaValue stream_meta_value;
-      if (stream_meta_value.length() == 0) {
-        return true;
-      }
+      return stream_meta_value.length() == 0;
     }
     return false;
   }

--- a/src/storage/tests/hashes_test.cc
+++ b/src/storage/tests/hashes_test.cc
@@ -875,6 +875,14 @@ TEST_F(HashesTest, HSetTest) {
   s = db.HGet("GP3_HSET_KEY", "HSET_TEST_NEW_FIELD", &value);
   ASSERT_TRUE(s.ok());
   ASSERT_EQ(value, "HSET_TEST_NEW_VALUE");
+
+  // ***************** Group 4 Test *****************
+  s = db.Setex("GP4_HSET_KEY", "STRING_VALUE_WITH_TTL", 1);
+  ASSERT_TRUE(s.ok());
+  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+  s = db.HSet("GP4_HSET_KEY", "HSET_TEST_NEW_FIELD", "HSET_TEST_NEW_VALUE", &ret);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(ret, 1);
 }
 
 // HSetnx

--- a/src/storage/tests/hashes_test.cc
+++ b/src/storage/tests/hashes_test.cc
@@ -877,9 +877,10 @@ TEST_F(HashesTest, HSetTest) {
   ASSERT_EQ(value, "HSET_TEST_NEW_VALUE");
 
   // ***************** Group 4 Test *****************
+  // hset after string type key expires, should success
   s = db.Setex("GP4_HSET_KEY", "STRING_VALUE_WITH_TTL", 1);
   ASSERT_TRUE(s.ok());
-  std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2100));
   s = db.HSet("GP4_HSET_KEY", "HSET_TEST_NEW_FIELD", "HSET_TEST_NEW_VALUE", &ret);
   ASSERT_TRUE(s.ok());
   ASSERT_EQ(ret, 1);


### PR DESCRIPTION
ExpectedStale didn't consider string type, so if the mismatched key type is string and it's expired, ExpectedStale returns wrong