### PR TITLE
fix: duplicate meta key read

### DIFF
--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -117,36 +117,36 @@ class Redis {
   Status ScanStreamsKeyNum(KeyInfo* key_info);
 
   // Keys Commands
-  virtual Status StringsExpire(const Slice& key, int64_t ttl);
-  virtual Status HashesExpire(const Slice& key, int64_t ttl);
-  virtual Status ListsExpire(const Slice& key, int64_t ttl);
-  virtual Status ZsetsExpire(const Slice& key, int64_t ttl);
-  virtual Status SetsExpire(const Slice& key, int64_t ttl);
+  virtual Status StringsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
+  virtual Status HashesExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
+  virtual Status ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
+  virtual Status ZsetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
+  virtual Status SetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
 
-  virtual Status StringsDel(const Slice& key);
-  virtual Status HashesDel(const Slice& key);
-  virtual Status ListsDel(const Slice& key);
-  virtual Status ZsetsDel(const Slice& key);
-  virtual Status SetsDel(const Slice& key);
-  virtual Status StreamsDel(const Slice& key);
+  virtual Status StringsDel(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status HashesDel(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status ListsDel(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status ZsetsDel(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status SetsDel(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status StreamsDel(const Slice& key, std::string&& prefetch_meta = {});
 
-  virtual Status StringsExpireat(const Slice& key, int64_t timestamp);
-  virtual Status HashesExpireat(const Slice& key, int64_t timestamp);
-  virtual Status ListsExpireat(const Slice& key, int64_t timestamp);
-  virtual Status SetsExpireat(const Slice& key, int64_t timestamp);
-  virtual Status ZsetsExpireat(const Slice& key, int64_t timestamp);
+  virtual Status StringsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
+  virtual Status HashesExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
+  virtual Status ListsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
+  virtual Status SetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
+  virtual Status ZsetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
 
-  virtual Status StringsPersist(const Slice& key);
-  virtual Status HashesPersist(const Slice& key);
-  virtual Status ListsPersist(const Slice& key);
-  virtual Status ZsetsPersist(const Slice& key);
-  virtual Status SetsPersist(const Slice& key);
+  virtual Status StringsPersist(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status HashesPersist(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status ListsPersist(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status ZsetsPersist(const Slice& key, std::string&& prefetch_meta = {});
+  virtual Status SetsPersist(const Slice& key, std::string&& prefetch_meta = {});
 
-  virtual Status StringsTTL(const Slice& key, int64_t* timestamp);
-  virtual Status HashesTTL(const Slice& key, int64_t* timestamp);
-  virtual Status ListsTTL(const Slice& key, int64_t* timestamp);
-  virtual Status ZsetsTTL(const Slice& key, int64_t* timestamp);
-  virtual Status SetsTTL(const Slice& key, int64_t* timestamp);
+  virtual Status StringsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
+  virtual Status HashesTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
+  virtual Status ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
+  virtual Status ZsetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
+  virtual Status SetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
 
   // Strings Commands
   Status Append(const Slice& key, const Slice& value, int32_t* ret);
@@ -200,7 +200,7 @@ class Redis {
   Status HIncrby(const Slice& key, const Slice& field, int64_t value, int64_t* ret);
   Status HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by, std::string* new_value);
   Status HKeys(const Slice& key, std::vector<std::string>* fields);
-  Status HLen(const Slice& key, int32_t* ret);
+  Status HLen(const Slice& key, int32_t* ret, std::string&& prefetch_meta = {});
   Status HMGet(const Slice& key, const std::vector<std::string>& fields, std::vector<ValueStatus>* vss);
   Status HMSet(const Slice& key, const std::vector<FieldValue>& fvs);
   Status HSet(const Slice& key, const Slice& field, const Slice& value, int32_t* res);
@@ -246,7 +246,7 @@ class Redis {
 
   // Sets Commands
   Status SAdd(const Slice& key, const std::vector<std::string>& members, int32_t* ret);
-  Status SCard(const Slice& key, int32_t* ret);
+  Status SCard(const Slice& key, int32_t* ret, std::string&& prefetch_meta = {});
   Status SDiff(const std::vector<std::string>& keys, std::vector<std::string>* members);
   Status SDiffstore(const Slice& destination, const std::vector<std::string>& keys, std::vector<std::string>& value_to_dest, int32_t* ret);
   Status SInter(const std::vector<std::string>& keys, std::vector<std::string>* members);
@@ -269,7 +269,7 @@ class Redis {
   Status LIndex(const Slice& key, int64_t index, std::string* element);
   Status LInsert(const Slice& key, const BeforeOrAfter& before_or_after, const std::string& pivot,
                  const std::string& value, int64_t* ret);
-  Status LLen(const Slice& key, uint64_t* len);
+  Status LLen(const Slice& key, uint64_t* len, std::string&& prefetch_meta = {});
   Status LPop(const Slice& key, int64_t count, std::vector<std::string>* elements);
   Status LPush(const Slice& key, const std::vector<std::string>& values, uint64_t* ret);
   Status LPushx(const Slice& key, const std::vector<std::string>& values, uint64_t* len);
@@ -285,7 +285,7 @@ class Redis {
 
   // Zsets Commands
   Status ZAdd(const Slice& key, const std::vector<ScoreMember>& score_members, int32_t* ret);
-  Status ZCard(const Slice& key, int32_t* card);
+  Status ZCard(const Slice& key, int32_t* card, std::string&& prefetch_meta = {});
   Status ZCount(const Slice& key, double min, double max, bool left_close, bool right_close, int32_t* ret);
   Status ZIncrby(const Slice& key, const Slice& member, double increment, double* ret);
   Status ZRange(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members);
@@ -323,7 +323,7 @@ class Redis {
   Status XAdd(const Slice& key, const std::string& serialized_message, StreamAddTrimArgs& args);
   Status XDel(const Slice& key, const std::vector<streamID>& ids, int32_t& count);
   Status XTrim(const Slice& key, StreamAddTrimArgs& args, int32_t& count);
-  Status XRange(const Slice& key, const StreamScanArgs& args, std::vector<IdMessage>& id_messages);
+  Status XRange(const Slice& key, const StreamScanArgs& args, std::vector<IdMessage>& id_messages, std::string&& prefetch_meta = {});
   Status XRevrange(const Slice& key, const StreamScanArgs& args, std::vector<IdMessage>& id_messages);
   Status XLen(const Slice& key, int32_t& len);
   Status XRead(const StreamReadGroupReadArgs& args, std::vector<std::vector<IdMessage>>& results,
@@ -333,7 +333,7 @@ class Redis {
                     rocksdb::ReadOptions& read_options);
   // get and parse the stream meta if found
   // @return ok only when the stream meta exists
-  Status GetStreamMeta(StreamMetaValue& tream_meta, const rocksdb::Slice& key, rocksdb::ReadOptions& read_options);
+  Status GetStreamMeta(StreamMetaValue& tream_meta, const rocksdb::Slice& key, rocksdb::ReadOptions& read_options, std::string&& prefetch_meta = {});
 
   // Before calling this function, the caller should ensure that the ids are valid
   Status DeleteStreamMessages(const rocksdb::Slice& key, const StreamMetaValue& stream_meta,

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -88,7 +88,10 @@ Status Redis::HDel(const Slice& key, const std::vector<std::string>& fields, int
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -149,7 +152,10 @@ Status Redis::HGet(const Slice& key, const Slice& field, std::string* value) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -186,7 +192,10 @@ Status Redis::HGetall(const Slice& key, std::vector<FieldValue>* fvs) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -226,7 +235,10 @@ Status Redis::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -281,7 +293,10 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -370,7 +385,10 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -445,14 +463,16 @@ Status Redis::HKeys(const Slice& key, std::vector<std::string>* fields) {
   ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
 
-
   BaseMetaKey base_meta_key(key);
   Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -477,17 +497,25 @@ Status Redis::HKeys(const Slice& key, std::vector<std::string>* fields) {
   return s;
 }
 
-Status Redis::HLen(const Slice& key, int32_t* ret) {
+Status Redis::HLen(const Slice& key, int32_t* ret, std::string&& prefetch_meta) {
   *ret = 0;
-  std::string meta_value;
+  Status s;
+  std::string meta_value(std::move(prefetch_meta));
 
-  BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    BaseMetaKey base_meta_key(key);
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+        return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -523,7 +551,10 @@ Status Redis::HMGet(const Slice& key, const std::vector<std::string>& fields, st
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -584,7 +615,10 @@ Status Redis::HMSet(const Slice& key, const std::vector<FieldValue>& fvs) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -656,7 +690,10 @@ Status Redis::HSet(const Slice& key, const Slice& field, const Slice& value, int
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -728,7 +765,10 @@ Status Redis::HSetnx(const Slice& key, const Slice& field, const Slice& value, i
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -788,7 +828,10 @@ Status Redis::HVals(const Slice& key, std::vector<std::string>* values) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -848,7 +891,10 @@ Status Redis::HScan(const Slice& key, int64_t cursor, const std::string& pattern
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -922,7 +968,10 @@ Status Redis::HScanx(const Slice& key, const std::string& start_field, const std
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -983,14 +1032,16 @@ Status Redis::PKHScanRange(const Slice& key, const Slice& field_start, const std
     return Status::InvalidArgument("error in given range");
   }
 
-
   BaseMetaKey base_meta_key(key);
   Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1052,14 +1103,16 @@ Status Redis::PKHRScanRange(const Slice& key, const Slice& field_start, const st
     return Status::InvalidArgument("error in given range");
   }
 
-
   BaseMetaKey base_meta_key(key);
   Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1103,17 +1156,25 @@ Status Redis::PKHRScanRange(const Slice& key, const Slice& field_start, const st
   return Status::OK();
 }
 
-Status Redis::HashesExpire(const Slice& key, int64_t ttl) {
-  std::string meta_value;
+Status Redis::HashesExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+        return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1135,17 +1196,25 @@ Status Redis::HashesExpire(const Slice& key, int64_t ttl) {
   return s;
 }
 
-Status Redis::HashesDel(const Slice& key) {
-  std::string meta_value;
+Status Redis::HashesDel(const Slice& key, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+        return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1164,17 +1233,25 @@ Status Redis::HashesDel(const Slice& key) {
   return s;
 }
 
-Status Redis::HashesExpireat(const Slice& key, int64_t timestamp) {
-  std::string meta_value;
+Status Redis::HashesExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+        return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1195,17 +1272,25 @@ Status Redis::HashesExpireat(const Slice& key, int64_t timestamp) {
   return s;
 }
 
-Status Redis::HashesPersist(const Slice& key) {
-  std::string meta_value;
+Status Redis::HashesPersist(const Slice& key, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+        return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1227,16 +1312,24 @@ Status Redis::HashesPersist(const Slice& key) {
   return s;
 }
 
-Status Redis::HashesTTL(const Slice& key, int64_t* timestamp) {
-  std::string meta_value;
-
+Status Redis::HashesTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
+  Status s;
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kHashes)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kHashes, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+        return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kHashes)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -72,7 +72,10 @@ Status Redis::LIndex(const Slice& key, int64_t index, std::string* element) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -113,7 +116,10 @@ Status Redis::LInsert(const Slice& key, const BeforeOrAfter& before_or_after, co
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -211,17 +217,25 @@ Status Redis::LInsert(const Slice& key, const BeforeOrAfter& before_or_after, co
   return s;
 }
 
-Status Redis::LLen(const Slice& key, uint64_t* len) {
+Status Redis::LLen(const Slice& key, uint64_t* len, std::string&& prefetch_meta) {
   *len = 0;
-  std::string meta_value;
+  Status s;
 
-  BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  std::string meta_value(std::move(prefetch_meta));
+  if (meta_value.empty()) {
+    BaseMetaKey base_meta_key(key);
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -253,7 +267,10 @@ Status Redis::LPop(const Slice& key, int64_t count, std::vector<std::string>* el
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -308,7 +325,10 @@ Status Redis::LPush(const Slice& key, const std::vector<std::string>& values, ui
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -361,7 +381,10 @@ Status Redis::LPushx(const Slice& key, const std::vector<std::string>& values, u
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -402,7 +425,10 @@ Status Redis::LRange(const Slice& key, int64_t start, int64_t stop, std::vector<
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -459,7 +485,10 @@ Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -526,7 +555,10 @@ Status Redis::LRem(const Slice& key, int64_t count, const Slice& value, uint64_t
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -655,7 +687,10 @@ Status Redis::LSet(const Slice& key, int64_t index, const Slice& value) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -696,7 +731,10 @@ Status Redis::LTrim(const Slice& key, int64_t start, int64_t stop) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -766,7 +804,10 @@ Status Redis::RPop(const Slice& key, int64_t count, std::vector<std::string>* el
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -820,7 +861,10 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + destination.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + destination.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -872,7 +916,10 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
     if (ExpectedStale(source_meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + source.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(source_meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + source.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(source_meta_value))]);
     }
   }
   if (s.ok()) {
@@ -907,7 +954,10 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
     if (ExpectedStale(destination_meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + destination.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(destination_meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + destination.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(destination_meta_value))]);
     }
   }
   if (s.ok()) {
@@ -961,7 +1011,10 @@ Status Redis::RPush(const Slice& key, const std::vector<std::string>& values, ui
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1014,7 +1067,10 @@ Status Redis::RPushx(const Slice& key, const std::vector<std::string>& values, u
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1041,17 +1097,25 @@ Status Redis::RPushx(const Slice& key, const std::vector<std::string>& values, u
   return s;
 }
 
-Status Redis::ListsExpire(const Slice& key, int64_t ttl) {
-  std::string meta_value;
+Status Redis::ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1073,17 +1137,25 @@ Status Redis::ListsExpire(const Slice& key, int64_t ttl) {
   return s;
 }
 
-Status Redis::ListsDel(const Slice& key) {
-  std::string meta_value;
+Status Redis::ListsDel(const Slice& key, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1102,17 +1174,25 @@ Status Redis::ListsDel(const Slice& key) {
   return s;
 }
 
-Status Redis::ListsExpireat(const Slice& key, int64_t timestamp) {
-  std::string meta_value;
+Status Redis::ListsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1133,16 +1213,25 @@ Status Redis::ListsExpireat(const Slice& key, int64_t timestamp) {
   return s;
 }
 
-Status Redis::ListsPersist(const Slice& key) {
-  std::string meta_value;
+Status Redis::ListsPersist(const Slice& key, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1152,8 +1241,8 @@ Status Redis::ListsPersist(const Slice& key) {
     } else if (parsed_lists_meta_value.Count() == 0) {
       return Status::NotFound();
     } else {
-      uint64_t timestamp = parsed_lists_meta_value.Etime();
-      if (timestamp == 0) {
+      // Check if the list has set expiration time before attempting to persist
+      if (parsed_lists_meta_value.Etime() == 0) {
         return Status::NotFound("Not have an associated timeout");
       } else {
         parsed_lists_meta_value.SetEtime(0);
@@ -1164,16 +1253,24 @@ Status Redis::ListsPersist(const Slice& key) {
   return s;
 }
 
-Status Redis::ListsTTL(const Slice& key, int64_t* timestamp) {
-  std::string meta_value;
-
+Status Redis::ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kLists)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kLists, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kLists)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1185,6 +1282,7 @@ Status Redis::ListsTTL(const Slice& key, int64_t* timestamp) {
       *timestamp = -2;
       return Status::NotFound();
     } else {
+      // Return -1 for lists with no set expiration, and calculate remaining time for others
       *timestamp = parsed_lists_meta_value.Etime();
       if (*timestamp == 0) {
         *timestamp = -1;

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -83,7 +83,10 @@ rocksdb::Status Redis::SAdd(const Slice& key, const std::vector<std::string>& me
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -146,19 +149,25 @@ rocksdb::Status Redis::SAdd(const Slice& key, const std::vector<std::string>& me
   return db_->Write(default_write_options_, &batch);
 }
 
-rocksdb::Status Redis::SCard(const Slice& key, int32_t* ret) {
+rocksdb::Status Redis::SCard(const Slice& key, int32_t* ret, std::string&& meta) {
   *ret = 0;
-  std::string meta_value;
-
-  BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  std::string meta_value(std::move(meta));
+  rocksdb::Status s;
+  if (meta_value.empty()) {
+    BaseMetaKey base_meta_key(key);
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
+
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -195,7 +204,10 @@ rocksdb::Status Redis::SDiff(const std::vector<std::string>& keys, std::vector<s
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + keys[idx] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+       return Status::InvalidArgument(
+          "WRONGTYPE, key: " + keys[idx] + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -214,7 +226,10 @@ rocksdb::Status Redis::SDiff(const std::vector<std::string>& keys, std::vector<s
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + keys[0] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + keys[0] + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -280,7 +295,10 @@ rocksdb::Status Redis::SDiffstore(const Slice& destination, const std::vector<st
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + keys[idx] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + keys[idx] + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -300,7 +318,10 @@ rocksdb::Status Redis::SDiffstore(const Slice& destination, const std::vector<st
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + keys[0] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + keys[0] + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -346,7 +367,10 @@ rocksdb::Status Redis::SDiffstore(const Slice& destination, const std::vector<st
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + destination.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + destination.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -401,7 +425,10 @@ rocksdb::Status Redis::SInter(const std::vector<std::string>& keys, std::vector<
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + keys[idx] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+       return Status::InvalidArgument(
+          "WRONGTYPE, key: " + keys[idx] + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -424,7 +451,10 @@ rocksdb::Status Redis::SInter(const std::vector<std::string>& keys, std::vector<
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + keys[0] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + keys[0] + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -496,7 +526,10 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + keys[idx] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+       return Status::InvalidArgument(
+          "WRONGTYPE, key: " + keys[idx] + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -523,7 +556,10 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + keys[0] + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+        "WRONGTYPE, key: " + keys[0] + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -575,7 +611,10 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + destination.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + destination.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -624,7 +663,10 @@ rocksdb::Status Redis::SIsmember(const Slice& key, const Slice& member, int32_t*
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -661,14 +703,20 @@ rocksdb::Status Redis::SMembers(const Slice& key, std::vector<std::string>* memb
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -709,7 +757,10 @@ Status Redis::SMembersWithTTL(const Slice& key,
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -768,7 +819,10 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + source.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + source.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -811,7 +865,10 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + destination.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + destination.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -872,7 +929,10 @@ rocksdb::Status Redis::SPop(const Slice& key, std::vector<std::string>* members,
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -986,7 +1046,10 @@ rocksdb::Status Redis::SRandmember(const Slice& key, int32_t count, std::vector<
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1057,7 +1120,10 @@ rocksdb::Status Redis::SRem(const Slice& key, const std::vector<std::string>& me
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1121,7 +1187,10 @@ rocksdb::Status Redis::SUnion(const std::vector<std::string>& keys, std::vector<
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + key + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -1178,7 +1247,10 @@ rocksdb::Status Redis::SUnionstore(const Slice& destination, const std::vector<s
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + key + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -1217,7 +1289,10 @@ rocksdb::Status Redis::SUnionstore(const Slice& destination, const std::vector<s
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + destination.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + destination.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1274,7 +1349,10 @@ rocksdb::Status Redis::SScan(const Slice& key, int64_t cursor, const std::string
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -1329,17 +1407,25 @@ rocksdb::Status Redis::SScan(const Slice& key, int64_t cursor, const std::string
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status Redis::SetsExpire(const Slice& key, int64_t ttl) {
-  std::string meta_value;
+rocksdb::Status Redis::SetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  rocksdb::Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+          return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1361,17 +1447,25 @@ rocksdb::Status Redis::SetsExpire(const Slice& key, int64_t ttl) {
   return s;
 }
 
-rocksdb::Status Redis::SetsDel(const Slice& key) {
-  std::string meta_value;
+rocksdb::Status Redis::SetsDel(const Slice& key, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
+  rocksdb::Status s;
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+          return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1390,17 +1484,25 @@ rocksdb::Status Redis::SetsDel(const Slice& key) {
   return s;
 }
 
-rocksdb::Status Redis::SetsExpireat(const Slice& key, int64_t timestamp) {
-  std::string meta_value;
+rocksdb::Status Redis::SetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+          return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1421,17 +1523,25 @@ rocksdb::Status Redis::SetsExpireat(const Slice& key, int64_t timestamp) {
   return s;
 }
 
-rocksdb::Status Redis::SetsPersist(const Slice& key) {
-  std::string meta_value;
+rocksdb::Status Redis::SetsPersist(const Slice& key, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  rocksdb::Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+          return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1453,16 +1563,24 @@ rocksdb::Status Redis::SetsPersist(const Slice& key) {
   return s;
 }
 
-rocksdb::Status Redis::SetsTTL(const Slice& key, int64_t* timestamp) {
-  std::string meta_value;
-
+rocksdb::Status Redis::SetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta) {
+  std::string meta_value(std::move(prefetch_meta));
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
-    if (ExpectedStale(meta_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kSets)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+  rocksdb::Status s;
+
+  // meta_value is empty means no meta value get before,
+  // we should get meta first
+  if (meta_value.empty()) {
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kSets, meta_value)) {
+      if (ExpectedStale(meta_value)) {
+        s = Status::NotFound();
+      } else {
+          return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kSets)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      }
     }
   }
   if (s.ok()) {

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -74,7 +74,10 @@ Status Redis::Append(const Slice& key, const Slice& value, int32_t* ret) {
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -127,7 +130,10 @@ Status Redis::BitCount(const Slice& key, int64_t start_offset, int64_t end_offse
     if (ExpectedStale(value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
     }
   }
   if (s.ok()) {
@@ -230,7 +236,10 @@ Status Redis::BitOp(BitOpType op, const std::string& dest_key, const std::vector
       if (ExpectedStale(value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + dest_key + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + dest_key + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
       }
     }
     if (s.ok()) {
@@ -273,7 +282,10 @@ Status Redis::Decrby(const Slice& key, int64_t value, int64_t* ret) {
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -321,7 +333,10 @@ Status Redis::Get(const Slice& key, std::string* value) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+       return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -390,7 +405,10 @@ Status Redis::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + " get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + " get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
 
@@ -435,7 +453,10 @@ Status Redis::GetBit(const Slice& key, int64_t offset, int32_t* ret) {
       if (ExpectedStale(meta_value)) {
         s = Status::NotFound();
       } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+        return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
       }
     }
     if (s.ok()) {
@@ -470,7 +491,10 @@ Status Redis::Getrange(const Slice& key, int64_t start_offset, int64_t end_offse
     if (ExpectedStale(value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+      return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
     }
   }
   if (s.ok()) {
@@ -512,7 +536,10 @@ Status Redis::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t 
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+       return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -571,7 +598,10 @@ Status Redis::GetSet(const Slice& key, const Slice& value, std::string* old_valu
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+       return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok()) {
@@ -600,7 +630,10 @@ Status Redis::Incrby(const Slice& key, int64_t value, int64_t* ret) {
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -652,7 +685,10 @@ Status Redis::Incrbyfloat(const Slice& key, const Slice& value, std::string* ret
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -714,20 +750,14 @@ Status Redis::MSetnx(const std::vector<KeyValue>& kvs, int32_t* ret) {
   for (const auto & kv : kvs) {
     BaseKey base_key(kv.key);
     s = db_->Get(default_read_options_, base_key.Encode(), &value);
-    if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
-      if (ExpectedStale(value)) {
-        s = Status::NotFound();
-      } else {
-        return Status::InvalidArgument("WRONGTYPE, key: " + kv.key + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
-      }
+    if (!s.ok() && !s.IsNotFound()) {
+      return s;
     }
-    if (s.ok()) {
-      ParsedStringsValue parsed_strings_value(&value);
-      if (!parsed_strings_value.IsStale()) {
-        exists = true;
-        break;
-      }
+    if (s.ok() && !ExpectedStale(value)) {
+      exists = true;
+      break;
     }
+    // when reaches here, either s is not found or s is ok but expired
   }
   if (!exists) {
     s = MSet(kvs);
@@ -758,7 +788,10 @@ Status Redis::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t 
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -795,7 +828,10 @@ Status Redis::SetBit(const Slice& key, int64_t offset, int32_t on, int32_t* ret)
     if (ExpectedStale(meta_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
+       return Status::InvalidArgument(
+          "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+          DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+          DataTypeStrings[static_cast<int>(GetMetaValueType(meta_value))]);
     }
   }
   if (s.ok() || s.IsNotFound()) {
@@ -860,34 +896,22 @@ Status Redis::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t 
   BaseKey base_key(key);
   ScopeRecordLock l(lock_mgr_, key);
   Status s = db_->Get(default_read_options_, base_key.Encode(), &old_value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kStrings, old_value)) {
-    if (ExpectedStale(old_value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
-    }
+  if (!s.ok() && !s.IsNotFound()) {
+    return s;
   }
+  if (s.ok() && !ExpectedStale(old_value)) {
+    return s;
+  }
+  // when reaches here, either s is not found or s is ok but expired
+  s = Status::NotFound();
+
+  StringsValue strings_value(value);
+  if (ttl > 0) {
+    strings_value.SetRelativeTimestamp(ttl);
+  }
+  s = db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
   if (s.ok()) {
-    ParsedStringsValue parsed_strings_value(&old_value);
-    if (parsed_strings_value.IsStale()) {
-      StringsValue strings_value(value);
-      if (ttl > 0) {
-        strings_value.SetRelativeTimestamp(ttl);
-      }
-      s = db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
-      if (s.ok()) {
-        *ret = 1;
-      }
-    }
-  } else if (s.IsNotFound()) {
-    StringsValue strings_value(value);
-    if (ttl > 0) {
-      strings_value.SetRelativeTimestamp(ttl);
-    }
-    s = db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
-    if (s.ok()) {
-      *ret = 1;
-    }
+    *ret = 1;
   }
   return s;
 }
@@ -904,7 +928,10 @@ Status Redis::Setvx(const Slice& key, const Slice& value, const Slice& new_value
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -945,7 +972,10 @@ Status Redis::Delvx(const Slice& key, const Slice& value, int32_t* ret) {
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -981,7 +1011,10 @@ Status Redis::Setrange(const Slice& key, int64_t start_offset, const Slice& valu
     if (ExpectedStale(old_value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(old_value))]);
     }
   }
   if (s.ok()) {
@@ -1087,7 +1120,10 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t* ret) {
     if (ExpectedStale(value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
     }
   }
   if (s.ok()) {
@@ -1131,7 +1167,10 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_
     if (ExpectedStale(value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
     }
   }
   if (s.ok()) {
@@ -1188,7 +1227,10 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_
     if (ExpectedStale(value)) {
       s = Status::NotFound();
     } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+     return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
     }
   }
   if (s.ok()) {
@@ -1254,17 +1296,25 @@ Status Redis::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp)
   return db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
 }
 
-Status Redis::StringsExpire(const Slice& key, int64_t ttl) {
-  std::string value;
+Status Redis::StringsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+  std::string value(std::move(prefetch_meta));
 
   BaseKey base_key(key);
   ScopeRecordLock l(lock_mgr_, key);
-  Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
-    if (ExpectedStale(value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+  Status s;
+  // value is empty means no meta value get before,
+  // we should get meta first
+  if (value.empty()) {
+    Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
+      if (ExpectedStale(value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1282,17 +1332,25 @@ Status Redis::StringsExpire(const Slice& key, int64_t ttl) {
   return s;
 }
 
-Status Redis::StringsDel(const Slice& key) {
-  std::string value;
+Status Redis::StringsDel(const Slice& key, std::string&& prefetch_meta) {
+  std::string value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseKey base_key(key);
-  Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
-    if (ExpectedStale(value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+  Status s;
+
+  // value is empty means no meta value get before,
+  // we should get meta first
+  if (value.empty()) {
+    Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
+      if (ExpectedStale(value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1305,17 +1363,25 @@ Status Redis::StringsDel(const Slice& key) {
   return s;
 }
 
-Status Redis::StringsExpireat(const Slice& key, int64_t timestamp) {
-  std::string value;
+Status Redis::StringsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+  std::string value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseKey base_key(key);
-  Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
-    if (ExpectedStale(value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+  Status s;
+
+  // value is empty means no meta value get before,
+  // we should get meta first
+  if (value.empty()) {
+    Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
+      if (ExpectedStale(value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1334,17 +1400,25 @@ Status Redis::StringsExpireat(const Slice& key, int64_t timestamp) {
   return s;
 }
 
-Status Redis::StringsPersist(const Slice& key) {
-  std::string value;
+Status Redis::StringsPersist(const Slice& key, std::string&& prefetch_meta) {
+  std::string value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseKey base_key(key);
-  Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
-    if (ExpectedStale(value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+  Status s;
+
+  // value is empty means no meta value get before,
+  // we should get meta first
+  if (value.empty()) {
+    s = db_->Get(default_read_options_, base_key.Encode(), &value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
+      if (ExpectedStale(value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1364,17 +1438,25 @@ Status Redis::StringsPersist(const Slice& key) {
   return s;
 }
 
-Status Redis::StringsTTL(const Slice& key, int64_t* timestamp) {
-  std::string value;
+Status Redis::StringsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta) {
+  std::string value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
-
   BaseKey base_key(key);
-  Status s = db_->Get(default_read_options_, base_key.Encode(), &value);
-  if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
-    if (ExpectedStale(value)) {
-      s = Status::NotFound();
-    } else {
-      return Status::InvalidArgument("WRONGTYPE, key: " + key.ToString() + ", expect type: " + DataTypeStrings[static_cast<int>(DataType::kStrings)] + "get type: " + DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+  Status s;
+
+  // value is empty means no meta value get before,
+  // we should get meta first
+  if (value.empty()) {
+    s = db_->Get(default_read_options_, base_key.Encode(), &value);
+    if (s.ok() && !ExpectedMetaValue(DataType::kStrings, value)) {
+      if (ExpectedStale(value)) {
+        s = Status::NotFound();
+      } else {
+       return Status::InvalidArgument(
+        "WRONGTYPE, key: " + key.ToString() + ", expect type: " +
+        DataTypeStrings[static_cast<int>(DataType::kStrings)] + ", get type: " +
+        DataTypeStrings[static_cast<int>(GetMetaValueType(value))]);
+      }
     }
   }
   if (s.ok()) {
@@ -1430,7 +1512,6 @@ void Redis::ScanStrings() {
 rocksdb::Status Redis::Exists(const Slice& key) {
   std::string meta_value;
   uint64_t llen = 0;
-  std::string value;
   int32_t ret = 0;
   BaseMetaKey base_meta_key(key);
   std::vector<storage::IdMessage> id_messages;
@@ -1442,17 +1523,17 @@ rocksdb::Status Redis::Exists(const Slice& key) {
     auto type = static_cast<DataType>(static_cast<uint8_t>(meta_value[0]));
     switch (type) {
       case DataType::kSets:
-        return SCard(key, &ret);
+        return SCard(key, &ret, std::move(meta_value));
       case DataType::kZSets:
-        return ZCard(key, &ret);
+        return ZCard(key, &ret, std::move(meta_value));
       case DataType::kHashes:
-        return HLen(key, &ret);
+        return HLen(key, &ret, std::move(meta_value));
       case DataType::kLists:
-        return LLen(key, &llen);
-      case DataType::kStrings:
-        return Get(key, &value);
+        return LLen(key, &llen, std::move(meta_value));
       case DataType::kStreams:
-        return XRange(key, arg, id_messages);
+        return XRange(key, arg, id_messages, std::move(meta_value));
+      case DataType::kStrings:
+        return ExpectedStale(meta_value) ? rocksdb::Status::NotFound() : rocksdb::Status::OK();
       default:
         return rocksdb::Status::NotFound();
     }
@@ -1468,17 +1549,17 @@ rocksdb::Status Redis::Del(const Slice& key) {
     auto type = static_cast<DataType>(static_cast<uint8_t>(meta_value[0]));
     switch (type) {
       case DataType::kSets:
-        return SetsDel(key);
+        return SetsDel(key, std::move(meta_value));
       case DataType::kZSets:
-        return ZsetsDel(key);
+        return ZsetsDel(key, std::move(meta_value));
       case DataType::kHashes:
-        return HashesDel(key);
+        return HashesDel(key, std::move(meta_value));
       case DataType::kLists:
-        return ListsDel(key);
+        return ListsDel(key, std::move(meta_value));
       case DataType::kStrings:
-        return StringsDel(key);
+        return StringsDel(key, std::move(meta_value));
       case DataType::kStreams:
-        return StreamsDel(key);
+        return StreamsDel(key, std::move(meta_value));
       default:
         return rocksdb::Status::NotFound();
     }
@@ -1494,15 +1575,15 @@ rocksdb::Status Redis::Expire(const Slice& key, int64_t ttl) {
     auto type = static_cast<DataType>(static_cast<uint8_t>(meta_value[0]));
     switch (type) {
       case DataType::kSets:
-        return SetsExpire(key, ttl);
+        return SetsExpire(key, ttl, std::move(meta_value));
       case DataType::kZSets:
-        return ZsetsExpire(key, ttl);
+        return ZsetsExpire(key, ttl, std::move(meta_value));
       case DataType::kHashes:
-        return HashesExpire(key, ttl);
+        return HashesExpire(key, ttl, std::move(meta_value));
       case DataType::kLists:
-        return ListsExpire(key, ttl);
+        return ListsExpire(key, ttl, std::move(meta_value));
       case DataType::kStrings:
-        return StringsExpire(key, ttl);
+        return StringsExpire(key, ttl, std::move(meta_value));
       default:
         return rocksdb::Status::NotFound();
     }
@@ -1518,15 +1599,15 @@ rocksdb::Status Redis::Expireat(const Slice& key, int64_t ttl) {
     auto type = static_cast<DataType>(static_cast<uint8_t>(meta_value[0]));
     switch (type) {
       case DataType::kSets:
-        return SetsExpireat(key, ttl);
+        return SetsExpireat(key, ttl, std::move(meta_value));
       case DataType::kZSets:
-        return ZsetsExpireat(key, ttl);
+        return ZsetsExpireat(key, ttl, std::move(meta_value));
       case DataType::kHashes:
-        return HashesExpireat(key, ttl);
+        return HashesExpireat(key, ttl, std::move(meta_value));
       case DataType::kLists:
-        return ListsExpireat(key, ttl);
+        return ListsExpireat(key, ttl, std::move(meta_value));
       case DataType::kStrings:
-        return StringsExpireat(key, ttl);
+        return StringsExpireat(key, ttl, std::move(meta_value));
       default:
         return rocksdb::Status::NotFound();
     }
@@ -1542,15 +1623,15 @@ rocksdb::Status Redis::Persist(const Slice& key) {
     auto type = static_cast<DataType>(static_cast<uint8_t>(meta_value[0]));
     switch (type) {
       case DataType::kSets:
-        return SetsPersist(key);
+        return SetsPersist(key, std::move(meta_value));
       case DataType::kZSets:
-        return ZsetsPersist(key);
+        return ZsetsPersist(key, std::move(meta_value));
       case DataType::kHashes:
-        return HashesPersist(key);
+        return HashesPersist(key, std::move(meta_value));
       case DataType::kLists:
-        return ListsPersist(key);
+        return ListsPersist(key, std::move(meta_value));
       case DataType::kStrings:
-        return StringsPersist(key);
+        return StringsPersist(key, std::move(meta_value));
       default:
         return rocksdb::Status::NotFound();
     }
@@ -1566,15 +1647,15 @@ rocksdb::Status Redis::TTL(const Slice& key, int64_t* timestamp) {
     auto type = static_cast<DataType>(static_cast<uint8_t>(meta_value[0]));
     switch (type) {
       case DataType::kSets:
-        return SetsTTL(key, timestamp);
+        return SetsTTL(key, timestamp, std::move(meta_value));
       case DataType::kZSets:
-        return ZsetsTTL(key, timestamp);
+        return ZsetsTTL(key, timestamp, std::move(meta_value));
       case DataType::kHashes:
-        return HashesTTL(key, timestamp);
+        return HashesTTL(key, timestamp, std::move(meta_value));
       case DataType::kLists:
-        return ListsTTL(key, timestamp);
+        return ListsTTL(key, timestamp, std::move(meta_value));
       case DataType::kStrings:
-        return StringsTTL(key, timestamp);
+        return StringsTTL(key, timestamp, std::move(meta_value));
       default:
         return rocksdb::Status::NotFound();
     }
@@ -1597,6 +1678,9 @@ rocksdb::Status Redis::IsExist(const storage::Slice& key) {
   BaseMetaKey base_meta_key(key);
   rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
+    if (ExpectedStale(meta_value)) {
+      return Status::NotFound();
+    }
     return Status::OK();
   }
   return rocksdb::Status::NotFound();

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -238,9 +238,8 @@ Status Storage::MSetnx(const std::vector<KeyValue>& kvs, int32_t* ret) {
   Status s;
   for (const auto& kv : kvs) {
     auto& inst = GetDBInstance(kv.key);
-    std::string value;
-    s = inst->Get(Slice(kv.key), &value);
-    if (s.ok() || !s.IsNotFound()) {
+    s = inst->IsExist(Slice(kv.key));
+    if (!s.IsNotFound()) {
       return s;
     }
   }


### PR DESCRIPTION
fix bugs mentioned in https://github.com/OpenAtomFoundation/pika/issues/2735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for prefetching metadata in various Redis operations, enhancing performance and efficiency.

- **Refactor**
  - Updated Redis methods across different data structures (Strings, Hashes, Lists, Sets, Zsets, Streams) to accept a `prefetch_meta` parameter, optimizing metadata handling.
  - Improved logic in key existence checks and expiration handling.

- **Bug Fixes**
  - Ensured consistency with Redis implementation by setting `exists = true` and returning `Status::OK()` in specific conditions.
  
- **Performance Improvements**
  - Enhanced the flow of operations by incorporating prefetch metadata, leading to more efficient handling of Redis commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->