### PR TITLE
fix: pika-port string illegal truncate bug

### DIFF
--- a/tools/pika-port/pika_port_3/migrator_thread.cc
+++ b/tools/pika-port/pika_port_3/migrator_thread.cc
@@ -60,8 +60,8 @@ void MigratorThread::MigrateStringsDB() {
     std::string cmd;
 
     argv.push_back("SET");
-    argv.push_back(iter->key().ToString().c_str());
-    argv.push_back(parsed_strings_value.value().ToString().c_str());
+    argv.push_back(iter->key().ToString());
+    argv.push_back(parsed_strings_value.value().ToString());
     if (ts != 0 && ttl > 0) {
       argv.push_back("EX");
       argv.push_back(std::to_string(ttl));


### PR DESCRIPTION
pika-port  migrator. no need c_str()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved memory management and efficiency in the data migration process for better performance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->