### PR TITLE
fix: remove an unnecessary shared_lock in hot path

### DIFF
--- a/include/pika_binlog.h
+++ b/include/pika_binlog.h
@@ -52,7 +52,7 @@ class Binlog : public pstd::noncopyable {
   void Unlock() { mutex_.unlock(); }
 
   pstd::Status Put(const std::string& item);
-
+  pstd::Status IsOpened();
   pstd::Status GetProducerStatus(uint32_t* filenum, uint64_t* pro_offset, uint32_t* term = nullptr, uint64_t* logic_id = nullptr);
   /*
    * Set Producer pro_num and pro_offset with lock

--- a/src/pika_binlog.cc
+++ b/src/pika_binlog.cc
@@ -145,6 +145,13 @@ void Binlog::InitLogFile() {
   opened_.store(true);
 }
 
+Status Binlog::IsOpened() {
+  if (!opened_.load()) {
+    return Status::Busy("Binlog is not open yet");
+  }
+  return Status::OK();
+}
+
 Status Binlog::GetProducerStatus(uint32_t* filenum, uint64_t* pro_offset, uint32_t* term, uint64_t* logic_id) {
   if (!opened_.load()) {
     return Status::Busy("Binlog is not open yet");

--- a/src/pika_consensus.cc
+++ b/src/pika_consensus.cc
@@ -374,9 +374,7 @@ Status ConsensusCoordinator::InternalAppendBinlog(const std::shared_ptr<Cmd>& cm
     }
     return s;
   }
-  uint32_t filenum = 0;
-  uint64_t offset = 0;
-  return stable_logger_->Logger()->GetProducerStatus(&filenum, &offset);
+  return stable_logger_->Logger()->IsOpened();
 }
 
 Status ConsensusCoordinator::AddSlaveNode(const std::string& ip, int port, int session_id) {


### PR DESCRIPTION
**问题**：每次写binlog 后，在ConsensusCoordinator::InternalAppendBinlog结尾，都要执行一次stable_logger_->Logger()->GetProducerStatus(&filenum, &offset)， 但是这里的filenum, offset取了之后根本不用，只是取用了这个函数的返回值。而这里面要取filenum, offset要对全局唯一的version_对象加锁，尽管只是shared_lock，但这个锁对象是一把全局都在抢的锁，而且这个位置是热点，开启binlog的情况下，每一条请求都要去做这件事情，这就会有较大竞争，最重要的是这个竞争是完全没有必要的。

**这个PR做的事情**是将GetProducerStatus中除了＂加锁获取filename, offset＂之外的逻辑复制封装成了一个新的函数 IsOpened(),该函数同GetProducerStatus有一样的返回值，用于在ConsensusCoordinator::InternalAppendBinlog替换对GetProducerStatus的调用。


**Issue**: Each time after writing "bingo", at the end of the ConsensusCoordinator::InternalAppendBinlog function, the stable_logger_->Logger()->GetProducerStatus(&filenum, &offset) is executed. However, the filenum and offset variables are not used after being retrieved; only the return value of this function is utilized. Acquiring these variables requires locking the globally unique version_ object, even though it is just a shared_lock, which is a lock object that is highly contended globally. This spot is a hotspot, and in scenarios where binlog is enabled, each request has to perform this action, leading to significant competition. More crucially, this competition is entirely unnecessary.

**This PR addresses the issue** by copying and encapsulating the logic within GetProducerStatus, except for the "locking and retrieving filenum and offset" part, into a new function called IsOpened(). This new function has the same return value as GetProducerStatus and is utilized to replace the call to GetProducerStatus in ConsensusCoordinator::InternalAppendBinlog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to check if the binlog is open, enhancing log management and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->