### PR TITLE
fix: keyspace error for stream type

### DIFF
--- a/include/pika_db.h
+++ b/include/pika_db.h
@@ -24,11 +24,11 @@ struct KeyScanInfo {
   time_t start_time = 0;
   std::string s_start_time;
   int32_t duration = -3;
-  std::vector<storage::KeyInfo> key_infos;  // the order is strings, hashes, lists, zsets, sets
+  std::vector<storage::KeyInfo> key_infos;  // the order is strings, hashes, lists, zsets, sets, streams
   bool key_scaning_ = false;
   KeyScanInfo() :
                   s_start_time("0"),
-                  key_infos({{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}})
+                  key_infos({{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}})
   {}
 };
 

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2842,11 +2842,14 @@ void DbsizeCmd::Do() {
     }
     KeyScanInfo key_scan_info = dbs->GetKeyScanInfo();
     std::vector<storage::KeyInfo> key_infos = key_scan_info.key_infos;
-    if (key_infos.size() != 5) {
+    if (key_infos.size() != (size_t)(storage::DataType::kNones)) {
       res_.SetRes(CmdRes::kErrOther, "keyspace error");
       return;
     }
-    uint64_t dbsize = key_infos[0].keys + key_infos[1].keys + key_infos[2].keys + key_infos[3].keys + key_infos[4].keys;
+    uint64_t dbsize = 0;
+    for (auto info : key_infos) {
+      dbsize += info.keys;
+    }
     res_.AppendInteger(static_cast<int64_t>(dbsize));
   }
 }

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1201,7 +1201,7 @@ void InfoCmd::InfoKeyspace(std::string& info) {
       key_scan_info = db_item.second->GetKeyScanInfo();
       key_infos = key_scan_info.key_infos;
       duration = key_scan_info.duration;
-      if (key_infos.size() != 5) {
+      if (key_infos.size() != (size_t)(storage::DataType::kNones)) {
         info.append("info keyspace error\r\n");
         return;
       }
@@ -1227,6 +1227,8 @@ void InfoCmd::InfoKeyspace(std::string& info) {
                  << ", invalid_keys=" << key_infos[3].invaild_keys << "\r\n";
       tmp_stream << db_name << " Sets_keys=" << key_infos[4].keys << ", expires=" << key_infos[4].expires
                  << ", invalid_keys=" << key_infos[4].invaild_keys << "\r\n\r\n";
+      tmp_stream << db_name << " Streams_keys=" << key_infos[5].keys << ", expires=" << key_infos[5].expires
+                 << ", invalid_keys=" << key_infos[5].invaild_keys << "\r\n\r\n";
     }
   }
   info.append(tmp_stream.str());

--- a/src/pika_db.cc
+++ b/src/pika_db.cc
@@ -95,20 +95,11 @@ bool DB::IsKeyScaning() {
 
 void DB::RunKeyScan() {
   Status s;
-  std::vector<storage::KeyInfo> new_key_infos(5);
+  std::vector<storage::KeyInfo> new_key_infos;
 
   InitKeyScan();
   std::shared_lock l(dbs_rw_);
-  std::vector<storage::KeyInfo> tmp_key_infos;
-  s = GetKeyNum(&tmp_key_infos);
-  if (s.ok()) {
-    for (size_t idx = 0; idx < tmp_key_infos.size(); ++idx) {
-      new_key_infos[idx].keys += tmp_key_infos[idx].keys;
-      new_key_infos[idx].expires += tmp_key_infos[idx].expires;
-      new_key_infos[idx].avg_ttl += tmp_key_infos[idx].avg_ttl;
-      new_key_infos[idx].invaild_keys += tmp_key_infos[idx].invaild_keys;
-    }
-  }
+  s = GetKeyNum(&new_key_infos);
   key_scan_info_.duration = static_cast<int32_t>(time(nullptr) - key_scan_info_.start_time);
 
   std::lock_guard lm(key_scan_protector_);

--- a/src/storage/src/redis.cc
+++ b/src/storage/src/redis.cc
@@ -387,7 +387,7 @@ Status Redis::ScanKeyNum(std::vector<KeyInfo>* key_infos) {
   if (!s.ok()) {
     return s;
   }
-  s = ScanSetsKeyNum(&((*key_infos)[5]));
+  s = ScanStreamsKeyNum(&((*key_infos)[5]));
   if (!s.ok()) {
     return s;
   }

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1823,7 +1823,7 @@ uint64_t Storage::GetProperty(const std::string& property) {
 
 Status Storage::GetKeyNum(std::vector<KeyInfo>* key_infos) {
   KeyInfo key_info;
-  key_infos->resize(5);
+  key_infos->resize(size_t(DataType::kNones));
   for (const auto& db : insts_) {
     std::vector<KeyInfo> db_key_infos;
     // check the scanner was stopped or not, before scanning the next db


### PR DESCRIPTION
Fixed the problem that the keyspace command does not count the number of stream types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for stream keys in keyspace information output.
  
- **Improvements**
  - Enhanced key scan logic for better performance and accuracy.
  - Updated key information handling to be more flexible and future-proof by using dynamic sizing.

- **Bug Fixes**
  - Fixed incorrect key information sizing to prevent potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->