### PR TITLE
fix: add back the override Execute() of WatchCmd, InfoCmd, ConfigCmd

### DIFF
--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -257,6 +257,7 @@ class InfoCmd : public Cmd {
   void Split(const HintKeys& hint_keys) override {};
   void Merge() override {};
   Cmd* Clone() override { return new InfoCmd(*this); }
+  void Execute() override;
 
  private:
   InfoSection info_section_;
@@ -324,6 +325,7 @@ class ConfigCmd : public Cmd {
   void Split(const HintKeys& hint_keys) override {};
   void Merge() override {};
   Cmd* Clone() override { return new ConfigCmd(*this); }
+  void Execute() override;
 
  private:
   std::vector<std::string> config_args_v_;

--- a/include/pika_transaction.h
+++ b/include/pika_transaction.h
@@ -82,6 +82,7 @@ class WatchCmd : public Cmd {
   Cmd* Clone() override { return new WatchCmd(*this); }
   void Merge() override {}
   std::vector<std::string> current_key() const override { return keys_; }
+  void Execute() override;
 
  private:
   void DoInitial() override;

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -752,6 +752,11 @@ const std::string InfoCmd::kDebugSection = "debug";
 const std::string InfoCmd::kCommandStatsSection = "commandstats";
 const std::string InfoCmd::kCacheSection = "cache";
 
+void InfoCmd::Execute() {
+  std::shared_ptr<DB> db = g_pika_server->GetDB(db_name_);
+  Do();
+}
+
 void InfoCmd::DoInitial() {
   size_t argc = argv_.size();
   if (argc > 4) {
@@ -1385,6 +1390,9 @@ std::string InfoCmd::CacheStatusToString(int status) {
     default:
       return std::string("Unknown");
   }
+}
+void ConfigCmd::Execute() {
+  Do();
 }
 
 void ConfigCmd::DoInitial() {

--- a/src/pika_transaction.cc
+++ b/src/pika_transaction.cc
@@ -220,6 +220,10 @@ void ExecCmd::ServeToBLrPopWithKeys() {
   }
 }
 
+void WatchCmd::Execute() {
+  Do();
+}
+
 void WatchCmd::Do() {
   auto mp = std::map<storage::DataType, storage::Status>{};
   for (const auto& key : keys_) {


### PR DESCRIPTION
In https://github.com/OpenAtomFoundation/pika/pull/2533/files, the override Execute() of WatchCmd, InfoCmd, ConfigCmd has been deleted only for simplicity, but those override function has their own unique purpose: avoding calling the Execute() implimented by their base class "Cmd"

PS: No obvious bugs were found, but adding these methods back would be more secure.