### PR TITLE
docs: modify run pika in docker  readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,10 +254,10 @@ Users can directly download the latest binary version package from [releases](ht
 
   Modify the following configuration items of the conf file:
  ```
-log-path : /data/log/
-db-path : /data/db/
-db-sync-path : /data/dbsync/
-dump-path : /data/dump/
+  log-path : /data/log/
+  db-path : /data/db/
+  db-sync-path : /data/dbsync/
+  dump-path : /data/dump/
  ```
 
   And then execute the following statement to start pika in docker:

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Users can directly download the latest binary version package from [releases](ht
 
 * #### 3.1 Running with Docker
 
-  Modify the following configuration items of the conf file:
+  Modify the following configuration items of conf/pika.conf file:
  ```
 log-path : /data/log/
 db-path : /data/db/

--- a/README.md
+++ b/README.md
@@ -252,14 +252,14 @@ Users can directly download the latest binary version package from [releases](ht
 
 * #### 3.1 Running with Docker
 
+  Modify the conf/pika.conf file, change log-path value to /data/log/, db-path value to /data/db/, dump-path value to /data/dump/, and db-sync-path value to /data/dbsync/, and then execute the following statement to start pika in docker:
+
   ```bash
   docker run -d \
     --restart=always \
     -p 9221:9221 \
-    -v <log_dir>:/pika/log \
-    -v <db_dir>:/pika/db \
-    -v <dump_dir>:/pika/dump \
-    -v <dbsync_dir>:/pika/dbsync \
+    -v "$(pwd)/conf":"/pika/conf" \
+    -v "/tmp/pika-data":"/data" \
     pikadb/pika:v3.3.6
 
   redis-cli -p 9221 "info"

--- a/README.md
+++ b/README.md
@@ -252,9 +252,16 @@ Users can directly download the latest binary version package from [releases](ht
 
 * #### 3.1 Running with Docker
 
-  Modify the conf/pika.conf file, change log-path value to /data/log/, db-path value to /data/db/, dump-path value to /data/dump/, and db-sync-path value to /data/dbsync/, and then execute the following statement to start pika in docker:
+  Modify the following configuration items of the conf file:
+ ```
+log-path : /data/log/
+db-path : /data/db/
+db-sync-path : /data/dbsync/
+dump-path : /data/dump/
+ ```
 
-  ```bash
+  And then execute the following statement to start pika in docker:
+ ```bash
   docker run -d \
     --restart=always \
     -p 9221:9221 \


### PR DESCRIPTION
fix https://github.com/OpenAtomFoundation/pika/issues/2740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated README to reflect new paths for log, database, dump, and database synchronization directories when using Pika with Docker.
  - Adjusted Docker run command in README to match new path configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->