### PR TITLE
fix: changed the calculating logic of epoll timeout provided by TimerTaskManager

### DIFF
--- a/src/net/src/dispatch_thread.cc
+++ b/src/net/src/dispatch_thread.cc
@@ -66,7 +66,7 @@ int DispatchThread::StartThread() {
   // Adding timer tasks and run timertaskThread
   timer_task_thread_.AddTimerTask("blrpop_blocking_info_scan", 250, true,
                                 [this] { this->ScanExpiredBlockedConnsOfBlrpop(); });
-  timer_task_thread_.set_thread_name("TimerTaskThread");
+  timer_task_thread_.set_thread_name("DispacherTimerTaskThread");
   timer_task_thread_.StartThread();
   return ServerThread::StartThread();
 }

--- a/src/net/src/net_util.cc
+++ b/src/net/src/net_util.cc
@@ -48,12 +48,12 @@ int64_t TimerTaskManager::ExecTimerTask() {
   std::vector<ExecTsWithId> fired_tasks_;
   int64_t now_in_ms = NowInMs();
   // traverse in ascending order, and exec expired tasks
-  for (auto pair : exec_queue_) {
-    if (pair.exec_ts <= now_in_ms) {
-      auto it = id_to_task_.find(pair.id);
+  for (const auto& task : exec_queue_) {
+    if (task.exec_ts <= now_in_ms) {
+      auto it = id_to_task_.find(task.id);
       assert(it != id_to_task_.end());
       it->second.fun();
-      fired_tasks_.push_back({pair.exec_ts, pair.id});
+      fired_tasks_.push_back({task.exec_ts, task.id});
       now_in_ms = NowInMs();
     } else {
       break;

--- a/src/net/src/net_util.cc
+++ b/src/net/src/net_util.cc
@@ -35,31 +35,31 @@ uint32_t TimerTaskManager::AddTimerTask(const std::string& task_name, int interv
   int64_t next_expired_time = NowInMs() + interval_ms;
   exec_queue_.insert({next_expired_time, new_task.task_id});
 
-  if (min_interval_ms_ > interval_ms || min_interval_ms_ == -1) {
-    min_interval_ms_ = interval_ms;
-  }
   // return the id of this task
   return new_task.task_id;
 }
+
 int64_t TimerTaskManager::NowInMs() {
   auto now = std::chrono::system_clock::now();
   return std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch().count();
 }
-int TimerTaskManager::ExecTimerTask() {
+
+int32_t TimerTaskManager::ExecTimerTask() {
   std::vector<ExecTsWithId> fired_tasks_;
   int64_t now_in_ms = NowInMs();
-  // traverse in ascending order
-  for (auto pair = exec_queue_.begin(); pair != exec_queue_.end(); pair++) {
-    if (pair->exec_ts <= now_in_ms) {
-      auto it = id_to_task_.find(pair->id);
+  // traverse in ascending order, and exec expired tasks
+  for (auto pair : exec_queue_) {
+    if (pair.exec_ts <= now_in_ms) {
+      auto it = id_to_task_.find(pair.id);
       assert(it != id_to_task_.end());
       it->second.fun();
-      fired_tasks_.push_back({pair->exec_ts, pair->id});
+      fired_tasks_.push_back({pair.exec_ts, pair.id});
       now_in_ms = NowInMs();
     } else {
       break;
     }
   }
+
   for (auto task : fired_tasks_) {
     exec_queue_.erase(task);
     auto it = id_to_task_.find(task.id);
@@ -69,15 +69,19 @@ int TimerTaskManager::ExecTimerTask() {
       exec_queue_.insert({now_in_ms + it->second.interval_ms, task.id});
     } else {
       // this task only need to be exec once, completely remove this task
-      int interval_del = it->second.interval_ms;
       id_to_task_.erase(task.id);
-      if (interval_del == min_interval_ms_) {
-        RenewMinIntervalMs();
-      }
     }
   }
-  return min_interval_ms_;
+
+  if (exec_queue_.empty()) {
+    //to avoid wasting of cpu resources, epoll use 5000ms as timeout value when no task to exec
+    return 5000;
+  }
+  int32_t gap_between_now_and_next_task = static_cast<int32_t>(exec_queue_.begin()->exec_ts - NowInMs());
+  gap_between_now_and_next_task = gap_between_now_and_next_task < 0 ? 0 : gap_between_now_and_next_task;
+  return gap_between_now_and_next_task;
 }
+
 bool TimerTaskManager::DelTimerTaskByTaskId(uint32_t task_id) {
   // remove the task
   auto task_to_del = id_to_task_.find(task_id);
@@ -86,11 +90,6 @@ bool TimerTaskManager::DelTimerTaskByTaskId(uint32_t task_id) {
   }
   int interval_del = task_to_del->second.interval_ms;
   id_to_task_.erase(task_to_del);
-
-  // renew the min_interval_ms_
-  if (interval_del == min_interval_ms_) {
-    RenewMinIntervalMs();
-  }
 
   // remove from exec queue
   ExecTsWithId target_key = {-1, 0};
@@ -104,15 +103,6 @@ bool TimerTaskManager::DelTimerTaskByTaskId(uint32_t task_id) {
     exec_queue_.erase(target_key);
   }
   return true;
-}
-
-void TimerTaskManager::RenewMinIntervalMs() {
-  min_interval_ms_ = -1;
-  for (auto pair : id_to_task_) {
-    if (pair.second.interval_ms < min_interval_ms_ || min_interval_ms_ == -1) {
-      min_interval_ms_ = pair.second.interval_ms;
-    }
-  }
 }
 
 TimerTaskThread::~TimerTaskThread() {

--- a/src/net/src/net_util.cc
+++ b/src/net/src/net_util.cc
@@ -27,7 +27,7 @@ int Setnonblocking(int sockfd) {
   return flags;
 }
 
-uint32_t TimerTaskManager::AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec,
+TimerTaskID TimerTaskManager::AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec,
                                         const std::function<void()>& task) {
   TimedTask new_task = {last_task_id_++, task_name, interval_ms, repeat_exec, task};
   id_to_task_[new_task.task_id] = new_task;
@@ -84,7 +84,7 @@ int64_t TimerTaskManager::ExecTimerTask() {
   return gap_between_now_and_next_task;
 }
 
-bool TimerTaskManager::DelTimerTaskByTaskId(uint32_t task_id) {
+bool TimerTaskManager::DelTimerTaskByTaskId(TimerTaskID task_id) {
   // remove the task
   auto task_to_del = id_to_task_.find(task_id);
   if (task_to_del == id_to_task_.end()) {

--- a/src/net/src/net_util.cc
+++ b/src/net/src/net_util.cc
@@ -77,8 +77,7 @@ int64_t TimerTaskManager::ExecTimerTask() {
     //to avoid wasting of cpu resources, epoll use 5000ms as timeout value when no task to exec
     return 5000;
   }
-  // gap_between_now_and_next_task will be used as epoll_wait's para 'timeout' and which is an int32_t,
-  // so here we explicitly cast it to int32_t instead of let it be implicitly truncated when passing it to epoll_wait.
+  
   int64_t gap_between_now_and_next_task = exec_queue_.begin()->exec_ts - NowInMs();
   gap_between_now_and_next_task = gap_between_now_and_next_task < 0 ? 0 : gap_between_now_and_next_task;
   return gap_between_now_and_next_task;

--- a/src/net/src/net_util.cc
+++ b/src/net/src/net_util.cc
@@ -77,6 +77,8 @@ int32_t TimerTaskManager::ExecTimerTask() {
     //to avoid wasting of cpu resources, epoll use 5000ms as timeout value when no task to exec
     return 5000;
   }
+  // gap_between_now_and_next_task will be used as epoll_wait's para 'timeout' and which is an int32_t,
+  // so here we explicitly cast it to int32_t instead of let it be implicitly truncated when passing it to epoll_wait.
   int32_t gap_between_now_and_next_task = static_cast<int32_t>(exec_queue_.begin()->exec_ts - NowInMs());
   gap_between_now_and_next_task = gap_between_now_and_next_task < 0 ? 0 : gap_between_now_and_next_task;
   return gap_between_now_and_next_task;

--- a/src/net/src/net_util.h
+++ b/src/net/src/net_util.h
@@ -62,7 +62,7 @@ class TimerTaskManager {
   int64_t ExecTimerTask();
   bool DelTimerTaskByTaskId(uint32_t task_id);
   int64_t NowInMs();
-  bool Empty() const { return 0 == last_task_id_; }
+  bool Empty() const { return exec_queue_.empty(); }
  private:
   //items stored in std::set are ascending ordered, we regard it as an auto sorted queue
   std::set<ExecTsWithId> exec_queue_;

--- a/src/net/src/net_util.h
+++ b/src/net/src/net_util.h
@@ -47,12 +47,6 @@ struct ExecTsWithId {
   }
 };
 
-/*
- * For simplicity, current version of TimerTaskThread has no lock inside and all task should be registered before TimerTaskThread started,
- * but if you have the needs of dynamically add/remove timer task after TimerTaskThread started, you can simply add a mutex to protect
- * the timer_task_manager_ and also a pipe to wake up the maybe being endless-wait epoll(if all task consumed, epoll will sink into
- * endless wait) to implement the feature.
- */
 class TimerTaskManager {
  public:
   TimerTaskManager() = default;

--- a/src/net/src/net_util.h
+++ b/src/net/src/net_util.h
@@ -21,9 +21,9 @@
 namespace net {
 
 int Setnonblocking(int sockfd);
-
+using TimerTaskID = int64_t;
 struct TimedTask{
-  uint32_t task_id;
+  TimerTaskID task_id;
   std::string task_name;
   int interval_ms;
   bool repeat_exec;
@@ -34,7 +34,7 @@ struct ExecTsWithId {
   //the next exec time of the task, unit in ms
   int64_t exec_ts;
   //id of the task to be exec
-  uint32_t id;
+  TimerTaskID id;
 
   bool operator<(const ExecTsWithId& other) const{
     if(exec_ts == other.exec_ts){
@@ -57,19 +57,17 @@ class TimerTaskManager {
  public:
   TimerTaskManager() = default;
   ~TimerTaskManager() = default;
-
   uint32_t AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec, const std::function<void()> &task);
   //return the time gap between now and next task-expired time, which can be used as the timeout value of epoll
-  int ExecTimerTask();
+  int64_t ExecTimerTask();
   bool DelTimerTaskByTaskId(uint32_t task_id);
   int64_t NowInMs();
   bool Empty() const { return 0 == last_task_id_; }
-
  private:
   //items stored in std::set are ascending ordered, we regard it as an auto sorted queue
   std::set<ExecTsWithId> exec_queue_;
   std::unordered_map<uint32_t, TimedTask> id_to_task_;
-  uint32_t last_task_id_{0};
+  TimerTaskID last_task_id_{0};
 };
 
 

--- a/src/net/src/net_util.h
+++ b/src/net/src/net_util.h
@@ -59,24 +59,24 @@ class TimerTaskManager {
   ~TimerTaskManager() = default;
 
   uint32_t AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec, const std::function<void()> &task);
-  //return the newest min_minterval_ms
+  //return the time gap between now and next task-expired time, which can be used as the timeout value of epoll
   int ExecTimerTask();
   bool DelTimerTaskByTaskId(uint32_t task_id);
-  int GetMinIntervalMs() const { return min_interval_ms_; }
   int64_t NowInMs();
-  void RenewMinIntervalMs();
-  bool Empty(){ return 0 == last_task_id_; }
+  bool Empty() const { return 0 == last_task_id_; }
 
  private:
   //items stored in std::set are ascending ordered, we regard it as an auto sorted queue
   std::set<ExecTsWithId> exec_queue_;
   std::unordered_map<uint32_t, TimedTask> id_to_task_;
   uint32_t last_task_id_{0};
-  int min_interval_ms_{-1};
 };
 
 
-
+/*
+ * For simplicity, current version of TimerTaskThread has no lock inside and all task should be registered before TimerTaskThread started,
+ * but if you have the needs of dynamically add/remove timer task after TimerTaskThread started, you can simply add a mutex to protect the timer_task_manager_
+ */
 class TimerTaskThread : public Thread {
  public:
   TimerTaskThread(){

--- a/src/net/src/net_util.h
+++ b/src/net/src/net_util.h
@@ -51,16 +51,16 @@ class TimerTaskManager {
  public:
   TimerTaskManager() = default;
   ~TimerTaskManager() = default;
-  uint32_t AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec, const std::function<void()> &task);
+  TimerTaskID AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec, const std::function<void()> &task);
   //return the time gap between now and next task-expired time, which can be used as the timeout value of epoll
   int64_t ExecTimerTask();
-  bool DelTimerTaskByTaskId(uint32_t task_id);
+  bool DelTimerTaskByTaskId(TimerTaskID task_id);
   int64_t NowInMs();
   bool Empty() const { return exec_queue_.empty(); }
  private:
   //items stored in std::set are ascending ordered, we regard it as an auto sorted queue
   std::set<ExecTsWithId> exec_queue_;
-  std::unordered_map<uint32_t, TimedTask> id_to_task_;
+  std::unordered_map<TimerTaskID, TimedTask> id_to_task_;
   TimerTaskID last_task_id_{0};
 };
 
@@ -80,11 +80,11 @@ class TimerTaskThread : public Thread {
   int StopThread() override;
   void set_thread_name(const std::string& name) override { Thread::set_thread_name(name); }
 
-  uint32_t AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec, const std::function<void()> &task){
+  TimerTaskID AddTimerTask(const std::string& task_name, int interval_ms, bool repeat_exec, const std::function<void()> &task){
       return timer_task_manager_.AddTimerTask(task_name, interval_ms, repeat_exec, task);
   };
 
-  bool DelTimerTaskByTaskId(uint32_t task_id){
+  bool DelTimerTaskByTaskId(TimerTaskID task_id){
     return timer_task_manager_.DelTimerTaskByTaskId(task_id);
 };
 


### PR DESCRIPTION
**问题**：
原本的TimerTaskManager(定时器)提供给epoll的timeout值为min_interval_ms，即注册在定时器内部所有定时任务中，执行间隔最小的任务的那个执行间隔。但是这样可能导致一个问题：假如有2个定时任务，一个每隔 20s执行一次，一个每隔30s执行一次，那这个定时器取的timeout就都是20s（min_time_interval）, 也就是每隔20s才会检查一下有没有任务过期。这样就会导致那个30s间隔的定时任务每次都要延迟10s才能被执行到。

**解决**：
直接取下一个即将过期的定时任务的过期时间戳减去当前时间戳，得到的值交给epoll_wait作为timeout参数即可。这样逻辑更加简单直接，而且可以规避上面提到的间隔误差问题。

**Question**: Originally, the TimerTaskManager (timer) provided the timeout value for epoll as min_interval_ms, which is the execution interval of the task with the shortest interval among all the scheduled tasks within the timer. However, this approach can lead to a problem: if there are two scheduled tasks, one that executes every 20 seconds and another that executes every 30 seconds, the timer will take 20 seconds (min_time_interval) as the timeout value. This means it will check for expired tasks every 20 seconds. Consequently, the task with a 30-second interval will always be delayed by 10 seconds before it is executed.

**Solution**:
Directly take the difference between the expiration timestamp of the next task to expire and the current timestamp, and pass this value to epoll_wait as the timeout parameter. This approach is simpler and more direct, and it avoids the interval error problem mentioned above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in task execution times by modifying the return type of `ExecTimerTask`.
- **Refactor**
  - Removed outdated `RenewMinIntervalMs` method to streamline code.
- **Performance**
  - Enhanced execution and management logic for `TimerTaskManager`, resulting in better task handling and timeout calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->