### PR TITLE
fix: github action  centos CI can’t pull dependencies

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,6 +86,8 @@ jobs:
     steps:
       - name: Install deps
         run: |
+          # disable the cache
+          echo 'exclude=fastestmirror' >> /etc/yum/pluginconf.d/fastestmirror.conf
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
             -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
             -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,9 +86,15 @@ jobs:
     steps:
       - name: Install deps
         run: |
+          minorver=7.9.2009
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
-            /etc/yum.repos.d/CentOS-Base.repo
+          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/$minorver|g" \
+          -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
+          /etc/yum.repos.d/CentOS-*.repo
+
+          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
+          -e 's|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
+          /etc/yum.repos.d/CentOS-SCLo-scl*.repo
           yum clean all
           yum makecache
           yum install -y wget git autoconf centos-release-scl gcc

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,10 +86,37 @@ jobs:
     steps:
       - name: set up mirror
         run: |
-          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
-          -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
-          /etc/yum.repos.d/CentOS-*.repo
+#          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
+#          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
+#          -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
+#          /etc/yum.repos.d/CentOS-*.repo
+          rm -rf /etc/yum.repos.d/CentOS-Base.repo 
+          cat > /etc/yum.repos.d/CentOS-Base.repo << EOL
+          [base]
+          name=CentOS-\$releasever - Base
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/os/\$basearch/
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [updates]
+          name=CentOS-\$releasever - Updates
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/updates/\$basearch/
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [extras]
+          name=CentOS-\$releasever - Extras
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/extras/\$basearch/
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [centosplus]
+          name=CentOS-\$releasever - Plus
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/centosplus/\$basearch/
+          gpgcheck=1
+          enabled=0
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          EOL
           
           # 创建并配置 CentOS-SCLo-scl.repo
           cat > /etc/yum.repos.d/CentOS-SCLo-scl.repo << EOL
@@ -98,14 +125,14 @@ jobs:
           baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/sclo/
           gpgcheck=1
           enabled=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
           
           [centos-sclo-sclo-source]
           name=CentOS-7 - SCLo sclo Source
           baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/sclo/
           gpgcheck=1
           enabled=0
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
           EOL
           
           # 创建并配置 CentOS-SCLo-scl-rh.repo
@@ -115,19 +142,25 @@ jobs:
           baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/rh/
           gpgcheck=1
           enabled=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
           
           [centos-sclo-rh-source]
           name=CentOS-7 - SCLo rh Source
           baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/rh/
           gpgcheck=1
           enabled=0
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
           EOL
+          
+          # 导入正确的 GPG 密钥
+          rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7
+          rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo
           
           # 清理并重新生成 yum 缓存
           yum clean all
           yum makecache
+
+
 
       - name: Install deps
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,6 +86,7 @@ jobs:
     steps:
       - name: Set yum Upstream
         run: |
+          curl -I https://www.baidu.com  
           ping -c 5 baidu.com
           ping -c 5 google.com
           sed -e 's|^mirrorlist=|#mirrorlist=|g' \

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install deps
         run: |
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9|g" \
+            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
             /etc/yum.repos.d/CentOS-Base.repo
           yum clean all
           yum makecache

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,68 +86,7 @@ jobs:
     steps:
       - name: set up mirror
         run: |
-          rm -rf /etc/yum.repos.d/CentOS-Base.repo 
-          cat > /etc/yum.repos.d/CentOS-Base.repo << EOL
-          [base]
-          name=CentOS-\$releasever - Base
-          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/os/\$basearch/
-          gpgcheck=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-          
-          [updates]
-          name=CentOS-\$releasever - Updates
-          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/updates/\$basearch/
-          gpgcheck=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-          
-          [extras]
-          name=CentOS-\$releasever - Extras
-          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/extras/\$basearch/
-          gpgcheck=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-          
-          [centosplus]
-          name=CentOS-\$releasever - Plus
-          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/centosplus/\$basearch/
-          gpgcheck=1
-          enabled=0
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-          EOL
-          
-          cat > /etc/yum.repos.d/CentOS-SCLo-scl.repo << EOL
-          [centos-sclo-sclo]
-          name=CentOS-7 - SCLo sclo
-          baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/sclo/
-          gpgcheck=1
-          enabled=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-          
-          [centos-sclo-sclo-source]
-          name=CentOS-7 - SCLo sclo Source
-          baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/sclo/
-          gpgcheck=1
-          enabled=0
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-          EOL
-          
-          cat > /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo << EOL
-          [centos-sclo-rh]
-          name=CentOS-7 - SCLo rh
-          baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/rh/
-          gpgcheck=1
-          enabled=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-          
-          [centos-sclo-rh-source]
-          name=CentOS-7 - SCLo rh Source
-          baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/rh/
-          gpgcheck=1
-          enabled=0
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-          EOL
-          
-          rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7
-          rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo
+          curl -o /etc/yum.repos.d/CentOS-Base.repo http://mirrors.aliyun.com/repo/Centos-7.repo
           
           yum clean all
           yum makecache

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,10 +86,6 @@ jobs:
     steps:
       - name: set up mirror
         run: |
