### PR TITLE
fix:  modify cmdId assignment time to assgining after registering cmdtable

### DIFF
--- a/include/pika_cmd_table_manager.h
+++ b/include/pika_cmd_table_manager.h
@@ -34,7 +34,7 @@ class PikaCmdTableManager {
   std::shared_ptr<Cmd> GetCmd(const std::string& opt);
   bool CmdExist(const std::string& cmd) const;
   CmdTable* GetCmdTable();
-  uint32_t GetCmdId();
+  uint32_t GetMaxCmdId();
 
   std::vector<std::string> GetAclCategoryCmdNames(uint32_t flag);
 

--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -566,6 +566,7 @@ class Cmd : public std::enable_shared_from_this<Cmd> {
   std::shared_ptr<std::string> GetResp();
 
   void SetStage(CmdStage stage);
+  void SetCmdId(uint32_t cmdId){cmdId_ = cmdId;}
 
   virtual void DoBinlog();
 

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -47,6 +47,7 @@ void PikaCmdTableManager::InitCmdTable(void) {
   CommandStatistics statistics;
   for (auto& iter : *cmds_) {
     cmdstat_map_.emplace(iter.first, statistics);
+    iter.second->SetCmdId(cmdId_++);
   }
 }
 

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -82,7 +82,7 @@ std::shared_ptr<Cmd> PikaCmdTableManager::NewCommand(const std::string& opt) {
 
 CmdTable* PikaCmdTableManager::GetCmdTable() { return cmds_.get(); }
 
-uint32_t PikaCmdTableManager::GetCmdId() { return ++cmdId_; }
+uint32_t PikaCmdTableManager::GetMaxCmdId() { return cmdId_; }
 
 bool PikaCmdTableManager::CheckCurrentThreadDistributionMapExist(const std::thread::id& tid) {
   std::shared_lock l(map_protector_);

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -830,8 +830,6 @@ bool Cmd::CheckArg(uint64_t num) const { return !((arity_ > 0 && num != arity_) 
 
 Cmd::Cmd(std::string name, int arity, uint32_t flag, uint32_t aclCategory)
     : name_(std::move(name)), arity_(arity), flag_(flag), aclCategory_(aclCategory) {
-  // assign cmd id
-  cmdId_ = g_pika_cmd_table_manager->GetCmdId();
 }
 
 void Cmd::Initial(const PikaCmdArgsType& argv, const std::string& db_name) {

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -10,7 +10,6 @@
 #include "include/pika_acl.h"
 #include "include/pika_admin.h"
 #include "include/pika_bit.h"
-#include "include/pika_cmd_table_manager.h"
 #include "include/pika_command.h"
 #include "include/pika_geo.h"
 #include "include/pika_hash.h"


### PR DESCRIPTION
Fix #2686
**主要解决以下问题**
* pika 之前的 cmdID 赋值是在 cmd 初始函数里，并且会对 PikaCmdTableManager 对象中的 cmdID 自增。由于 PikaCmdTableManager 的 cmdID 是全局唯一，并且没有并发保护。当存在并发构造 cmd 的时候就会引起 data race。

**解决方式**
* 调整cmd 赋值与自增时间为注册完 cmdtable 后，由于pika 注册 cmdtable 为单线程，所以不存在并发写问题。