### PR TITLE
fix: delete iter before returns

### DIFF
--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1748,6 +1748,7 @@ rocksdb::Status Redis::PKPatternMatchDel(const std::string& pattern, int32_t* re
         batch.Clear();
       } else {
         *ret = total_delete;
+        delete iter;
         return s;
       }
     }

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1761,6 +1761,7 @@ rocksdb::Status Redis::PKPatternMatchDel(const std::string& pattern, int32_t* re
     }
   }
 
+  delete iter;
   *ret = total_delete;
   return s;
 }


### PR DESCRIPTION
pkpatternmatchdel doesn't delete iter before returns which may cause the rocksdb refs a version forever until process restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory management in the pattern matching delete function to prevent potential memory leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->