-#          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-#          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
-#          -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
-#          /etc/yum.repos.d/CentOS-*.repo
           rm -rf /etc/yum.repos.d/CentOS-Base.repo 
           cat > /etc/yum.repos.d/CentOS-Base.repo << EOL
           [base]
@@ -118,7 +114,6 @@ jobs:
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
           EOL
           
-          # 创建并配置 CentOS-SCLo-scl.repo
           cat > /etc/yum.repos.d/CentOS-SCLo-scl.repo << EOL
           [centos-sclo-sclo]
           name=CentOS-7 - SCLo sclo
@@ -135,7 +130,6 @@ jobs:
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
           EOL
           
-          # 创建并配置 CentOS-SCLo-scl-rh.repo
           cat > /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo << EOL
           [centos-sclo-rh]
           name=CentOS-7 - SCLo rh
@@ -152,15 +146,11 @@ jobs:
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
           EOL
           
-          # 导入正确的 GPG 密钥
           rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7
           rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo
           
-          # 清理并重新生成 yum 缓存
           yum clean all
           yum makecache
-
-
 
       - name: Install deps
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -94,10 +94,6 @@ jobs:
             -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
             /etc/yum.repos.d/CentOS-*.repo
 
-          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g" \
-            -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g' \
-            /etc/yum.repos.d/CentOS-SCLo-scl.repo 
 
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
             -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g" \

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,12 +86,8 @@ jobs:
     steps:
       - name: Install deps
         run: |
-          sed -i.bak \
-            -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/os/$basearch/|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/updates/$basearch/|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/extras/$basearch/|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/centosplus/$basearch/|g' \
+          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9|g" \
             /etc/yum.repos.d/CentOS-Base.repo
           yum clean all
           yum makecache

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,16 +86,10 @@ jobs:
     steps:
       - name: Install deps
         run: |
-          minorver=7.9.2009
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/$minorver|g" \
+          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
           -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
           /etc/yum.repos.d/CentOS-*.repo
-
-#          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-#          -e 's|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
-#          /etc/yum.repos.d/CentOS-SCLo-scl*.repo
-          
           yum clean all
           yum makecache
           

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -92,11 +92,13 @@ jobs:
           -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
           /etc/yum.repos.d/CentOS-*.repo
 
-          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-          -e 's|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
-          /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+#          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
+#          -e 's|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
+#          /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+          
           yum clean all
           yum makecache
+          
           yum install -y wget git autoconf centos-release-scl gcc
           yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util
           yum install -y llvm-toolset-7 llvm-toolset-7-clang tcl which 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,13 +86,15 @@ jobs:
     steps:
       - name: Set yum Upstream
         run: |
-          curl -I https://www.baidu.com  
-          ping -c 5 baidu.com
-          ping -c 5 google.com
-          sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-              -e 's|^#baseurl=http://mirror.centos.org|baseurl=http://mirror.aliyun.com|g' \
-              -i.bak \
-              /etc/yum.repos.d/CentOS-*.repo
+          sudo sed -i.bak \
+            -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/os/$basearch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/updates/$basearch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/extras/$basearch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/centosplus/$basearch/|g' \
+            /etc/yum.repos.d/CentOS-Base.repo
+          sudo yum clean all
+          sudo yum makecache
       - name: Install deps
         run: |
           yum install -y wget git autoconf centos-release-scl gcc

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -91,7 +91,6 @@ jobs:
           -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
           /etc/yum.repos.d/CentOS-*.repo
           yum clean all
-          yum makecache
           
           yum install -y wget git autoconf centos-release-scl gcc
           yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Set yum Upstream
         run: |
-          sudo sed -i.bak \
+           sed -i.bak \
             -e 's|^mirrorlist=|#mirrorlist=|g' \
             -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/os/$basearch/|g' \
             -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/updates/$basearch/|g' \

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,13 +86,8 @@ jobs:
     steps:
       - name: Set yum Upstream
         run: |
