### PR TITLE
fix: abnormal log output when exec slaveof no one

### DIFF
--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -166,6 +166,7 @@ class PikaReplicaManager {
   void RmStatus(std::string* debug_info);
   pstd::Status CheckDBRole(const std::string& table, int* role);
   pstd::Status LostConnection(const std::string& ip, int port);
+  pstd::Status DeactivateSyncSlaveDB(const std::string& ip, int port);
 
   // Update binlog win and try to send next binlog
   pstd::Status UpdateSyncBinlogStatus(const RmNode& slave, const LogOffset& offset_start, const LogOffset& offset_end);

--- a/src/pika_rm.cc
+++ b/src/pika_rm.cc
@@ -726,6 +726,17 @@ bool PikaReplicaManager::CheckSlaveDBState(const std::string& ip, const int port
   return true;
 }
 
+Status PikaReplicaManager::DeactivateSyncSlaveDB(const std::string& ip, int port) {
+  std::shared_lock l(dbs_rw_);
+  for (auto& iter : sync_slave_dbs_) {
+    std::shared_ptr<SyncSlaveDB> db = iter.second;
+    if (db->MasterIp() == ip && db->MasterPort() == port) {
+      db->Deactivate();
+    }
+  }
+  return Status::OK();
+}
+
 Status PikaReplicaManager::LostConnection(const std::string& ip, int port) {
   std::shared_lock l(dbs_rw_);
   for (auto& iter : sync_master_dbs_) {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -659,7 +659,7 @@ void PikaServer::RemoveMaster() {
 
     if (!master_ip_.empty() && master_port_ != -1) {
       g_pika_rm->CloseReplClientConn(master_ip_, master_port_ + kPortShiftReplServer);
-      g_pika_rm->LostConnection(master_ip_, master_port_);
+      g_pika_rm->DeactivateSyncSlaveDB(master_ip_, master_port_);
       UpdateMetaSyncTimestampWithoutLock();
       LOG(INFO) << "Remove Master Success, ip_port: " << master_ip_ << ":" << master_port_;
     }


### PR DESCRIPTION
该PR修复了 Issue #2800 

**问题原因**：执行slaveof no one时会执行RemoveMaster流程，会调一个LostConnect函数，其流程是：

 1 这个函数把SyncMasterDB遍历一遍，移除MasterIp:port所对应的slaveNode（实际上slave端根本没有这样一个slaveNode，只是移除行为是一个map的erase，即使没有命中也不会报错，当然也没有实际的危害）。于是每次做完一个移除行为就会打印一条日志告知Remove了slaveNode  

2 遍历一遍SyncSlaveDB，都执行Deactivate行为。

实际上在执行slaveof no one时，只做第二步就行了，所以把第二步的行为抽出了一个函数用来替代这个位置对于LostConnect的调用


This PR fixes Issue #2800.

**Cause**: When executing `slaveof no one`, the `RemoveMaster` process is triggered, which calls a `LostConnect` function. The process of this function is as follows:

1. The function iterates through `SyncMasterDB` and removes the `slaveNode` corresponding to `MasterIp:port`. In fact, there is no such `slaveNode` on the slave side. The removal is essentially a map erase operation. Even if there is no match, it does not report an error, and it does not cause any real harm.

2. It iterates through `SyncSlaveDB` and performs a `Deactivate` operation on each entry.

In reality, when executing `slaveof no one`, only the second step is necessary. Therefore, a new function was created to extract the second step's behavior to replace the call to `LostConnect` in this context.