### PR TITLE
fix: some streams errors such as pkpatternmatchdel etc

### DIFF
--- a/src/storage/src/base_filter.h
+++ b/src/storage/src/base_filter.h
@@ -41,7 +41,7 @@ class BaseMetaFilter : public rocksdb::CompactionFilter {
     DEBUG("==========================START==========================");
     if (type == DataType::kStrings) {
       ParsedStringsValue parsed_strings_value(value);
-      DEBUG("[StringsFilter]  key: {}, value = {}, timestamp: {}, cur_time: {}", key.ToString().c_str(),
+      DEBUG("[string type]  key: {}, value = {}, timestamp: {}, cur_time: {}", key.ToString().c_str(),
             parsed_strings_value.UserValue().ToString().c_str(), parsed_strings_value.Etime(), cur_time);
       if (parsed_strings_value.Etime() != 0 && parsed_strings_value.Etime() < cur_time) {
         DEBUG("Drop[Stale]");
@@ -52,14 +52,14 @@ class BaseMetaFilter : public rocksdb::CompactionFilter {
       }
     } else if (type == DataType::kStreams) {
       ParsedStreamMetaValue parsed_stream_meta_value(value);
-      DEBUG("[ListMetaFilter], key: {}, entries_added = {}, first_id: {}, last_id: {}, version: {}",
+      DEBUG("[stream meta type], key: {}, entries_added = {}, first_id: {}, last_id: {}, version: {}",
             key.ToString().c_str(), parsed_stream_meta_value.entries_added(),
             parsed_stream_meta_value.first_id(), parsed_stream_meta_value.last_id(),
             parsed_stream_meta_value.version());
       return false;
     } else if (type == DataType::kLists) {
       ParsedListsMetaValue parsed_lists_meta_value(value);
-      DEBUG("[ListMetaFilter], key: {}, count = {}, timestamp: {}, cur_time: {}, version: {}", key.ToString().c_str(),
+      DEBUG("[list meta type], key: {}, count = {}, timestamp: {}, cur_time: {}, version: {}", key.ToString().c_str(),
             parsed_lists_meta_value.Count(), parsed_lists_meta_value.Etime(), cur_time,
             parsed_lists_meta_value.Version());
 
@@ -76,7 +76,7 @@ class BaseMetaFilter : public rocksdb::CompactionFilter {
       return false;
     } else {
       ParsedBaseMetaValue parsed_base_meta_value(value);
-      DEBUG("[MetaFilter]  key: {}, count = {}, timestamp: {}, cur_time: {}, version: {}", key.ToString().c_str(),
+      DEBUG("[hashe/set/zset meta type]  key: {}, count = {}, timestamp: {}, cur_time: {}, version: {}", key.ToString().c_str(),
             parsed_base_meta_value.Count(), parsed_base_meta_value.Etime(), cur_time, parsed_base_meta_value.Version());
 
       if (parsed_base_meta_value.Etime() != 0 && parsed_base_meta_value.Etime() < cur_time &&

--- a/src/storage/src/pika_stream_meta_value.h
+++ b/src/storage/src/pika_stream_meta_value.h
@@ -82,7 +82,8 @@ class StreamMetaValue {
     value_ = std::move(value);
     assert(value_.size() == kDefaultStreamValueLength);
     if (value_.size() != kDefaultStreamValueLength) {
-      LOG(ERROR) << "Invalid stream meta value length: ";
+      LOG(ERROR) << "Invalid stream meta value length: " << value_.size()
+                 << " expected: " << kDefaultStreamValueLength;
       return;
     }
     char* pos = &value_[0];
@@ -215,7 +216,8 @@ class ParsedStreamMetaValue {
   ParsedStreamMetaValue(const Slice& value) {
     assert(value.size() == kDefaultStreamValueLength);
     if (value.size() != kDefaultStreamValueLength) {
-      LOG(ERROR) << "Invalid stream meta value length: ";
+      LOG(ERROR) << "Invalid stream meta value length: " << value.size()
+                 << " expected: " << kDefaultStreamValueLength;
       return;
     }
     char* pos = const_cast<char*>(value.data());
@@ -294,7 +296,7 @@ class StreamCGroupMetaValue {
     uint64_t needed = kDefaultStreamCGroupValueLength;
     assert(value_.size() == 0);
     if (value_.size() != 0) {
-      LOG(FATAL) << "Init on a existed stream cgroup meta value!";
+      LOG(ERROR) << "Init on a existed stream cgroup meta value!";
       return;
     }
     value_.resize(needed);
@@ -314,7 +316,8 @@ class StreamCGroupMetaValue {
     value_ = std::move(value);
     assert(value_.size() == kDefaultStreamCGroupValueLength);
     if (value_.size() != kDefaultStreamCGroupValueLength) {
-      LOG(FATAL) << "Invalid stream cgroup meta value length: ";
+      LOG(ERROR) << "Invalid stream cgroup meta value length: " << value_.size()
+                 << " expected: " << kDefaultStreamValueLength;
       return;
     }
     if (value_.size() == kDefaultStreamCGroupValueLength) {
@@ -373,7 +376,7 @@ class StreamConsumerMetaValue {
     value_ = std::move(value);
     assert(value_.size() == kDefaultStreamConsumerValueLength);
     if (value_.size() != kDefaultStreamConsumerValueLength) {
-      LOG(FATAL) << "Invalid stream consumer meta value length: " << value_.size()
+      LOG(ERROR) << "Invalid stream consumer meta value length: " << value_.size()
                  << " expected: " << kDefaultStreamConsumerValueLength;
       return;
     }
@@ -391,7 +394,7 @@ class StreamConsumerMetaValue {
     pel_ = pel;
     assert(value_.size() == 0);
     if (value_.size() != 0) {
-      LOG(FATAL) << "Invalid stream consumer meta value length: " << value_.size() << " expected: 0";
+      LOG(ERROR) << "Invalid stream consumer meta value length: " << value_.size() << " expected: 0";
       return;
     }
     uint64_t needed = kDefaultStreamConsumerValueLength;

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1589,10 +1589,10 @@ rocksdb::Status Redis::PKPatternMatchDel(const std::string& pattern, int32_t* re
   rocksdb::WriteBatch batch;
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   iter->SeekToFirst();
-  key = iter->key().ToString();
   while (iter->Valid()) {
     auto meta_type = static_cast<enum DataType>(static_cast<uint8_t>(iter->value()[0]));
     ParsedBaseMetaKey parsed_meta_key(iter->key().ToString());
+    key = iter->key().ToString();
     meta_value = iter->value().ToString();
 
     if (meta_type == DataType::kStrings) {

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1593,15 +1593,15 @@ rocksdb::Status Redis::PKPatternMatchDel(const std::string& pattern, int32_t* re
   while (iter->Valid()) {
     auto meta_type = static_cast<enum DataType>(static_cast<uint8_t>(iter->value()[0]));
     ParsedBaseMetaKey parsed_meta_key(iter->key().ToString());
+    meta_value = iter->value().ToString();
+
     if (meta_type == DataType::kStrings) {
-      meta_value = iter->value().ToString();
       ParsedStringsValue parsed_strings_value(&meta_value);
       if (!parsed_strings_value.IsStale() &&
           (StringMatch(pattern.data(), pattern.size(), parsed_meta_key.Key().data(), parsed_meta_key.Key().size(), 0) != 0)) {
         batch.Delete(key);
       }
     } else if (meta_type == DataType::kLists) {
-      meta_value = iter->value().ToString();
       ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
       if (!parsed_lists_meta_value.IsStale() && (parsed_lists_meta_value.Count() != 0U) &&
           (StringMatch(pattern.data(), pattern.size(), parsed_meta_key.Key().data(), parsed_meta_key.Key().size(), 0) !=
@@ -1618,7 +1618,6 @@ rocksdb::Status Redis::PKPatternMatchDel(const std::string& pattern, int32_t* re
         batch.Put(handles_[kMetaCF], key, stream_meta_value.value());
       }
     } else {
-      meta_value = iter->value().ToString();
       ParsedBaseMetaValue parsed_meta_value(&meta_value);
       if (!parsed_meta_value.IsStale() && (parsed_meta_value.Count() != 0) &&
           (StringMatch(pattern.data(), pattern.size(), parsed_meta_key.Key().data(), parsed_meta_key.Key().size(), 0) !=

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1397,11 +1397,14 @@ Status Storage::PKRScanRange(const DataType& data_type, const Slice& key_start, 
 
 Status Storage::PKPatternMatchDel(const DataType& data_type, const std::string& pattern, int32_t* ret) {
   Status s;
+  *ret = 0;
   for (const auto& inst : insts_) {
-    s = inst->PKPatternMatchDel(pattern, ret);
+    int32_t tmp_ret = 0;
+    s = inst->PKPatternMatchDel(pattern, &tmp_ret);
     if (!s.ok()) {
       return s;
     }
+    *ret += tmp_ret;
   }
   return s;
 }

--- a/src/storage/tests/keys_test.cc
+++ b/src/storage/tests/keys_test.cc
@@ -2095,517 +2095,517 @@ for (const auto& kv : kvs) {
   db.Compact(DataType::kAll, true);
 }
 
-// TEST_F(KeysTest, PKPatternMatchDel) {
-//   int32_t ret;
-//   uint64_t ret64;
-//   int32_t delete_count;
-//   std::vector<std::string> keys;
-//   std::map<DataType, Status> type_status;
+TEST_F(KeysTest, PKPatternMatchDel) {
+  int32_t ret;
+  uint64_t ret64;
+  int32_t delete_count;
+  std::vector<std::string> keys;
+  std::map<DataType, Status> type_status;
 
-//   //=============================== Strings ===============================
+  //=============================== Strings ===============================
 
-//   // ***************** Group 1 Test *****************
-//   db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY1", "VALUE");
-//   db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY2", "VALUE");
-//   db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY3", "VALUE");
-//   db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY4", "VALUE");
-//   db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY5", "VALUE");
-//   db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY6", "VALUE");
-//   s = db.PKPatternMatchDel(DataType::kStrings, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 6);
-//   keys.clear();
-//   db.Keys(DataType::kStrings, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 1 Test *****************
+  db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY1", "VALUE");
+  db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY2", "VALUE");
+  db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY3", "VALUE");
+  db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY4", "VALUE");
+  db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY5", "VALUE");
+  db.Set("GP1_PKPATTERNMATCHDEL_STRING_KEY6", "VALUE");
+  s = db.PKPatternMatchDel(DataType::kStrings, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 6);
+  keys.clear();
+  db.Keys(DataType::kStrings, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 2 Test *****************
-//   db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY1", "VALUE");
-//   db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY2", "VALUE");
-//   db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY3", "VALUE");
-//   db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY4", "VALUE");
-//   db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY5", "VALUE");
-//   db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY6", "VALUE");
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_STRING_KEY1"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_STRING_KEY3"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_STRING_KEY5"));
-//   s = db.PKPatternMatchDel(DataType::kStrings, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kStrings, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 2 Test *****************
+  db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY1", "VALUE");
+  db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY2", "VALUE");
+  db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY3", "VALUE");
+  db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY4", "VALUE");
+  db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY5", "VALUE");
+  db.Set("GP2_PKPATTERNMATCHDEL_STRING_KEY6", "VALUE");
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_STRING_KEY1"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_STRING_KEY3"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_STRING_KEY5"));
+  s = db.PKPatternMatchDel(DataType::kStrings, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kStrings, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 3 Test *****************
-//   db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY1_0xxx0", "VALUE");
-//   db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY2_0ooo0", "VALUE");
-//   db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY3_0xxx0", "VALUE");
-//   db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY4_0ooo0", "VALUE");
-//   db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY5_0xxx0", "VALUE");
-//   db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY6_0ooo0", "VALUE");
-//   s = db.PKPatternMatchDel(DataType::kStrings, "*0xxx0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kStrings, "*", &keys);
-//   ASSERT_EQ(keys.size(), 3);
-//   ASSERT_EQ(keys[0], "GP3_PKPATTERNMATCHDEL_STRING_KEY2_0ooo0");
-//   ASSERT_EQ(keys[1], "GP3_PKPATTERNMATCHDEL_STRING_KEY4_0ooo0");
-//   ASSERT_EQ(keys[2], "GP3_PKPATTERNMATCHDEL_STRING_KEY6_0ooo0");
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 3 Test *****************
+  db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY1_0xxx0", "VALUE");
+  db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY2_0ooo0", "VALUE");
+  db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY3_0xxx0", "VALUE");
+  db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY4_0ooo0", "VALUE");
+  db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY5_0xxx0", "VALUE");
+  db.Set("GP3_PKPATTERNMATCHDEL_STRING_KEY6_0ooo0", "VALUE");
+  s = db.PKPatternMatchDel(DataType::kStrings, "*0xxx0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kStrings, "*", &keys);
+  ASSERT_EQ(keys.size(), 3);
+  ASSERT_EQ(keys[0], "GP3_PKPATTERNMATCHDEL_STRING_KEY2_0ooo0");
+  ASSERT_EQ(keys[1], "GP3_PKPATTERNMATCHDEL_STRING_KEY4_0ooo0");
+  ASSERT_EQ(keys[2], "GP3_PKPATTERNMATCHDEL_STRING_KEY6_0ooo0");
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 4 Test *****************
-//   db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY1", "VALUE");
-//   db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY2_0ooo0", "VALUE");
-//   db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY3", "VALUE");
-//   db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY4_0ooo0", "VALUE");
-//   db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY5", "VALUE");
-//   db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY6_0ooo0", "VALUE");
-//   ASSERT_TRUE(make_expired(&db, "GP4_PKPATTERNMATCHDEL_STRING_KEY1"));
-//   ASSERT_TRUE(make_expired(&db, "GP4_PKPATTERNMATCHDEL_STRING_KEY3"));
-//   ASSERT_TRUE(make_expired(&db, "GP4_PKPATTERNMATCHDEL_STRING_KEY5"));
-//   s = db.PKPatternMatchDel(DataType::kStrings, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kStrings, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 4 Test *****************
+  db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY1", "VALUE");
+  db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY2_0ooo0", "VALUE");
+  db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY3", "VALUE");
+  db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY4_0ooo0", "VALUE");
+  db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY5", "VALUE");
+  db.Set("GP4_PKPATTERNMATCHDEL_STRING_KEY6_0ooo0", "VALUE");
+  ASSERT_TRUE(make_expired(&db, "GP4_PKPATTERNMATCHDEL_STRING_KEY1"));
+  ASSERT_TRUE(make_expired(&db, "GP4_PKPATTERNMATCHDEL_STRING_KEY3"));
+  ASSERT_TRUE(make_expired(&db, "GP4_PKPATTERNMATCHDEL_STRING_KEY5"));
+  s = db.PKPatternMatchDel(DataType::kStrings, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kStrings, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 5 Test *****************
-//   size_t gp5_total_kv = 23333;
-//   for (size_t idx = 0; idx < gp5_total_kv; ++idx) {
-//     db.Set("GP5_PKPATTERNMATCHDEL_STRING_KEY" + std::to_string(idx), "VALUE");
-//   }
-//   s = db.PKPatternMatchDel(DataType::kStrings, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, gp5_total_kv);
-//   keys.clear();
-//   db.Keys(DataType::kStrings, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 5 Test *****************
+  size_t gp5_total_kv = 23333;
+  for (size_t idx = 0; idx < gp5_total_kv; ++idx) {
+    db.Set("GP5_PKPATTERNMATCHDEL_STRING_KEY" + std::to_string(idx), "VALUE");
+  }
+  s = db.PKPatternMatchDel(DataType::kStrings, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, gp5_total_kv);
+  keys.clear();
+  db.Keys(DataType::kStrings, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   //=============================== Set ===============================
+  //=============================== Set ===============================
 
-//   // ***************** Group 1 Test *****************
-//   db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
-//   db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY2", {"M1"}, &ret);
-//   db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
-//   db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY4", {"M1"}, &ret);
-//   db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
-//   db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY6", {"M1"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 6);
-//   keys.clear();
-//   db.Keys(DataType::kSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 1 Test *****************
+  db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
+  db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY2", {"M1"}, &ret);
+  db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
+  db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY4", {"M1"}, &ret);
+  db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
+  db.SAdd("GP1_PKPATTERNMATCHDEL_SET_KEY6", {"M1"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 6);
+  keys.clear();
+  db.Keys(DataType::kSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 2 Test *****************
-//   db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
-//   db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY2", {"M1"}, &ret);
-//   db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
-//   db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY4", {"M1"}, &ret);
-//   db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
-//   db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY6", {"M1"}, &ret);
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_SET_KEY1"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_SET_KEY3"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_SET_KEY5"));
-//   s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 2 Test *****************
+  db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
+  db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY2", {"M1"}, &ret);
+  db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
+  db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY4", {"M1"}, &ret);
+  db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
+  db.SAdd("GP2_PKPATTERNMATCHDEL_SET_KEY6", {"M1"}, &ret);
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_SET_KEY1"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_SET_KEY3"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_SET_KEY5"));
+  s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 3 Test *****************
-//   db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY1_0xxx0", {"M1"}, &ret);
-//   db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY2_0ooo0", {"M1"}, &ret);
-//   db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY3_0xxx0", {"M1"}, &ret);
-//   db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY4_0ooo0", {"M1"}, &ret);
-//   db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY5_0xxx0", {"M1"}, &ret);
-//   db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY6_0ooo0", {"M1"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kSets, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 3);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_SET_KEY1_0xxx0", keys[0]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_SET_KEY3_0xxx0", keys[1]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_SET_KEY5_0xxx0", keys[2]);
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 3 Test *****************
+  db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY1_0xxx0", {"M1"}, &ret);
+  db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY2_0ooo0", {"M1"}, &ret);
+  db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY3_0xxx0", {"M1"}, &ret);
+  db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY4_0ooo0", {"M1"}, &ret);
+  db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY5_0xxx0", {"M1"}, &ret);
+  db.SAdd("GP3_PKPATTERNMATCHDEL_SET_KEY6_0ooo0", {"M1"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kSets, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 3);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_SET_KEY1_0xxx0", keys[0]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_SET_KEY3_0xxx0", keys[1]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_SET_KEY5_0xxx0", keys[2]);
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 4 Test *****************
-//   db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
-//   db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY2", {"M1"}, &ret);
-//   db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
-//   db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY4", {"M1"}, &ret);
-//   db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
-//   db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY6", {"M1"}, &ret);
-//   db.SRem("GP4_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
-//   db.SRem("GP4_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
-//   db.SRem("GP4_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 4 Test *****************
+  db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
+  db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY2", {"M1"}, &ret);
+  db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
+  db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY4", {"M1"}, &ret);
+  db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
+  db.SAdd("GP4_PKPATTERNMATCHDEL_SET_KEY6", {"M1"}, &ret);
+  db.SRem("GP4_PKPATTERNMATCHDEL_SET_KEY1", {"M1"}, &ret);
+  db.SRem("GP4_PKPATTERNMATCHDEL_SET_KEY3", {"M1"}, &ret);
+  db.SRem("GP4_PKPATTERNMATCHDEL_SET_KEY5", {"M1"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 5 Test *****************
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY1_0ooo0", {"M1"}, &ret);
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY2_0xxx0", {"M1"}, &ret);
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY3_0ooo0", {"M1"}, &ret);
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY4_0xxx0", {"M1"}, &ret);
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY5_0ooo0", {"M1"}, &ret);
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY6_0xxx0", {"M1"}, &ret);
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY7_0ooo0", {"M1"}, &ret);
-//   db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY8_0xxx0", {"M1"}, &ret);
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_SET_KEY1_0ooo0"));
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_SET_KEY2_0xxx0"));
-//   db.SRem("GP5_PKPATTERNMATCHDEL_SET_KEY3_0ooo0", {"M1"}, &ret);
-//   db.SRem("GP5_PKPATTERNMATCHDEL_SET_KEY4_0xxx0", {"M1"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kSets, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 2);
-//   keys.clear();
-//   db.Keys(DataType::kSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 2);
-//   ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_SET_KEY6_0xxx0");
-//   ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_SET_KEY8_0xxx0");
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 5 Test *****************
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY1_0ooo0", {"M1"}, &ret);
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY2_0xxx0", {"M1"}, &ret);
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY3_0ooo0", {"M1"}, &ret);
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY4_0xxx0", {"M1"}, &ret);
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY5_0ooo0", {"M1"}, &ret);
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY6_0xxx0", {"M1"}, &ret);
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY7_0ooo0", {"M1"}, &ret);
+  db.SAdd("GP5_PKPATTERNMATCHDEL_SET_KEY8_0xxx0", {"M1"}, &ret);
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_SET_KEY1_0ooo0"));
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_SET_KEY2_0xxx0"));
+  db.SRem("GP5_PKPATTERNMATCHDEL_SET_KEY3_0ooo0", {"M1"}, &ret);
+  db.SRem("GP5_PKPATTERNMATCHDEL_SET_KEY4_0xxx0", {"M1"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kSets, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 2);
+  keys.clear();
+  db.Keys(DataType::kSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 2);
+  ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_SET_KEY6_0xxx0");
+  ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_SET_KEY8_0xxx0");
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 6 Test *****************
-//   size_t gp6_total_set = 23333;
-//   for (size_t idx = 0; idx < gp6_total_set; ++idx) {
-//     db.SAdd("GP6_PKPATTERNMATCHDEL_SET_KEY" + std::to_string(idx), {"M1"}, &ret);
-//   }
-//   s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, gp6_total_set);
-//   keys.clear();
-//   db.Keys(DataType::kSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 6 Test *****************
+  size_t gp6_total_set = 23333;
+  for (size_t idx = 0; idx < gp6_total_set; ++idx) {
+    db.SAdd("GP6_PKPATTERNMATCHDEL_SET_KEY" + std::to_string(idx), {"M1"}, &ret);
+  }
+  s = db.PKPatternMatchDel(DataType::kSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, gp6_total_set);
+  keys.clear();
+  db.Keys(DataType::kSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   //=============================== Hashes ===============================
+  //=============================== Hashes ===============================
 
-//   // ***************** Group 1 Test *****************
-//   db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY1", "FIELD", "VALUE", &ret);
-//   db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY2", "FIELD", "VALUE", &ret);
-//   db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY3", "FIELD", "VALUE", &ret);
-//   db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY4", "FIELD", "VALUE", &ret);
-//   db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY5", "FIELD", "VALUE", &ret);
-//   db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY6", "FIELD", "VALUE", &ret);
-//   s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 6);
-//   keys.clear();
-//   db.Keys(DataType::kHashes, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 1 Test *****************
+  db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY1", "FIELD", "VALUE", &ret);
+  db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY2", "FIELD", "VALUE", &ret);
+  db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY3", "FIELD", "VALUE", &ret);
+  db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY4", "FIELD", "VALUE", &ret);
+  db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY5", "FIELD", "VALUE", &ret);
+  db.HSet("GP1_PKPATTERNMATCHDEL_HASH_KEY6", "FIELD", "VALUE", &ret);
+  s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 6);
+  keys.clear();
+  db.Keys(DataType::kHashes, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 2 Test *****************
-//   db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY1", "FIELD", "VALUE", &ret);
-//   db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY2", "FIELD", "VALUE", &ret);
-//   db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY3", "FIELD", "VALUE", &ret);
-//   db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY4", "FIELD", "VALUE", &ret);
-//   db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY5", "FIELD", "VALUE", &ret);
-//   db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY6", "FIELD", "VALUE", &ret);
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_HASH_KEY1"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_HASH_KEY3"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_HASH_KEY5"));
-//   s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kHashes, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 2 Test *****************
+  db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY1", "FIELD", "VALUE", &ret);
+  db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY2", "FIELD", "VALUE", &ret);
+  db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY3", "FIELD", "VALUE", &ret);
+  db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY4", "FIELD", "VALUE", &ret);
+  db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY5", "FIELD", "VALUE", &ret);
+  db.HSet("GP2_PKPATTERNMATCHDEL_HASH_KEY6", "FIELD", "VALUE", &ret);
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_HASH_KEY1"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_HASH_KEY3"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_HASH_KEY5"));
+  s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kHashes, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 3 Test *****************
-//   db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY1_0xxx0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY2_0ooo0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY3_0xxx0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY4_0ooo0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY5_0xxx0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY6_0ooo0", "FIELD", "VALUE", &ret);
-//   s = db.PKPatternMatchDel(DataType::kHashes, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kHashes, "*", &keys);
-//   ASSERT_EQ(keys.size(), 3);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_HASH_KEY1_0xxx0", keys[0]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_HASH_KEY3_0xxx0", keys[1]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_HASH_KEY5_0xxx0", keys[2]);
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 3 Test *****************
+  db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY1_0xxx0", "FIELD", "VALUE", &ret);
+  db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY2_0ooo0", "FIELD", "VALUE", &ret);
+  db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY3_0xxx0", "FIELD", "VALUE", &ret);
+  db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY4_0ooo0", "FIELD", "VALUE", &ret);
+  db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY5_0xxx0", "FIELD", "VALUE", &ret);
+  db.HSet("GP3_PKPATTERNMATCHDEL_HASH_KEY6_0ooo0", "FIELD", "VALUE", &ret);
+  s = db.PKPatternMatchDel(DataType::kHashes, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kHashes, "*", &keys);
+  ASSERT_EQ(keys.size(), 3);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_HASH_KEY1_0xxx0", keys[0]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_HASH_KEY3_0xxx0", keys[1]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_HASH_KEY5_0xxx0", keys[2]);
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 4 Test *****************
-//   db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY1", "FIELD", "VALUE", &ret);
-//   db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY2", "FIELD", "VALUE", &ret);
-//   db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY3", "FIELD", "VALUE", &ret);
-//   db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY4", "FIELD", "VALUE", &ret);
-//   db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY5", "FIELD", "VALUE", &ret);
-//   db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY6", "FIELD", "VALUE", &ret);
-//   db.HDel("GP4_PKPATTERNMATCHDEL_HASH_KEY1", {"FIELD"}, &ret);
-//   db.HDel("GP4_PKPATTERNMATCHDEL_HASH_KEY3", {"FIELD"}, &ret);
-//   db.HDel("GP4_PKPATTERNMATCHDEL_HASH_KEY5", {"FIELD"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kHashes, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 4 Test *****************
+  db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY1", "FIELD", "VALUE", &ret);
+  db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY2", "FIELD", "VALUE", &ret);
+  db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY3", "FIELD", "VALUE", &ret);
+  db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY4", "FIELD", "VALUE", &ret);
+  db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY5", "FIELD", "VALUE", &ret);
+  db.HSet("GP4_PKPATTERNMATCHDEL_HASH_KEY6", "FIELD", "VALUE", &ret);
+  db.HDel("GP4_PKPATTERNMATCHDEL_HASH_KEY1", {"FIELD"}, &ret);
+  db.HDel("GP4_PKPATTERNMATCHDEL_HASH_KEY3", {"FIELD"}, &ret);
+  db.HDel("GP4_PKPATTERNMATCHDEL_HASH_KEY5", {"FIELD"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kHashes, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 5 Test *****************
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY1_0ooo0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY2_0xxx0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY3_0ooo0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY4_0xxx0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY5_0ooo0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY6_0xxx0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY7_0ooo0", "FIELD", "VALUE", &ret);
-//   db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY8_0xxx0", "FIELD", "VALUE", &ret);
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_HASH_KEY1_0ooo0"));
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_HASH_KEY2_0xxx0"));
-//   db.HDel("GP5_PKPATTERNMATCHDEL_HASH_KEY3_0ooo0", {"FIELD"}, &ret);
-//   db.HDel("GP5_PKPATTERNMATCHDEL_HASH_KEY4_0xxx0", {"FIELD"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kHashes, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 2);
-//   keys.clear();
-//   db.Keys(DataType::kHashes, "*", &keys);
-//   ASSERT_EQ(keys.size(), 2);
-//   ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_HASH_KEY6_0xxx0");
-//   ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_HASH_KEY8_0xxx0");
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 5 Test *****************
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY1_0ooo0", "FIELD", "VALUE", &ret);
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY2_0xxx0", "FIELD", "VALUE", &ret);
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY3_0ooo0", "FIELD", "VALUE", &ret);
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY4_0xxx0", "FIELD", "VALUE", &ret);
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY5_0ooo0", "FIELD", "VALUE", &ret);
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY6_0xxx0", "FIELD", "VALUE", &ret);
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY7_0ooo0", "FIELD", "VALUE", &ret);
+  db.HSet("GP5_PKPATTERNMATCHDEL_HASH_KEY8_0xxx0", "FIELD", "VALUE", &ret);
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_HASH_KEY1_0ooo0"));
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_HASH_KEY2_0xxx0"));
+  db.HDel("GP5_PKPATTERNMATCHDEL_HASH_KEY3_0ooo0", {"FIELD"}, &ret);
+  db.HDel("GP5_PKPATTERNMATCHDEL_HASH_KEY4_0xxx0", {"FIELD"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kHashes, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 2);
+  keys.clear();
+  db.Keys(DataType::kHashes, "*", &keys);
+  ASSERT_EQ(keys.size(), 2);
+  ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_HASH_KEY6_0xxx0");
+  ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_HASH_KEY8_0xxx0");
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 6 Test *****************
-//   size_t gp6_total_hash = 23333;
-//   for (size_t idx = 0; idx < gp6_total_hash; ++idx) {
-//     db.HSet("GP6_PKPATTERNMATCHDEL_HASH_KEY" + std::to_string(idx), "FIELD", "VALUE", &ret);
-//   }
-//   s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, gp6_total_hash);
-//   keys.clear();
-//   db.Keys(DataType::kHashes, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 6 Test *****************
+  size_t gp6_total_hash = 23333;
+  for (size_t idx = 0; idx < gp6_total_hash; ++idx) {
+    db.HSet("GP6_PKPATTERNMATCHDEL_HASH_KEY" + std::to_string(idx), "FIELD", "VALUE", &ret);
+  }
+  s = db.PKPatternMatchDel(DataType::kHashes, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, gp6_total_hash);
+  keys.clear();
+  db.Keys(DataType::kHashes, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   //=============================== ZSets ===============================
+  //=============================== ZSets ===============================
 
-//   // ***************** Group 1 Test *****************
-//   db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY1", {{1, "M"}}, &ret);
-//   db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY2", {{1, "M"}}, &ret);
-//   db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY3", {{1, "M"}}, &ret);
-//   db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY4", {{1, "M"}}, &ret);
-//   db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY5", {{1, "M"}}, &ret);
-//   db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY6", {{1, "M"}}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 6);
-//   keys.clear();
-//   db.Keys(DataType::kZSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 1 Test *****************
+  db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY1", {{1, "M"}}, &ret);
+  db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY2", {{1, "M"}}, &ret);
+  db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY3", {{1, "M"}}, &ret);
+  db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY4", {{1, "M"}}, &ret);
+  db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY5", {{1, "M"}}, &ret);
+  db.ZAdd("GP1_PKPATTERNMATCHDEL_ZSET_KEY6", {{1, "M"}}, &ret);
+  s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 6);
+  keys.clear();
+  db.Keys(DataType::kZSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 2 Test *****************
-//   db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY1", {{1, "M"}}, &ret);
-//   db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY2", {{1, "M"}}, &ret);
-//   db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY3", {{1, "M"}}, &ret);
-//   db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY4", {{1, "M"}}, &ret);
-//   db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY5", {{1, "M"}}, &ret);
-//   db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY6", {{1, "M"}}, &ret);
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_ZSET_KEY1"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_ZSET_KEY3"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_ZSET_KEY5"));
-//   s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kZSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 2 Test *****************
+  db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY1", {{1, "M"}}, &ret);
+  db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY2", {{1, "M"}}, &ret);
+  db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY3", {{1, "M"}}, &ret);
+  db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY4", {{1, "M"}}, &ret);
+  db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY5", {{1, "M"}}, &ret);
+  db.ZAdd("GP2_PKPATTERNMATCHDEL_ZSET_KEY6", {{1, "M"}}, &ret);
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_ZSET_KEY1"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_ZSET_KEY3"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_ZSET_KEY5"));
+  s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kZSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 3 Test *****************
-//   db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY1_0xxx0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY2_0ooo0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY3_0xxx0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY4_0ooo0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY5_0xxx0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY6_0ooo0", {{1, "M"}}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kZSets, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kZSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 3);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_ZSET_KEY1_0xxx0", keys[0]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_ZSET_KEY3_0xxx0", keys[1]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_ZSET_KEY5_0xxx0", keys[2]);
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 3 Test *****************
+  db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY1_0xxx0", {{1, "M"}}, &ret);
+  db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY2_0ooo0", {{1, "M"}}, &ret);
+  db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY3_0xxx0", {{1, "M"}}, &ret);
+  db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY4_0ooo0", {{1, "M"}}, &ret);
+  db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY5_0xxx0", {{1, "M"}}, &ret);
+  db.ZAdd("GP3_PKPATTERNMATCHDEL_ZSET_KEY6_0ooo0", {{1, "M"}}, &ret);
+  s = db.PKPatternMatchDel(DataType::kZSets, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kZSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 3);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_ZSET_KEY1_0xxx0", keys[0]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_ZSET_KEY3_0xxx0", keys[1]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_ZSET_KEY5_0xxx0", keys[2]);
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 4 Test *****************
-//   db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY1", {{1, "M"}}, &ret);
-//   db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY2", {{1, "M"}}, &ret);
-//   db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY3", {{1, "M"}}, &ret);
-//   db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY4", {{1, "M"}}, &ret);
-//   db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY5", {{1, "M"}}, &ret);
-//   db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY6", {{1, "M"}}, &ret);
-//   db.ZRem("GP4_PKPATTERNMATCHDEL_ZSET_KEY1", {"M"}, &ret);
-//   db.ZRem("GP4_PKPATTERNMATCHDEL_ZSET_KEY3", {"M"}, &ret);
-//   db.ZRem("GP4_PKPATTERNMATCHDEL_ZSET_KEY5", {"M"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kZSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 4 Test *****************
+  db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY1", {{1, "M"}}, &ret);
+  db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY2", {{1, "M"}}, &ret);
+  db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY3", {{1, "M"}}, &ret);
+  db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY4", {{1, "M"}}, &ret);
+  db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY5", {{1, "M"}}, &ret);
+  db.ZAdd("GP4_PKPATTERNMATCHDEL_ZSET_KEY6", {{1, "M"}}, &ret);
+  db.ZRem("GP4_PKPATTERNMATCHDEL_ZSET_KEY1", {"M"}, &ret);
+  db.ZRem("GP4_PKPATTERNMATCHDEL_ZSET_KEY3", {"M"}, &ret);
+  db.ZRem("GP4_PKPATTERNMATCHDEL_ZSET_KEY5", {"M"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kZSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 5 Test *****************
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY1_0ooo0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY2_0xxx0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY3_0ooo0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY4_0xxx0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY5_0ooo0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY6_0xxx0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY7_0ooo0", {{1, "M"}}, &ret);
-//   db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY8_0xxx0", {{1, "M"}}, &ret);
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_ZSET_KEY1_0ooo0"));
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_ZSET_KEY2_0xxx0"));
-//   db.ZRem("GP5_PKPATTERNMATCHDEL_ZSET_KEY3_0ooo0", {"M"}, &ret);
-//   db.ZRem("GP5_PKPATTERNMATCHDEL_ZSET_KEY4_0xxx0", {"M"}, &ret);
-//   s = db.PKPatternMatchDel(DataType::kZSets, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 2);
-//   keys.clear();
-//   db.Keys(DataType::kZSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 2);
-//   ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_ZSET_KEY6_0xxx0");
-//   ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_ZSET_KEY8_0xxx0");
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 5 Test *****************
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY1_0ooo0", {{1, "M"}}, &ret);
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY2_0xxx0", {{1, "M"}}, &ret);
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY3_0ooo0", {{1, "M"}}, &ret);
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY4_0xxx0", {{1, "M"}}, &ret);
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY5_0ooo0", {{1, "M"}}, &ret);
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY6_0xxx0", {{1, "M"}}, &ret);
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY7_0ooo0", {{1, "M"}}, &ret);
+  db.ZAdd("GP5_PKPATTERNMATCHDEL_ZSET_KEY8_0xxx0", {{1, "M"}}, &ret);
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_ZSET_KEY1_0ooo0"));
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_ZSET_KEY2_0xxx0"));
+  db.ZRem("GP5_PKPATTERNMATCHDEL_ZSET_KEY3_0ooo0", {"M"}, &ret);
+  db.ZRem("GP5_PKPATTERNMATCHDEL_ZSET_KEY4_0xxx0", {"M"}, &ret);
+  s = db.PKPatternMatchDel(DataType::kZSets, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 2);
+  keys.clear();
+  db.Keys(DataType::kZSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 2);
+  ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_ZSET_KEY6_0xxx0");
+  ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_ZSET_KEY8_0xxx0");
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 6 Test *****************
-//   size_t gp6_total_zset = 23333;
-//   for (size_t idx = 0; idx < gp6_total_zset; ++idx) {
-//     db.ZAdd("GP6_PKPATTERNMATCHDEL_ZSET_KEY" + std::to_string(idx), {{1, "M"}}, &ret);
-//   }
-//   s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, gp6_total_zset);
-//   keys.clear();
-//   db.Keys(DataType::kZSets, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 6 Test *****************
+  size_t gp6_total_zset = 23333;
+  for (size_t idx = 0; idx < gp6_total_zset; ++idx) {
+    db.ZAdd("GP6_PKPATTERNMATCHDEL_ZSET_KEY" + std::to_string(idx), {{1, "M"}}, &ret);
+  }
+  s = db.PKPatternMatchDel(DataType::kZSets, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, gp6_total_zset);
+  keys.clear();
+  db.Keys(DataType::kZSets, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   //=============================== List ===============================
+  //=============================== List ===============================
 
-//   // ***************** Group 1 Test *****************
-//   db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY1", {"VALUE"}, &ret64);
-//   db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY2", {"VALUE"}, &ret64);
-//   db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY3", {"VALUE"}, &ret64);
-//   db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY4", {"VALUE"}, &ret64);
-//   db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY5", {"VALUE"}, &ret64);
-//   db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY6", {"VALUE"}, &ret64);
-//   s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 6);
-//   keys.clear();
-//   db.Keys(DataType::kLists, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 1 Test *****************
+  db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY1", {"VALUE"}, &ret64);
+  db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY2", {"VALUE"}, &ret64);
+  db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY3", {"VALUE"}, &ret64);
+  db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY4", {"VALUE"}, &ret64);
+  db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY5", {"VALUE"}, &ret64);
+  db.LPush("GP1_PKPATTERNMATCHDEL_LIST_KEY6", {"VALUE"}, &ret64);
+  s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 6);
+  keys.clear();
+  db.Keys(DataType::kLists, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 2 Test *****************
-//   db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY1", {"VALUE"}, &ret64);
-//   db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY2", {"VALUE"}, &ret64);
-//   db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY3", {"VALUE"}, &ret64);
-//   db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY4", {"VALUE"}, &ret64);
-//   db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY5", {"VALUE"}, &ret64);
-//   db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY6", {"VALUE"}, &ret64);
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_LIST_KEY1"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_LIST_KEY3"));
-//   ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_LIST_KEY5"));
-//   s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kLists, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 2 Test *****************
+  db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY1", {"VALUE"}, &ret64);
+  db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY2", {"VALUE"}, &ret64);
+  db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY3", {"VALUE"}, &ret64);
+  db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY4", {"VALUE"}, &ret64);
+  db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY5", {"VALUE"}, &ret64);
+  db.LPush("GP2_PKPATTERNMATCHDEL_LIST_KEY6", {"VALUE"}, &ret64);
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_LIST_KEY1"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_LIST_KEY3"));
+  ASSERT_TRUE(make_expired(&db, "GP2_PKPATTERNMATCHDEL_LIST_KEY5"));
+  s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kLists, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 3 Test *****************
-//   db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY1_0xxx0", {"VALUE"}, &ret64);
-//   db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY2_0ooo0", {"VALUE"}, &ret64);
-//   db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY3_0xxx0", {"VALUE"}, &ret64);
-//   db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY4_0ooo0", {"VALUE"}, &ret64);
-//   db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY5_0xxx0", {"VALUE"}, &ret64);
-//   db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY6_0ooo0", {"VALUE"}, &ret64);
-//   s = db.PKPatternMatchDel(DataType::kLists, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kLists, "*", &keys);
-//   ASSERT_EQ(keys.size(), 3);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_LIST_KEY1_0xxx0", keys[0]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_LIST_KEY3_0xxx0", keys[1]);
-//   ASSERT_EQ("GP3_PKPATTERNMATCHDEL_LIST_KEY5_0xxx0", keys[2]);
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 3 Test *****************
+  db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY1_0xxx0", {"VALUE"}, &ret64);
+  db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY2_0ooo0", {"VALUE"}, &ret64);
+  db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY3_0xxx0", {"VALUE"}, &ret64);
+  db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY4_0ooo0", {"VALUE"}, &ret64);
+  db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY5_0xxx0", {"VALUE"}, &ret64);
+  db.LPush("GP3_PKPATTERNMATCHDEL_LIST_KEY6_0ooo0", {"VALUE"}, &ret64);
+  s = db.PKPatternMatchDel(DataType::kLists, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kLists, "*", &keys);
+  ASSERT_EQ(keys.size(), 3);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_LIST_KEY1_0xxx0", keys[0]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_LIST_KEY3_0xxx0", keys[1]);
+  ASSERT_EQ("GP3_PKPATTERNMATCHDEL_LIST_KEY5_0xxx0", keys[2]);
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 4 Test *****************
-//   db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY1", {"VALUE"}, &ret64);
-//   db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY2", {"VALUE"}, &ret64);
-//   db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY3", {"VALUE"}, &ret64);
-//   db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY4", {"VALUE"}, &ret64);
-//   db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY5", {"VALUE"}, &ret64);
-//   db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY6", {"VALUE"}, &ret64);
-//   db.LRem("GP4_PKPATTERNMATCHDEL_LIST_KEY1", 1, "VALUE", &ret64);
-//   db.LRem("GP4_PKPATTERNMATCHDEL_LIST_KEY3", 1, "VALUE", &ret64);
-//   db.LRem("GP4_PKPATTERNMATCHDEL_LIST_KEY5", 1, "VALUE", &ret64);
-//   s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 3);
-//   keys.clear();
-//   db.Keys(DataType::kLists, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 4 Test *****************
+  db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY1", {"VALUE"}, &ret64);
+  db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY2", {"VALUE"}, &ret64);
+  db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY3", {"VALUE"}, &ret64);
+  db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY4", {"VALUE"}, &ret64);
+  db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY5", {"VALUE"}, &ret64);
+  db.LPush("GP4_PKPATTERNMATCHDEL_LIST_KEY6", {"VALUE"}, &ret64);
+  db.LRem("GP4_PKPATTERNMATCHDEL_LIST_KEY1", 1, "VALUE", &ret64);
+  db.LRem("GP4_PKPATTERNMATCHDEL_LIST_KEY3", 1, "VALUE", &ret64);
+  db.LRem("GP4_PKPATTERNMATCHDEL_LIST_KEY5", 1, "VALUE", &ret64);
+  s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 3);
+  keys.clear();
+  db.Keys(DataType::kLists, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   // ***************** Group 5 Test *****************
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY1_0ooo0", {"VALUE"}, &ret64);
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY2_0xxx0", {"VALUE"}, &ret64);
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY3_0ooo0", {"VALUE"}, &ret64);
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY4_0xxx0", {"VALUE"}, &ret64);
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY5_0ooo0", {"VALUE"}, &ret64);
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY6_0xxx0", {"VALUE"}, &ret64);
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY7_0ooo0", {"VALUE"}, &ret64);
-//   db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY8_0xxx0", {"VALUE"}, &ret64);
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_LIST_KEY1_0ooo0"));
-//   ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_LIST_KEY2_0xxx0"));
-//   db.LRem("GP5_PKPATTERNMATCHDEL_LIST_KEY3_0ooo0", 1, "VALUE", &ret64);
-//   db.LRem("GP5_PKPATTERNMATCHDEL_LIST_KEY4_0xxx0", 1, "VALUE", &ret64);
-//   s = db.PKPatternMatchDel(DataType::kLists, "*0ooo0", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, 2);
-//   keys.clear();
-//   db.Keys(DataType::kLists, "*", &keys);
-//   ASSERT_EQ(keys.size(), 2);
-//   ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_LIST_KEY6_0xxx0");
-//   ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_LIST_KEY8_0xxx0");
-//   type_status.clear();
-//   db.Del(keys);
+  // ***************** Group 5 Test *****************
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY1_0ooo0", {"VALUE"}, &ret64);
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY2_0xxx0", {"VALUE"}, &ret64);
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY3_0ooo0", {"VALUE"}, &ret64);
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY4_0xxx0", {"VALUE"}, &ret64);
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY5_0ooo0", {"VALUE"}, &ret64);
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY6_0xxx0", {"VALUE"}, &ret64);
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY7_0ooo0", {"VALUE"}, &ret64);
+  db.LPush("GP5_PKPATTERNMATCHDEL_LIST_KEY8_0xxx0", {"VALUE"}, &ret64);
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_LIST_KEY1_0ooo0"));
+  ASSERT_TRUE(make_expired(&db, "GP5_PKPATTERNMATCHDEL_LIST_KEY2_0xxx0"));
+  db.LRem("GP5_PKPATTERNMATCHDEL_LIST_KEY3_0ooo0", 1, "VALUE", &ret64);
+  db.LRem("GP5_PKPATTERNMATCHDEL_LIST_KEY4_0xxx0", 1, "VALUE", &ret64);
+  s = db.PKPatternMatchDel(DataType::kLists, "*0ooo0", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, 2);
+  keys.clear();
+  db.Keys(DataType::kLists, "*", &keys);
+  ASSERT_EQ(keys.size(), 2);
+  ASSERT_EQ(keys[0], "GP5_PKPATTERNMATCHDEL_LIST_KEY6_0xxx0");
+  ASSERT_EQ(keys[1], "GP5_PKPATTERNMATCHDEL_LIST_KEY8_0xxx0");
+  type_status.clear();
+  db.Del(keys);
 
-//   // ***************** Group 6 Test *****************
-//   size_t gp6_total_list = 23333;
-//   for (size_t idx = 0; idx < gp6_total_list; ++idx) {
-//     db.LPush("GP6_PKPATTERNMATCHDEL_LIST_KEY" + std::to_string(idx), {"VALUE"}, &ret64);
-//   }
-//   s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
-//   ASSERT_TRUE(s.ok());
-//   ASSERT_EQ(delete_count, gp6_total_hash);
-//   keys.clear();
-//   db.Keys(DataType::kLists, "*", &keys);
-//   ASSERT_EQ(keys.size(), 0);
+  // ***************** Group 6 Test *****************
+  size_t gp6_total_list = 23333;
+  for (size_t idx = 0; idx < gp6_total_list; ++idx) {
+    db.LPush("GP6_PKPATTERNMATCHDEL_LIST_KEY" + std::to_string(idx), {"VALUE"}, &ret64);
+  }
+  s = db.PKPatternMatchDel(DataType::kLists, "*", &delete_count);
+  ASSERT_TRUE(s.ok());
+  ASSERT_EQ(delete_count, gp6_total_hash);
+  keys.clear();
+  db.Keys(DataType::kLists, "*", &keys);
+  ASSERT_EQ(keys.size(), 0);
 
-//   sleep(2);
-//   db.Compact(DataType::kAll, true);
-// }
+  sleep(2);
+  db.Compact(DataType::kAll, true);
+}
 
 // Scan
 // Note: This test needs to execute at first because all of the data is

--- a/src/storage/tests/keys_test.cc
+++ b/src/storage/tests/keys_test.cc
@@ -2098,7 +2098,7 @@ for (const auto& kv : kvs) {
 TEST_F(KeysTest, PKPatternMatchDel) {
   int32_t ret;
   uint64_t ret64;
-  int32_t delete_count;
+  int32_t delete_count = 0;
   std::vector<std::string> keys;
   std::map<DataType, Status> type_status;
 


### PR DESCRIPTION
1. add pkpatternmatchdel unit test.
2. fix pkpatternmatchdel bug for using wrong key.
3. fix basemetafilter and datafilter, because stream type doesn't have expire time and uses a different type meta value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for a new data type `kStreams`, enabling more efficient handling of stream data within filters.

- **Bug Fixes**
  - Improved error logging for stream meta values, providing more detailed information on errors.

- **Refactor**
  - Optimized the order of key and meta value assignments in pattern match deletion functions, enhancing processing flow.
  
- **Enhancements**
  - Modified the logic for accumulating results in pattern match deletions, ensuring accurate final value computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->