### PR TITLE
fix: set SlaveNode to DBSync status before commit bgsave task

### DIFF
--- a/src/pika_repl_server_conn.cc
+++ b/src/pika_repl_server_conn.cc
@@ -281,11 +281,12 @@ void PikaReplServerConn::HandleDBSyncRequest(void* arg) {
     }
   }
 
-  g_pika_server->TryDBSync(node.ip(), node.port() + kPortShiftRSync, db_name,
-                           static_cast<int32_t>(slave_boffset.filenum()));
   // Change slave node's state to kSlaveDbSync so that the binlog will perserved.
   // See details in SyncMasterSlot::BinlogCloudPurge.
   master_db->ActivateSlaveDbSync(node.ip(), node.port());
+
+  g_pika_server->TryDBSync(node.ip(), node.port() + kPortShiftRSync, db_name,
+                           static_cast<int32_t>(slave_boffset.filenum()));
 
   std::string reply_str;
   if (!response.SerializeToString(&reply_str) || (conn->WriteResp(reply_str) != 0)) {


### PR DESCRIPTION
这个PR修复了 Issue #2795 。
具体地，调换了两行代码的执行顺序。确保在Master端的SlaveNode会在提交bgsave任务开始前就进入DBSync状态（暂停BInlog的Purge），以确保bgsave执行时所基于的binlog(增量续传的起始点)不会在某些极端情况下被purge掉。

This PR fixes Issue #2795. 
Specifically, it changes the execution order of two lines of code to ensure that the SlaveNode on the Master side enters the DBSync state (pausing Binlog purge) before the bgsave task begins. This ensures that the binlog, which serves as the starting point for incremental replication, is not purged in extreme cases during the execution of bgsave.