### PR TITLE
fix:not correct used bgsave_info_

### DIFF
--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -310,8 +310,7 @@ class PikaServer : public pstd::noncopyable {
   bool SlotsMigrateBatch(const std::string &ip, int64_t port, int64_t time_out, int64_t slots, int64_t keys_num, const std::shared_ptr<DB>& db);
   void GetSlotsMgrtSenderStatus(std::string *ip, int64_t* port, int64_t *slot, bool *migrating, int64_t *moved, int64_t *remained);
   bool SlotsMigrateAsyncCancel();
-  std::shared_mutex bgsave_protector_;
-  BgSaveInfo bgsave_info_;
+  std::shared_mutex bgslots_protector_;
 
   /*
    * BGSlotsReload used
@@ -337,28 +336,28 @@ class PikaServer : public pstd::noncopyable {
   BGSlotsReload bgslots_reload_;
 
   BGSlotsReload bgslots_reload() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     return bgslots_reload_;
   }
   bool GetSlotsreloading() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     return bgslots_reload_.reloading;
   }
   void SetSlotsreloading(bool reloading) {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     bgslots_reload_.reloading = reloading;
   }
   void SetSlotsreloadingCursor(int64_t cursor) {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     bgslots_reload_.cursor = cursor;
   }
   int64_t GetSlotsreloadingCursor() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     return bgslots_reload_.cursor;
   }
 
   void SetSlotsreloadingEndTime() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     bgslots_reload_.end_time = time(nullptr);
   }
   void Bgslotsreload(const std::shared_ptr<DB>& db);
@@ -399,33 +398,33 @@ class PikaServer : public pstd::noncopyable {
   net::BGThread bgslots_cleanup_thread_;
 
   BGSlotsCleanup bgslots_cleanup() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     return bgslots_cleanup_;
   }
   bool GetSlotscleaningup() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     return bgslots_cleanup_.cleaningup;
   }
   void SetSlotscleaningup(bool cleaningup) {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     bgslots_cleanup_.cleaningup = cleaningup;
   }
   void SetSlotscleaningupCursor(int64_t cursor) {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     bgslots_cleanup_.cursor = cursor;
   }
   void SetCleanupSlots(std::vector<int> cleanup_slots) {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     bgslots_cleanup_.cleanup_slots.swap(cleanup_slots);
   }
   std::vector<int> GetCleanupSlots() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     return bgslots_cleanup_.cleanup_slots;
   }
 
   void Bgslotscleanup(std::vector<int> cleanup_slots, const std::shared_ptr<DB>& db);
   void StopBgslotscleanup() {
-    std::lock_guard ml(bgsave_protector_);
+    std::lock_guard ml(bgslots_protector_);
     bgslots_cleanup_.cleaningup = false;
     std::vector<int> cleanup_slots;
     bgslots_cleanup_.cleanup_slots.swap(cleanup_slots);

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1433,8 +1433,8 @@ bool PikaServer::SlotsMigrateAsyncCancel() {
 
 void PikaServer::Bgslotsreload(const std::shared_ptr<DB>& db) {
   // Only one thread can go through
-  std::lock_guard ml(bgslots_protector_);
   {
+    std::lock_guard ml(bgslots_protector_);
     if (bgslots_reload_.reloading || db->IsBgSaving()) {
       return;
     }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1433,9 +1433,9 @@ bool PikaServer::SlotsMigrateAsyncCancel() {
 
 void PikaServer::Bgslotsreload(const std::shared_ptr<DB>& db) {
   // Only one thread can go through
+  std::lock_guard ml(bgslots_protector_);
   {
-    std::lock_guard ml(bgsave_protector_);
-    if (bgslots_reload_.reloading || bgsave_info_.bgsaving) {
+    if (bgslots_reload_.reloading || db->IsBgSaving()) {
       return;
     }
     bgslots_reload_.reloading = true;
@@ -1498,8 +1498,8 @@ void DoBgslotsreload(void* arg) {
 void PikaServer::Bgslotscleanup(std::vector<int> cleanupSlots, const std::shared_ptr<DB>& db) {
   // Only one thread can go through
   {
-    std::lock_guard ml(bgsave_protector_);
-    if (bgslots_cleanup_.cleaningup || bgslots_reload_.reloading || bgsave_info_.bgsaving) {
+    std::lock_guard ml(bgslots_protector_);
+    if (bgslots_cleanup_.cleaningup || bgslots_reload_.reloading || db->IsBgSaving()) {
       return;
     }
     bgslots_cleanup_.cleaningup = true;


### PR DESCRIPTION
这里是为了bgsave和slots cleanup相互制衡，但是使用了 pika server中的bgsave_info_，但是pika_server中的bgsave_info_没有赋值，应该使用 DB中的，考虑到codis slot迁移只能支持一个DB这里暂时没有考虑多DB 场景


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed internal mechanisms for slot management to improve code clarity and maintenance.
  
- **Bug Fixes**
  - Improved slot management methods in the server to resolve potential conflicts during background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->