### PR TITLE
fix: parse min-blob-size error when min-blob-size ends with unit

### DIFF
--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -662,7 +662,7 @@ int PikaConf::Load() {
 
   // rocksdb blob configure
   GetConfBool("enable-blob-files", &enable_blob_files_);
-  GetConfInt64("min-blob-size", &min_blob_size_);
+  GetConfInt64Human("min-blob-size", &min_blob_size_);
   if (min_blob_size_ <= 0) {
     min_blob_size_ = 4096;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted configuration loading for "min-blob-size" to handle human-readable formats, improving usability.

- **New Features**
  - Added a test case for the `ZREVRANK` functionality in the Redis client for better reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->