### PR TITLE
fix: Revised RocksDB-Related Parameters in Pika

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -240,7 +240,8 @@ slave-priority : 100
 # The disable_auto_compactions option is [true | false]
 disable_auto_compactions : false
 
-# Rocksdb max_subcompactions
+# Rocksdb max_subcompactions, increasing this value can accelerate the exec speed of a single compaction task
+# it's recommended to increase it's value if large compaction is found in you instance
 max-subcompactions : 1
 # The minimum disk usage ratio for checking resume.
 # If the disk usage ratio is lower than min-check-resume-ratio, it will not check resume, only higher will check resume.
@@ -347,17 +348,42 @@ compression : snappy
 # https://github.com/facebook/rocksdb/wiki/Compression
 #compression_per_level : [none:none:snappy:lz4:lz4]
 
+# The number of rocksdb background threads(sum of max-background-compactions and max-background-flushes)
+# If max-background-jobs has a valid value AND both 'max-background-flushs' and 'max-background-compactions' is set to -1,
+# then max-background-flushs' and 'max-background-compactions will be auto config by rocksdb, specifically:
+# 1/4 of max-background-jobs will be given to max-background-flushs' and the rest(3/4) will be given to  'max-background-compactions'.
+# 'max-background-jobs' default value is 3 and the value range is [2, 12].
+max-background-jobs : 3
+
 # The number of background flushing threads.
-# max-background-flushes default value is 1 and the value range is [1, 4].
-max-background-flushes : 1
+# max-background-flushes default value is -1 and the value range is [1, 4] or -1.
+# if 'max-background-flushes' is set to -1, the 'max-background-compactions' should also be set to -1,
+# which means let rocksdb to auto config them based on the value of 'max-background-jobs'
+max-background-flushes : -1
+
+# [NOTICE] you MUST NOT set one of the max-background-flushes or max-background-compactions to -1 while setting another one to other values(not -1).
+# They SHOULD both be -1 or both not(if you want to config them manually).
 
 # The number of background compacting threads.
-# max-background-compactions default value is 2 and the value range is [1, 8].
-max-background-compactions : 2
+# max-background-compactions default value is -1 and the value range is [1, 8] or -1.
+# if 'max-background-compactions' is set to -1, the 'max-background-flushes' should also be set to -1,
+# which means let rocksdb to auto config them based on the value of 'max-background-jobs'
+max-background-compactions : -1
 
-# The number of background threads.
-# max-background-jobs default value is 3 and the value range is [2, 12].
-max-background-jobs : 3
+# RocksDB delayed-write-rate, default is 0(infer from rate-limiter by RocksDB)
+# Ref from rocksdb: Whenever stall conditions are triggered, RocksDB will reduce write rate to delayed_write_rate,
+# and could possibly reduce write rate to even lower than delayed_write_rate if estimated pending compaction bytes accumulates.
+# If the value is 0, RcoksDB will infer a value from `rater_limiter` value if it is not empty, or 16MB if `rater_limiter` is empty.
+# Note that if users change the rate in `rate_limiter` after DB is opened, delayed_write_rate won't be adjusted.
+# [Support Dynamically changeable] send 'config set delayed-write-rate' to a running pika can change it's value dynamically
+delayed-write-rate : 0
+
+
+# RocksDB will try to limit number of bytes in one compaction to be lower than this max-compaction-bytes.
+# But it's NOT guaranteed.
+# default value is -1, means let it be 25 * target-file-size-base (Which is RocksDB's default value)
+max-compaction-bytes : -1
+
 
 # maximum value of RocksDB cached open file descriptors
 max-cache-files : 5000
@@ -423,14 +449,17 @@ default-slot-num : 1024
 # 0: Read 1: Write 2: ReadAndWrite
 # rate-limiter-mode : default 1
 
-# rate limiter bandwidth, default 2000MB/s
-#rate-limiter-bandwidth : 2097152000
+# rate limiter bandwidth, units in bytes, default 1024GB/s (No limit)
+# [Support Dynamically changeable] send 'rate-limiter-bandwidth' to a running pika can change it's value dynamically
+#rate-limiter-bandwidth : 1099511627776
 
 #rate-limiter-refill-period-us : 100000
 #
 #rate-limiter-fairness: 10
 
