### PR TITLE
fix:ttl will deafult 0 when keys have ttl

### DIFF
--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -533,7 +533,7 @@ void MgetCmd::Do() {
     cache_miss_keys_ = keys_;
   }
   db_value_status_array_.clear();
-  s_ = db_->storage()->MGet(cache_miss_keys_, &db_value_status_array_);
+  s_ = db_->storage()->MGetWithTTL(cache_miss_keys_, &db_value_status_array_);
   if (!s_.ok()) {
     if (s_.IsInvalidArgument()) {
       res_.SetRes(CmdRes::kMultiKey);

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -1114,6 +1114,7 @@ class Storage {
 
   // For scan keys in data base
   std::atomic<bool> scan_keynum_exit_ = {false};
+  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
 };
 
 }  //  namespace storage

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -156,6 +156,7 @@ class Redis {
   Status Get(const Slice& key, std::string* value);
   Status MGet(const Slice& key, std::string* value);
   Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
+  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
   Status GetBit(const Slice& key, int64_t offset, int32_t* ret);
   Status Getrange(const Slice& key, int64_t start_offset, int64_t end_offset, std::string* ret);
   Status GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -357,38 +357,48 @@ Status Redis::MGet(const Slice& key, std::string* value) {
   return s;
 }
 
+void ClearValueAndSetTTL(std::string* value, int64_t* ttl, int64_t ttl_value) {
+  value->clear();
+  *ttl = ttl_value;
+}
+
+int64_t CalculateTTL(int64_t expiry_time) {
+  int64_t current_time;
+  rocksdb::Env::Default()->GetCurrentTime(&current_time);
+  return expiry_time - current_time >= 0 ? expiry_time - current_time : -2;
+}
+
+Status HandleParsedStringsValue(ParsedStringsValue& parsed_strings_value, std::string* value, int64_t* ttl) {
+  if (parsed_strings_value.IsStale()) {
+    ClearValueAndSetTTL(value, ttl, -2);
+    return Status::NotFound("Stale");
+  } else {
+    parsed_strings_value.StripSuffix();
+    int64_t expiry_time = parsed_strings_value.Etime();
+    *ttl = (expiry_time == 0) ? -1 : CalculateTTL(expiry_time);
+  }
+  return Status::OK();
+}
+
 Status Redis::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
   value->clear();
   BaseKey base_key(key);
   Status s = db_->Get(default_read_options_, base_key.Encode(), value);
   std::string meta_value = *value;
+
   if (s.ok() && !ExpectedMetaValue(DataType::kStrings, meta_value)) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + " get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
+
   if (s.ok()) {
     ParsedStringsValue parsed_strings_value(value);
-    if (parsed_strings_value.IsStale()) {
-      value->clear();
-      *ttl = -2;
-      return Status::NotFound("Stale");
-    } else {
-      parsed_strings_value.StripSuffix();
-      *ttl = parsed_strings_value.Etime();
-      if (*ttl == 0) {
-        *ttl = -1;
-      } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
-        *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
-      }
-    }
+    return HandleParsedStringsValue(parsed_strings_value, value, ttl);
   } else if (s.IsNotFound()) {
-    value->clear();
-    *ttl = -2;
+    ClearValueAndSetTTL(value, ttl, -2);
   }
 
   return s;
@@ -399,29 +409,16 @@ Status Redis::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
   BaseKey base_key(key);
   Status s = db_->Get(default_read_options_, base_key.Encode(), value);
   std::string meta_value = *value;
+
   if (s.ok() && !ExpectedMetaValue(DataType::kStrings, meta_value)) {
-      s = Status::NotFound();
+    s = Status::NotFound();
   }
+
   if (s.ok()) {
     ParsedStringsValue parsed_strings_value(value);
-    if (parsed_strings_value.IsStale()) {
-      value->clear();
-      *ttl = -2;
-      return Status::NotFound("Stale");
-    } else {
-      parsed_strings_value.StripSuffix();
-      *ttl = parsed_strings_value.Etime();
-      if (*ttl == 0) {
-        *ttl = -1;
-      } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
-        *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
-      }
-    }
+    return HandleParsedStringsValue(parsed_strings_value, value, ttl);
   } else if (s.IsNotFound()) {
-    value->clear();
-    *ttl = -2;
+    ClearValueAndSetTTL(value, ttl, -2);
   }
 
   return s;

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -155,6 +155,11 @@ Status Storage::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
   return inst->GetWithTTL(key, value, ttl);
 }
 
+Status Storage::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
+  auto& inst = GetDBInstance(key);
+  return inst->MGetWithTTL(key, value, ttl);
+}
+
 Status Storage::GetSet(const Slice& key, const Slice& value, std::string* old_value) {
   auto& inst = GetDBInstance(key);
   return inst->GetSet(key, value, old_value);
@@ -208,7 +213,7 @@ Status Storage::MGetWithTTL(const std::vector<std::string>& keys, std::vector<Va
     auto& inst = GetDBInstance(key);
     std::string value;
     int64_t ttl;
-    s = inst->GetWithTTL(key, &value, &ttl);
+    s = inst->MGetWithTTL(key, &value, &ttl);
     if (s.ok()) {
       vss->push_back({value, Status::OK(), ttl});
     } else if (s.IsNotFound()) {


### PR DESCRIPTION
写mgetwithttl这个函数的目的是：
当mget多个key，其中有一些key不是string类型的时候，返回nil而不是返回 错误，这里跟redis保持一致了

- **New Features**
  - Introduced a new method to retrieve values along with their Time To Live (TTL) information for multiple keys in the Storage class. This feature allows users to fetch data along with its expiration details in one call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a method to retrieve multiple key-value pairs with their time-to-live (TTL) information.

- **Enhancements**
  - Improved the `GetWithTTL` method to better handle value retrieval and TTL calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->