-           sed -i.bak \
-            -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/os/$basearch/|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/updates/$basearch/|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/extras/$basearch/|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/centosplus/$basearch/|g' \
-            /etc/yum.repos.d/CentOS-Base.repo
+          chmod +x ../tests/integration/set_upstream_centos.sh
+          ../tests/integration/set_upstream_centos.sh
           sudo yum clean all
           sudo yum makecache
       - name: Install deps

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -88,11 +88,24 @@ jobs:
         run: |
           # disable the cache
           echo 'exclude=fastestmirror' >> /etc/yum/pluginconf.d/fastestmirror.conf
+          
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
+            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/$7.9.2009|g" \
             -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
-            -e 's|^mirrorlist|#mirrorlist|g' \
-            /etc/yum.repos.d/*.repo
+            /etc/yum.repos.d/CentOS-*.repo
+
+          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g" \
+            -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g' \
+            /etc/yum.repos.d/CentOS-SCLo-scl.repo 
+
+          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g" \
+            -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g' \
+            /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+          
+          yum clean all
+          yum makecache
           
           yum install -y wget git autoconf centos-release-scl gcc
           yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,8 +86,9 @@ jobs:
     steps:
       - name: Set yum Upstream
         run: |
-          chmod +x ../tests/integration/set_upstream_centos.sh
-          ../tests/integration/set_upstream_centos.sh
+          cd ${{ github.workspace }}
+          chmod +x ./tests/integration/set_upstream_centos.sh
+          ./tests/integration/set_upstream_centos.sh
           sudo yum clean all
           sudo yum makecache
       - name: Install deps

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,6 +86,8 @@ jobs:
     steps:
       - name: Set yum Upstream
         run: |
+          ping -c 5 google.com
+          ping -c 5 baidu.com
           sed -e 's|^mirrorlist=|#mirrorlist=|g' \
               -e 's|^#baseurl=http://mirror.centos.org|baseurl=http://mirror.aliyun.com|g' \
               -i.bak \

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,8 +86,8 @@ jobs:
     steps:
       - name: Set yum Upstream
         run: |
-          ping -c 5 google.com
           ping -c 5 baidu.com
+          ping -c 5 google.com
           sed -e 's|^mirrorlist=|#mirrorlist=|g' \
               -e 's|^#baseurl=http://mirror.centos.org|baseurl=http://mirror.aliyun.com|g' \
               -i.bak \

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -84,6 +84,12 @@ jobs:
       image: centos:7
 
     steps:
+      - name: Set yum Upstream
+        run: |
+          sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+              -e 's|^#baseurl=http://mirror.centos.org|baseurl=http://mirror.aliyun.com|g' \
+              -i.bak \
+              /etc/yum.repos.d/CentOS-*.repo
       - name: Install deps
         run: |
           yum install -y wget git autoconf centos-release-scl gcc

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -84,15 +84,17 @@ jobs:
       image: centos:7
 
     steps:
-      - name: Set yum Upstream
-        run: |
-          cd ${{ github.workspace }}
-          chmod +x ./tests/integration/set_upstream_centos.sh
-          ./tests/integration/set_upstream_centos.sh
-          sudo yum clean all
-          sudo yum makecache
       - name: Install deps
         run: |
+          sed -i.bak \
+            -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/os/$basearch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/updates/$basearch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/extras/$basearch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/centosplus/$basearch/|g' \
+            /etc/yum.repos.d/CentOS-Base.repo
+          yum clean all
+          yum makecache
           yum install -y wget git autoconf centos-release-scl gcc
           yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util
           yum install -y llvm-toolset-7 llvm-toolset-7-clang tcl which 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -86,7 +86,68 @@ jobs:
     steps:
       - name: set up mirror
         run: |
-          curl -o /etc/yum.repos.d/CentOS-Base.repo http://mirrors.aliyun.com/repo/Centos-7.repo
+          rm -rf /etc/yum.repos.d/CentOS-Base.repo 
+          cat > /etc/yum.repos.d/CentOS-Base.repo << EOL
+          [base]
+          name=CentOS-\$releasever - Base
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/os/\$basearch/
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [updates]
+          name=CentOS-\$releasever - Updates
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/updates/\$basearch/
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [extras]
+          name=CentOS-\$releasever - Extras
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/extras/\$basearch/
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [centosplus]
+          name=CentOS-\$releasever - Plus
+          baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009/centosplus/\$basearch/
+          gpgcheck=1
+          enabled=0
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          EOL
+          
+          cat > /etc/yum.repos.d/CentOS-SCLo-scl.repo << EOL
+          [centos-sclo-sclo]
+          name=CentOS-7 - SCLo sclo
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/sclo/
+          gpgcheck=1
+          enabled=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+          
+          [centos-sclo-sclo-source]
+          name=CentOS-7 - SCLo sclo Source
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/sclo/
+          gpgcheck=1
+          enabled=0
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+          EOL
+          
+          cat > /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo << EOL
+          [centos-sclo-rh]
+          name=CentOS-7 - SCLo rh
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/rh/
+          gpgcheck=1
+          enabled=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+          
+          [centos-sclo-rh-source]
+          name=CentOS-7 - SCLo rh Source
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/rh/
+          gpgcheck=1
+          enabled=0
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+          EOL
+          
+          rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7
+          rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo
           
           yum clean all
           yum makecache

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -87,10 +87,10 @@ jobs:
       - name: Install deps
         run: |
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
-          -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
-          /etc/yum.repos.d/CentOS-*.repo
-          yum clean all
+            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
+            -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
+            -e 's|^mirrorlist|#mirrorlist|g' \
+            /etc/yum.repos.d/*.repo
           
           yum install -y wget git autoconf centos-release-scl gcc
           yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -84,25 +84,53 @@ jobs:
       image: centos:7
 
     steps:
-      - name: Install deps
+      - name: set up mirror
         run: |
-          # disable the cache
-          echo 'exclude=fastestmirror' >> /etc/yum/pluginconf.d/fastestmirror.conf
-          
           sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/$7.9.2009|g" \
-            -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
-            /etc/yum.repos.d/CentOS-*.repo
-
-
-          sed -i.bak -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g" \
-            -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos/\$releasever|g' \
-            /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+          -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/7.9.2009|g" \
+          -e 's|^baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/\$releasever|g' \
+          /etc/yum.repos.d/CentOS-*.repo
           
+          # 创建并配置 CentOS-SCLo-scl.repo
+          cat > /etc/yum.repos.d/CentOS-SCLo-scl.repo << EOL
+          [centos-sclo-sclo]
+          name=CentOS-7 - SCLo sclo
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/sclo/
+          gpgcheck=1
+          enabled=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [centos-sclo-sclo-source]
+          name=CentOS-7 - SCLo sclo Source
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/sclo/
+          gpgcheck=1
+          enabled=0
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          EOL
+          
+          # 创建并配置 CentOS-SCLo-scl-rh.repo
+          cat > /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo << EOL
+          [centos-sclo-rh]
+          name=CentOS-7 - SCLo rh
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/x86_64/rh/
+          gpgcheck=1
+          enabled=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          
+          [centos-sclo-rh-source]
+          name=CentOS-7 - SCLo rh Source
+          baseurl=https://mirrors.aliyun.com/centos/7/sclo/Source/rh/
+          gpgcheck=1
+          enabled=0
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+          EOL
+          
+          # 清理并重新生成 yum 缓存
           yum clean all
           yum makecache
-          
+
+      - name: Install deps
+        run: |
           yum install -y wget git autoconf centos-release-scl gcc
           yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++ devtoolset-10-make devtoolset-10-bin-util
           yum install -y llvm-toolset-7 llvm-toolset-7-clang tcl which 

--- a/tests/integration/set_upstream_centos.sh
+++ b/tests/integration/set_upstream_centos.sh
@@ -1,0 +1,7 @@
+sed -i.bak \
+  -e 's|^mirrorlist=|#mirrorlist=|g' \
+  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/os/$basearch/|g' \
+  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/updates/$basearch/|g' \
+  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/extras/$basearch/|g' \
+  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/centosplus/$basearch/|g' \
+  /etc/yum.repos.d/CentOS-Base.repo

--- a/tests/integration/set_upstream_centos.sh
+++ b/tests/integration/set_upstream_centos.sh
@@ -1,7 +1,0 @@
-sed -i.bak \
-  -e 's|^mirrorlist=|#mirrorlist=|g' \
-  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/os/$basearch/|g' \
-  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/updates/$basearch/|g' \
-  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/extras/$basearch/|g' \
-  -e 's|^#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos/$releasever/centosplus/$basearch/|g' \
-  /etc/yum.repos.d/CentOS-Base.repo


### PR DESCRIPTION
centos7源的官方源自2024.6.30下线了，换了阿里云存档源

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CentOS repository URLs to use a different mirror for improved package download reliability.
  - Modified yum repository configuration to align with the new mirror setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->