-# rate limiter auto tune https://rocksdb.org/blog/2017/12/18/17-auto-tuned-rate-limiter.html. the default value is false.
+# if auto_tuned is true: Enables dynamic adjustment of rate limit within the range
+#`[rate-limiter-bandwidth / 20, rate-limiter-bandwidth]`, according to the recent demand for background I/O.
+# rate limiter auto tune https://rocksdb.org/blog/2017/12/18/17-auto-tuned-rate-limiter.html. the default value is true.
 #rate-limiter-auto-tuned : true
 
 ################################## RocksDB Blob Configure #####################

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -255,6 +255,12 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return target_file_size_base_;
   }
+
+  uint64_t max_compaction_bytes() {
+    std::shared_lock l(rwlock_);
+    return static_cast<uint64_t>(max_compaction_bytes_);
+  }
+
   int max_cache_statistic_keys() {
     std::shared_lock l(rwlock_);
     return max_cache_statistic_keys_;
@@ -278,6 +284,10 @@ class PikaConf : public pstd::BaseConf {
   int max_background_jobs() {
     std::shared_lock l(rwlock_);
     return max_background_jobs_;
+  }
+  uint64_t delayed_write_rate(){
+    std::shared_lock l(rwlock_);
+    return static_cast<uint64_t>(delayed_write_rate_);
   }
   int max_cache_files() {
     std::shared_lock l(rwlock_);
@@ -723,6 +733,24 @@ class PikaConf : public pstd::BaseConf {
     arena_block_size_ = value;
   }
 
+  void SetRateLmiterBandwidth(int64_t value) {
+    std::lock_guard l(rwlock_);
+    TryPushDiffCommands("rate-limiter-bandwidth", std::to_string(value));
+    rate_limiter_bandwidth_ = value;
+  }
+
+  void SetDelayedWriteRate(int64_t value) {
+    std::lock_guard l(rwlock_);
+    TryPushDiffCommands("delayed-write-rate", std::to_string(value));
+    delayed_write_rate_ = value;
+  }
+
+  void SetMaxCompactionBytes(int64_t value) {
+    std::lock_guard l(rwlock_);
+    TryPushDiffCommands("max-compaction-bytes", std::to_string(value));
+    max_compaction_bytes_ = value;
+  }
+
   void SetLogLevel(const std::string& value) {
     std::lock_guard l(rwlock_);
     TryPushDiffCommands("loglevel", value);
@@ -862,9 +890,10 @@ class PikaConf : public pstd::BaseConf {
   int max_cache_statistic_keys_ = 0;
   int small_compaction_threshold_ = 0;
   int small_compaction_duration_threshold_ = 0;
-  int max_background_flushes_ = 1;
-  int max_background_compactions_ = 2;
+  int max_background_flushes_ = -1;
+  int max_background_compactions_ = -1;
   int max_background_jobs_ = 0;
+  int64_t delayed_write_rate_ = 0;
   int max_cache_files_ = 0;
   std::atomic<uint64_t> rocksdb_ttl_second_ = 0;
   std::atomic<uint64_t> rocksdb_periodic_second_ = 0;
@@ -908,6 +937,7 @@ class PikaConf : public pstd::BaseConf {
   //
   bool write_binlog_ = false;
   int target_file_size_base_ = 0;
+  int64_t max_compaction_bytes_ = 0;
   int binlog_file_size_ = 0;
 
   // cache
@@ -942,7 +972,7 @@ class PikaConf : public pstd::BaseConf {
   std::shared_mutex rwlock_;
 
   // Rsync Rate limiting configuration
-  int throttle_bytes_per_second_ = 207200000;
+  int throttle_bytes_per_second_ = 200 << 20; // 200MB/s
   int max_rsync_parallel_num_ = kMaxRsyncParallelNum;
   std::atomic_int64_t rsync_timeout_ms_ = 1000;
 };

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2367,7 +2367,7 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
       res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'delayed-write-rate'\r\n");
       return;
     }
-    std::unordered_map<std::string, std::string> options_map{{"delayed-write-rate", value}};
+    std::unordered_map<std::string, std::string> options_map{{"delayed_write_rate", value}};
     storage::Status s = g_pika_server->RewriteStorageOptions(storage::OptionType::kDB, options_map);
     if (!s.ok()) {
       res_.AppendStringRaw("-ERR Set delayed-write-rate wrong: " + s.ToString() + "\r\n");
@@ -2381,7 +2381,7 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
       res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'max-compaction-bytes'\r\n");
       return;
     }
-    std::unordered_map<std::string, std::string> options_map{{"max-compaction-bytes", value}};
+    std::unordered_map<std::string, std::string> options_map{{"max_compaction_bytes", value}};
     storage::Status s = g_pika_server->RewriteStorageOptions(storage::OptionType::kColumnFamily, options_map);
     if (!s.ok()) {
       res_.AppendStringRaw("-ERR Set max-compaction-bytes wrong: " + s.ToString() + "\r\n");

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1927,6 +1927,18 @@ void ConfigCmd::ConfigGet(std::string& ret) {
     EncodeNumber(&config_body, g_pika_conf->rate_limiter_bandwidth());
   }
 
+  if (pstd::stringmatch(pattern.data(), "delayed-write-rate", 1) != 0) {
+    elements += 2;
+    EncodeString(&config_body, "delayed-write-rate");
+    EncodeNumber(&config_body, g_pika_conf->delayed_write_rate());
+  }
+
+  if (pstd::stringmatch(pattern.data(), "max-compaction-bytes", 1) != 0) {
+    elements += 2;
+    EncodeString(&config_body, "max-compaction-bytes");
+    EncodeNumber(&config_body, g_pika_conf->max_compaction_bytes());
+  }
+
   if (pstd::stringmatch(pattern.data(), "rate-limiter-refill-period-us", 1) != 0) {
     elements += 2;
     EncodeString(&config_body, "rate-limiter-refill-period-us");
@@ -2340,6 +2352,43 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
     }
     g_pika_conf->SetDisableAutoCompaction(value);
     res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "rate-limiter-bandwidth") {
+    int64_t new_bandwidth = 0;
+    if (pstd::string2int(value.data(), value.size(), &new_bandwidth) == 0 || new_bandwidth <= 0) {
+      res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'rate-limiter-bandwidth'\r\n");
+      return;
+    }
+    g_pika_server->storage_options().options.rate_limiter->SetBytesPerSecond(new_bandwidth);
+    g_pika_conf->SetRateLmiterBandwidth(new_bandwidth);
+    res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "delayed-write-rate") {
+    int64_t new_delayed_write_rate = 0;
+    if (pstd::string2int(value.data(), value.size(), &new_delayed_write_rate) == 0 || new_delayed_write_rate <= 0) {
+      res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'delayed-write-rate'\r\n");
+      return;
+    }
+    std::unordered_map<std::string, std::string> options_map{{"delayed-write-rate", value}};
+    storage::Status s = g_pika_server->RewriteStorageOptions(storage::OptionType::kDB, options_map);
+    if (!s.ok()) {
+      res_.AppendStringRaw("-ERR Set delayed-write-rate wrong: " + s.ToString() + "\r\n");
+      return;
+    }
+    g_pika_conf->SetDelayedWriteRate(new_delayed_write_rate);
+    res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "max-compaction-bytes") {
+    int64_t new_max_compaction_bytes = 0;
+    if (pstd::string2int(value.data(), value.size(), &new_max_compaction_bytes) == 0 || new_max_compaction_bytes <= 0) {
+      res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'max-compaction-bytes'\r\n");
+      return;
+    }
+    std::unordered_map<std::string, std::string> options_map{{"max-compaction-bytes", value}};
+    storage::Status s = g_pika_server->RewriteStorageOptions(storage::OptionType::kColumnFamily, options_map);
+    if (!s.ok()) {
+      res_.AppendStringRaw("-ERR Set max-compaction-bytes wrong: " + s.ToString() + "\r\n");
+      return;
+    }
+    g_pika_conf->SetMaxCompactionBytes(new_max_compaction_bytes);
+    res_.AppendStringRaw("+OK\r\n");
   } else if (set_item == "max-client-response-size") {
     if ((pstd::string2int(value.data(), value.size(), &ival) == 0) || ival < 0) {
       res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'max-client-response-size'\r\n");
@@ -2459,7 +2508,7 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
     g_pika_conf->SetMaxCacheFiles(static_cast<int>(ival));
     res_.AppendStringRaw("+OK\r\n");
   } else if (set_item == "max-background-compactions") {
-    if (pstd::string2int(value.data(), value.size(), &ival) == 0) {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0) {
       res_.AppendStringRaw( "-ERR Invalid argument \'" + value + "\' for CONFIG SET 'max-background-compactions'\r\n");
       return;
     }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1299,10 +1299,12 @@ void PikaServer::InitStorageOptions() {
   storage_options_.options.max_bytes_for_level_base = g_pika_conf->level0_file_num_compaction_trigger() * g_pika_conf->write_buffer_size();
   storage_options_.options.max_subcompactions = g_pika_conf->max_subcompactions();
   storage_options_.options.target_file_size_base = g_pika_conf->target_file_size_base();
+  storage_options_.options.max_compaction_bytes = g_pika_conf->max_compaction_bytes();
   storage_options_.options.max_background_flushes = g_pika_conf->max_background_flushes();
   storage_options_.options.max_background_compactions = g_pika_conf->max_background_compactions();
   storage_options_.options.disable_auto_compactions = g_pika_conf->disable_auto_compactions();
   storage_options_.options.max_background_jobs = g_pika_conf->max_background_jobs();
+  storage_options_.options.delayed_write_rate = g_pika_conf->delayed_write_rate();
   storage_options_.options.max_open_files = g_pika_conf->max_cache_files();
   storage_options_.options.max_bytes_for_level_multiplier = g_pika_conf->max_bytes_for_level_multiplier();
   storage_options_.options.optimize_filters_for_hits = g_pika_conf->optimize_filters_for_hits();
@@ -1337,7 +1339,6 @@ void PikaServer::InitStorageOptions() {
     storage_options_.table_options.block_cache =
         rocksdb::NewLRUCache(storage_options_.block_cache_size, static_cast<int>(g_pika_conf->num_shard_bits()));
   }
-
   storage_options_.options.rate_limiter =
       std::shared_ptr<rocksdb::RateLimiter>(
           rocksdb::NewGenericRateLimiter(
@@ -1347,7 +1348,6 @@ void PikaServer::InitStorageOptions() {
               static_cast<rocksdb::RateLimiter::Mode>(g_pika_conf->rate_limiter_mode()),
               g_pika_conf->rate_limiter_auto_tuned()
                   ));
-
   // For Storage small compaction
   storage_options_.statistics_max_size = g_pika_conf->max_cache_statistic_keys();
   storage_options_.small_compaction_threshold = g_pika_conf->small_compaction_threshold();


### PR DESCRIPTION
 1 set the default value of rate-limiter to 1024GB and make it dynamically changeable
 2 allow user to config max-background-flushes and max-background-compactions to -1 while max-background-jobs is given
 3 add conf item delayed-write-rate and make it dynamically changeable
 4 add conf item max-compaction-bytes and make it dynamically changeable
 4 revised the comment of rate-limiter-auto-tuned in [pika.co](http://pika.co/)nf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic control over write rates with `delayed-write-rate`.
  - Added a limit to the number of bytes in a single compaction with `max-compaction-bytes`.
  - Enhanced configuration flexibility with `max-background-jobs`, `max-background-flushes`, and `max-background-compactions`.

- **Improvements**
  - Enabled dynamic adjustments to rate limiter bandwidth.
  - Improved documentation and guidelines within the configuration for better usability.

- **Error Handling**
  - Enhanced error handling for setting and validating new configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->