### PR TITLE
fix: delete iter before return for 3.5 branch

### DIFF
--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -15,6 +15,8 @@
 #include "src/scope_snapshot.h"
 #include "storage/util.h"
 
+#include "pstd/include/pstd_defer.h"
+
 namespace storage {
 
 RedisHashes::RedisHashes(Storage* const s, const DataType& type) : Redis(s, type) {}
@@ -156,6 +158,9 @@ Status RedisHashes::PKPatternMatchDel(const std::string& pattern, int32_t* ret) 
   Status s;
   rocksdb::WriteBatch batch;
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[0]);
+  DEFER {
+    delete iter;
+  };
   iter->SeekToFirst();
   while (iter->Valid()) {
     key = iter->key().ToString();

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -14,6 +14,8 @@
 #include "src/scope_snapshot.h"
 #include "storage/util.h"
 
+#include "pstd/include/pstd_defer.h"
+
 namespace storage {
 
 const rocksdb::Comparator* ListsDataKeyComparator() {
@@ -163,6 +165,9 @@ Status RedisLists::PKPatternMatchDel(const std::string& pattern, int32_t* ret) {
   Status s;
   rocksdb::WriteBatch batch;
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[0]);
+  DEFER {
+    delete iter;
+  };
   iter->SeekToFirst();
   while (iter->Valid()) {
     key = iter->key().ToString();

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -18,6 +18,8 @@
 #include "src/scope_snapshot.h"
 #include "storage/util.h"
 
+#include "pstd/include/pstd_defer.h"
+
 namespace storage {
 
 RedisSets::RedisSets(Storage* const s, const DataType& type) : Redis(s, type) {
@@ -163,6 +165,9 @@ rocksdb::Status RedisSets::PKPatternMatchDel(const std::string& pattern, int32_t
   rocksdb::Status s;
   rocksdb::WriteBatch batch;
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[0]);
+  DEFER {
+    delete iter;
+  };
   iter->SeekToFirst();
   while (iter->Valid()) {
     key = iter->key().ToString();
@@ -872,7 +877,7 @@ rocksdb::Status RedisSets::SPop(const Slice& key, std::vector<std::string>* memb
         //parsed_sets_meta_value.ModifyCount(-cnt);
         //batch.Put(handles_[0], key, meta_value);
         batch.Delete(handles_[0], key);
-        delete iter;   
+        delete iter;
 
       } else {
         engine.seed(time(nullptr));

--- a/src/storage/src/redis_streams.cc
+++ b/src/storage/src/redis_streams.cc
@@ -21,6 +21,8 @@
 #include "storage/storage.h"
 #include "storage/util.h"
 
+#include "pstd/include/pstd_defer.h"
+
 namespace storage {
 
 Status RedisStreams::XAdd(const Slice& key, const std::string& serialized_message, StreamAddTrimArgs& args) {
@@ -453,6 +455,9 @@ Status RedisStreams::PKPatternMatchDel(const std::string& pattern, int32_t* ret)
   Status s;
   rocksdb::WriteBatch batch;
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[0]);
+  DEFER {
+    delete iter;
+  };
   iter->SeekToFirst();
   while (iter->Valid()) {
     key = iter->key().ToString();

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -19,6 +19,8 @@
 #include "src/strings_filter.h"
 #include "storage/util.h"
 
+#include "pstd/include/pstd_defer.h"
+
 namespace storage {
 
 RedisStrings::RedisStrings(Storage* const s, const DataType& type) : Redis(s, type) {}
@@ -126,6 +128,9 @@ Status RedisStrings::PKPatternMatchDel(const std::string& pattern, int32_t* ret)
   Status s;
   rocksdb::WriteBatch batch;
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options);
+  DEFER {
+    delete iter;
+  };
   iter->SeekToFirst();
   while (iter->Valid()) {
     key = iter->key().ToString();
@@ -1464,8 +1469,8 @@ void RedisStrings::ScanDatabase() {
       survival_time =
           parsed_strings_value.timestamp() - current_time > 0 ? parsed_strings_value.timestamp() - current_time : -1;
     }
-    LOG(INFO) << fmt::format("[key : {:<30}] [value : {:<30}] [timestamp : {:<10}] [version : {}] [survival_time : {}]", iter->key().ToString(), 
-                             parsed_strings_value.value().ToString(), parsed_strings_value.timestamp(), parsed_strings_value.version(),  
+    LOG(INFO) << fmt::format("[key : {:<30}] [value : {:<30}] [timestamp : {:<10}] [version : {}] [survival_time : {}]", iter->key().ToString(),
+                             parsed_strings_value.value().ToString(), parsed_strings_value.timestamp(), parsed_strings_value.version(),
                              survival_time);
 
   }


### PR DESCRIPTION
pkpatternmatchdel doesn't delete iter before returns which may cause the rocksdb refs a version forever until process restarts.