### PR TITLE
fix: fix pkpatternmatchdel bug

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -317,6 +317,11 @@ max-write-buffer-num : 2
 # whether the key exists. Setting this value too high may hurt performance.
 min-write-buffer-number-to-merge : 1
 
+# The total size of wal files, when reaches this limit, rocksdb will force the flush of column-families
+# whose memtables are backed by the oldest live WAL file. Also used to control the rocksdb open time when
+# process restart.
+max-total-wal-size : 1073741824
+
 # rocksdb level0_stop_writes_trigger
 level0-stop-writes-trigger : 36
 

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -3035,6 +3035,7 @@ void PKPatternMatchDelCmd::DoInitial() {
   pattern_ = argv_[1];
 }
 
+//TODO: may lead to inconsistent between rediscache and db, because currently it only cleans db
 void PKPatternMatchDelCmd::Do() {
   int ret = 0;
   rocksdb::Status s = db_->storage()->PKPatternMatchDel(type_, pattern_, &ret);

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -131,7 +131,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNamePadding, std::move(paddingptr)));
 
   std::unique_ptr<Cmd> pkpatternmatchdelptr =
-      std::make_unique<PKPatternMatchDelCmd>(kCmdNamePKPatternMatchDel, 3, kCmdFlagsWrite | kCmdFlagsAdmin);
+      std::make_unique<PKPatternMatchDelCmd>(kCmdNamePKPatternMatchDel, 2, kCmdFlagsWrite | kCmdFlagsAdmin);
   cmd_table->insert(
       std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNamePKPatternMatchDel, std::move(pkpatternmatchdelptr)));
   std::unique_ptr<Cmd> dummyptr = std::make_unique<DummyCmd>(kCmdDummy, 0, kCmdFlagsWrite);

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -339,6 +339,12 @@ int PikaConf::Load() {
     max_write_buffer_size_ = PIKA_CACHE_SIZE_DEFAULT;  // 10Gb
   }
 
+  // max-total-wal-size
+  GetConfInt64("max-total-wal-size", &max_total_wal_size_);
+  if (max_total_wal_size_ < 0) {
+    max_total_wal_size_ = 0;
+  }
+
   // rate-limiter-mode
   rate_limiter_mode_ = 1;
   GetConfInt("rate-limiter-mode", &rate_limiter_mode_);

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1597,7 +1597,7 @@ rocksdb::Status Redis::PKPatternMatchDel(const std::string& pattern, int32_t* re
       meta_value = iter->value().ToString();
       ParsedStringsValue parsed_strings_value(&meta_value);
       if (!parsed_strings_value.IsStale() &&
-          (StringMatch(pattern.data(), pattern.size(), key.data(), key.size(), 0) != 0)) {
+          (StringMatch(pattern.data(), pattern.size(), parsed_meta_key.Key().data(), parsed_meta_key.Key().size(), 0) != 0)) {
         batch.Delete(key);
       }
     } else if (meta_type == DataType::kLists) {


### PR DESCRIPTION
pkpatternmatchdel compares pattern and encoded-key in string type, which will not delete pattern key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new configuration parameter `max-total-wal-size` to control the total size of WAL files in RocksDB. This helps manage storage more effectively by triggering a flush when the limit is reached.

- **Bug Fixes**
  - Adjusted the `PKPatternMatchDelCmd` command initialization to use 2 arguments instead of 3 for better consistency.
  - Updated the `Redis::PKPatternMatchDel` function to use the correct parameters, enhancing data integrity.

- **Documentation**
  - Added a comment in the `PKPatternMatchDelCmd::Do()` method to indicate a potential inconsistency issue between `rediscache` and the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->