### PR TITLE
fix: pksetexat should update cache

### DIFF
--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -792,6 +792,8 @@ class PKSetexAtCmd : public Cmd {
     return res;
   }
   void Do() override;
+  void DoThroughDB() override;
+  void DoUpdateCache() override;
   void Split(const HintKeys& hint_keys) override {};
   void Merge() override {};
   Cmd* Clone() override { return new PKSetexAtCmd(*this); }

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -370,7 +370,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameScanx, std::move(scanxptr)));
   ////PKSetexAtCmd
   std::unique_ptr<Cmd> pksetexatptr = std::make_unique<PKSetexAtCmd>(
-      kCmdNamePKSetexAt, 4, kCmdFlagsWrite |  kCmdFlagsKv | kCmdFlagsSlow);
+      kCmdNamePKSetexAt, 4, kCmdFlagsWrite |  kCmdFlagsKv | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNamePKSetexAt, std::move(pksetexatptr)));
   ////PKScanRange
   std::unique_ptr<Cmd> pkscanrangeptr = std::make_unique<PKScanRangeCmd>(

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1711,8 +1711,9 @@ void PKSetexAtCmd::DoThroughDB() {
 void PKSetexAtCmd::DoUpdateCache() {
   if (s_.ok()) {
     auto expire = time_stamp_ - static_cast<int64_t>(std::time(nullptr));
-    if (expire <= 0) {
-      // TODO(): handle error
+    if (expire <= 0) [[unlikely]] {
+      db_->cache()->Del({key_});
+      return;
     }
     db_->cache()->Setxx(key_, value_, expire);
   }

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1704,6 +1704,20 @@ void PKSetexAtCmd::Do() {
   }
 }
 
+void PKSetexAtCmd::DoThroughDB() {
+  Do();
+}
+
+void PKSetexAtCmd::DoUpdateCache() {
+  if (s_.ok()) {
+    auto expire = time_stamp_ - static_cast<int64_t>(std::time(nullptr));
+    if (expire <= 0) {
+      // TODO(): handle error
+    }
+    db_->cache()->Setxx(key_, value_, expire);
+  }
+}
+
 void PKScanRangeCmd::DoInitial() {
   if (!CheckArg(argv_.size())) {
     res_.SetRes(CmdRes::kWrongNum, kCmdNamePKScanRange);


### PR DESCRIPTION
issure: https://github.com/OpenAtomFoundation/pika/issues/2700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `PKSetexAtCmd` command to support database operations and cache updates automatically. 

- **Bug Fixes**
  - Improved command flags to ensure comprehensive execution with database and cache synchronization.

These changes optimize command execution and boost performance by ensuring that relevant data is consistently updated both in the database and the cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->