### PR TITLE
fix: flushdb may cause master-slave inconsistency

### DIFF
--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -170,7 +170,7 @@ class ConsensusCoordinator {
   pstd::Status InternalAppendLog(const std::shared_ptr<Cmd>& cmd_ptr);
   pstd::Status InternalAppendBinlog(const std::shared_ptr<Cmd>& cmd_ptr);
   void InternalApply(const MemLog::LogItem& log);
-  void InternalApplyFollower(const MemLog::LogItem& log);
+  void InternalApplyFollower(std::shared_ptr<Cmd> cmd_ptr);
 
   pstd::Status GetBinlogOffset(const BinlogOffset& start_offset, LogOffset* log_offset);
   pstd::Status GetBinlogOffset(const BinlogOffset& start_offset, const BinlogOffset& end_offset,

--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -170,7 +170,7 @@ class ConsensusCoordinator {
   pstd::Status InternalAppendLog(const std::shared_ptr<Cmd>& cmd_ptr);
   pstd::Status InternalAppendBinlog(const std::shared_ptr<Cmd>& cmd_ptr);
   void InternalApply(const MemLog::LogItem& log);
-  void InternalApplyFollower(std::shared_ptr<Cmd> cmd_ptr);
+  void InternalApplyFollower(const std::shared_ptr<Cmd>& cmd_ptr);
 
   pstd::Status GetBinlogOffset(const BinlogOffset& start_offset, LogOffset* log_offset);
   pstd::Status GetBinlogOffset(const BinlogOffset& start_offset, const BinlogOffset& end_offset,
@@ -182,6 +182,7 @@ class ConsensusCoordinator {
   pstd::Status FindLogicOffset(const BinlogOffset& start_offset, uint64_t target_index, LogOffset* found_offset);
   pstd::Status GetLogsBefore(const BinlogOffset& start_offset, std::vector<LogOffset>* hints);
 
+ private:
   // keep members in this class works in order
   pstd::Mutex order_mu_;
 

--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -164,14 +164,12 @@ class ConsensusCoordinator {
     return tmp_stream.str();
   }
 
-  void IncrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
-    unfinished_async_write_db_task_count_.fetch_add(step_size, std::memory_order::memory_order_seq_cst);
-    LOG(INFO) << "incur 1, curr:" << unfinished_async_write_db_task_count_.load();
+  void IncrAsyncWriteDBTaskCount(int32_t step_size) {
+    async_write_db_task_count_.fetch_add(step_size, std::memory_order::memory_order_seq_cst);
   }
 
-  void DecrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
-    unfinished_async_write_db_task_count_.fetch_sub(step_size, std::memory_order::memory_order_seq_cst);
-    LOG(INFO) << "decr 1, curr:" << unfinished_async_write_db_task_count_.load();
+  void DecrAsyncWriteDBTaskCount(int32_t step_size) {
+    async_write_db_task_count_.fetch_sub(step_size, std::memory_order::memory_order_seq_cst);
   }
 
  private:
@@ -213,6 +211,6 @@ class ConsensusCoordinator {
   //queued or being executing by WriteDBWorkers. If a flushdb-binlog need to apply DB, it must wait
   //util this count drop to zero. you can also check pika discussion #2807 to know more
   //it is only used in slaveNode when comsuming binlog
-  std::atomic<int32_t> unfinished_async_write_db_task_count_{0};
+  std::atomic<int32_t> async_write_db_task_count_{0};
 };
 #endif  // INCLUDE_PIKA_CONSENSUS_H_

--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -102,9 +102,6 @@ class MemLog {
 
 class ConsensusCoordinator {
  public:
-  void PrintAsyncCount() {
-    LOG(INFO) << db_name_ << " asyncTask Count: " << unfinished_async_write_db_task_count_.load();
-  }
   ConsensusCoordinator(const std::string& db_name);
   ~ConsensusCoordinator();
   // since it is invoked in constructor all locks not hold
@@ -169,12 +166,10 @@ class ConsensusCoordinator {
 
   void IncrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
     unfinished_async_write_db_task_count_.fetch_add(step_size, std::memory_order::memory_order_seq_cst);
-//    LOG(INFO) << db_name_ << " Incr count, now value:" << unfinished_async_write_db_task_count_.load();
   }
 
   void DecrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
     unfinished_async_write_db_task_count_.fetch_sub(step_size, std::memory_order::memory_order_seq_cst);
-//    LOG(INFO) << db_name_ << " Decr count, now value:" << unfinished_async_write_db_task_count_.load();
   }
 
  private:

--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -166,10 +166,12 @@ class ConsensusCoordinator {
 
   void IncrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
     unfinished_async_write_db_task_count_.fetch_add(step_size, std::memory_order::memory_order_seq_cst);
+    LOG(INFO) << "incur 1, curr:" << unfinished_async_write_db_task_count_.load();
   }
 
   void DecrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
     unfinished_async_write_db_task_count_.fetch_sub(step_size, std::memory_order::memory_order_seq_cst);
+    LOG(INFO) << "decr 1, curr:" << unfinished_async_write_db_task_count_.load();
   }
 
  private:

--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -102,6 +102,9 @@ class MemLog {
 
 class ConsensusCoordinator {
  public:
+  void PrintAsyncCount() {
+    LOG(INFO) << db_name_ << " asyncTask Count: " << unfinished_async_write_db_task_count_.load();
+  }
   ConsensusCoordinator(const std::string& db_name);
   ~ConsensusCoordinator();
   // since it is invoked in constructor all locks not hold
@@ -164,13 +167,23 @@ class ConsensusCoordinator {
     return tmp_stream.str();
   }
 
+  void IncrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
+    unfinished_async_write_db_task_count_.fetch_add(step_size, std::memory_order::memory_order_seq_cst);
+//    LOG(INFO) << db_name_ << " Incr count, now value:" << unfinished_async_write_db_task_count_.load();
+  }
+
+  void DecrUnfinishedAsyncWriteDbTaskCount(int32_t step_size) {
+    unfinished_async_write_db_task_count_.fetch_sub(step_size, std::memory_order::memory_order_seq_cst);
+//    LOG(INFO) << db_name_ << " Decr count, now value:" << unfinished_async_write_db_task_count_.load();
+  }
+
  private:
   pstd::Status TruncateTo(const LogOffset& offset);
 
   pstd::Status InternalAppendLog(const std::shared_ptr<Cmd>& cmd_ptr);
   pstd::Status InternalAppendBinlog(const std::shared_ptr<Cmd>& cmd_ptr);
   void InternalApply(const MemLog::LogItem& log);
-  void InternalApplyFollower(std::shared_ptr<Cmd> cmd_ptr);
+  void InternalApplyFollower(std::shared_ptr<Cmd> cmd_ptr, std::function<void()>& call_back_fun);
 
   pstd::Status GetBinlogOffset(const BinlogOffset& start_offset, LogOffset* log_offset);
   pstd::Status GetBinlogOffset(const BinlogOffset& start_offset, const BinlogOffset& end_offset,
@@ -198,5 +211,11 @@ class ConsensusCoordinator {
   SyncProgress sync_pros_;
   std::shared_ptr<StableLog> stable_logger_;
   std::shared_ptr<MemLog> mem_logger_;
+
+  //this is used when consuming binlog, which indicates the nums of async writedb tasks that are
+  //queued or being executing by WriteDBWorkers. If a flushdb-binlog need to apply DB, it must wait
+  //util this count drop to zero. you can also check pika discussion #2807 to know more
+  //it is only used in slaveNode when comsuming binlog
+  std::atomic<int32_t> unfinished_async_write_db_task_count_{0};
 };
 #endif  // INCLUDE_PIKA_CONSENSUS_H_

--- a/include/pika_repl_bgworker.h
+++ b/include/pika_repl_bgworker.h
@@ -25,21 +25,11 @@ class PikaReplBgWorker {
   int StartThread();
   int StopThread();
   void Schedule(net::TaskFunc func, void* arg);
-  void QueueClear();
   static void HandleBGWorkerWriteBinlog(void* arg);
   static void HandleBGWorkerWriteDB(void* arg);
   static void WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr);
   void SetThreadName(const std::string& thread_name) {
     bg_thread_.set_thread_name(thread_name);
-  }
-  bool IsAllTaskConsumed() {
-    int32_t qu_size = 0;
-    int32_t pri_size = 0;
-    bg_thread_.QueueSize(&pri_size, &qu_size);
-    if (qu_size == 0 && !bg_thread_.IsExecutingTask()) {
-      return true;
-    }
-    return false;
   }
   BinlogItem binlog_item_;
   net::RedisParser redis_parser_;

--- a/include/pika_repl_bgworker.h
+++ b/include/pika_repl_bgworker.h
@@ -8,7 +8,7 @@
 
 #include <memory>
 #include <string>
-
+#include <functional>
 #include "net/include/bg_thread.h"
 #include "net/include/pb_conn.h"
 #include "net/include/thread_pool.h"
@@ -25,6 +25,7 @@ class PikaReplBgWorker {
   int StartThread();
   int StopThread();
   void Schedule(net::TaskFunc func, void* arg);
+  void Schedule(net::TaskFunc func, void* arg, std::function<void()>& call_back);
   static void HandleBGWorkerWriteBinlog(void* arg);
   static void HandleBGWorkerWriteDB(void* arg);
   static void WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr);

--- a/include/pika_repl_bgworker.h
+++ b/include/pika_repl_bgworker.h
@@ -28,10 +28,19 @@ class PikaReplBgWorker {
   void QueueClear();
   static void HandleBGWorkerWriteBinlog(void* arg);
   static void HandleBGWorkerWriteDB(void* arg);
+  static void WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr);
   void SetThreadName(const std::string& thread_name) {
     bg_thread_.set_thread_name(thread_name);
   }
-
+  bool IsAllTaskConsumed() {
+    int32_t qu_size = 0;
+    int32_t pri_size = 0;
+    bg_thread_.QueueSize(&pri_size, &qu_size);
+    if (qu_size == 0 && !bg_thread_.IsExecutingTask()) {
+      return true;
+    }
+    return false;
+  }
   BinlogItem binlog_item_;
   net::RedisParser redis_parser_;
   std::string ip_port_;

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -44,9 +44,8 @@ struct ReplClientWriteBinlogTaskArg {
 
 struct ReplClientWriteDBTaskArg {
   const std::shared_ptr<Cmd> cmd_ptr;
-  std::function<void()> call_back_fun;
-  explicit ReplClientWriteDBTaskArg(std::shared_ptr<Cmd> _cmd_ptr, std::function<void()> call_back)
-      : cmd_ptr(std::move(_cmd_ptr)), call_back_fun(std::move(call_back)) {}
+  explicit ReplClientWriteDBTaskArg(std::shared_ptr<Cmd> _cmd_ptr)
+      : cmd_ptr(std::move(_cmd_ptr)) {}
   ~ReplClientWriteDBTaskArg() = default;
 };
 

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -64,7 +64,7 @@ class PikaReplClient {
   void ScheduleByDBName(net::TaskFunc func, void* arg, const std::string& db_name);
   void ScheduleWriteBinlogTask(const std::string& db_name, const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                const std::shared_ptr<net::PbConn>& conn, void* res_private_data);
-  void ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, const std::string& db_name);
+  void ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const std::string& db_name);
 
   pstd::Status SendMetaSync();
   pstd::Status SendDBSync(const std::string& ip, uint32_t port, const std::string& db_name,

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -80,14 +80,12 @@ class PikaReplClient {
     int32_t db_index = db_name.back() - '0';
     assert(db_index >= 0 && db_index <= 7);
     async_write_db_task_counts_[db_index].fetch_add(incr_step, std::memory_order::memory_order_seq_cst);
-    LOG(INFO) << db_name << " incr 1, curr:" <<  async_write_db_task_counts_[db_index].load(std::memory_order_seq_cst);
   }
 
   void DecrAsyncWriteDBTaskCount(const std::string& db_name, int32_t incr_step) {
     int32_t db_index = db_name.back() - '0';
     assert(db_index >= 0 && db_index <= 7);
     async_write_db_task_counts_[db_index].fetch_sub(incr_step, std::memory_order::memory_order_seq_cst);
-    LOG(INFO) << db_name << " decr 1, curr:" <<  async_write_db_task_counts_[db_index].load(std::memory_order_seq_cst);
   }
 
   int32_t GetUnfinishedAsyncDBTaskCount(const std::string& db_name) {

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -85,9 +85,6 @@ class PikaReplClient {
   int next_avail_ = 0;
   std::hash<std::string> str_hash;
   std::vector<std::unique_ptr<PikaReplBgWorker>> write_binlog_workers_;
-  //[NOTICE] the task queue of WriteDBWorker must never be deliberately cleared,
-  // because their queue size are related with  ConsensusCoordinator::async_write_db_task_count_
-  // check PR # /disscussion #2807 to know more
   std::vector<std::unique_ptr<PikaReplBgWorker>> write_db_workers_;
 };
 

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -88,7 +88,7 @@ class PikaReplClient {
     async_write_db_task_counts_[db_index].fetch_sub(incr_step, std::memory_order::memory_order_seq_cst);
   }
 
-  int32_t GetUnfinishedAsyncDBTaskCount(const std::string& db_name) {
+  int32_t GetUnfinishedAsyncWriteDBTaskCount(const std::string& db_name) {
     int32_t db_index = db_name.back() - '0';
     assert(db_index >= 0 && db_index <= 7);
     return async_write_db_task_counts_[db_index].load(std::memory_order_seq_cst);
@@ -103,7 +103,7 @@ class PikaReplClient {
   int next_avail_ = 0;
   std::hash<std::string> str_hash;
 
-  // this is used when consuming binlog, which indicates the nums of async write-DB tasks that are
+  // async_write_db_task_counts_ is used when consuming binlog, which indicates the nums of async write-DB tasks that are
   // queued or being executing by WriteDBWorkers. If a flushdb-binlog need to apply DB, it must wait
   // util this count drop to zero. you can also check pika discussion #2807 to know more
   // it is only used in slaveNode when consuming binlog

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -86,7 +86,7 @@ class PikaReplClient {
   std::hash<std::string> str_hash;
   std::vector<std::unique_ptr<PikaReplBgWorker>> write_binlog_workers_;
   //[NOTICE] the task queue of WriteDBWorker must never be deliberately cleared,
-  // because their queue size are related with  ConsensusCoordinator::unfinished_async_write_db_task_count_
+  // because their queue size are related with  ConsensusCoordinator::async_write_db_task_count_
   // check PR # /disscussion #2807 to know more
   std::vector<std::unique_ptr<PikaReplBgWorker>> write_db_workers_;
 };

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -44,9 +44,6 @@ class SyncDB {
 
 class SyncMasterDB : public SyncDB {
  public:
-  void PrintAsyncCount() {
-    coordinator_.PrintAsyncCount();
-  }
   SyncMasterDB(const std::string& db_name);
   pstd::Status AddSlaveNode(const std::string& ip, int port, int session_id);
   pstd::Status RemoveSlaveNode(const std::string& ip, int port);
@@ -132,11 +129,6 @@ class SyncSlaveDB : public SyncDB {
 
 class PikaReplicaManager {
  public:
-  void PrintAsyncCount() {
-    for (auto& db: sync_master_dbs_) {
-      db.second->PrintAsyncCount();
-    }
-  }
   PikaReplicaManager();
   ~PikaReplicaManager() = default;
   friend Cmd;

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -205,8 +205,8 @@ class PikaReplicaManager {
     return sync_slave_dbs_;
   }
 
-  int32_t GetUnfinishedAsyncDBTaskCount(const std::string& db_name) {
-    return pika_repl_client_->GetUnfinishedAsyncDBTaskCount(db_name);
+  int32_t GetUnfinishedAsyncWriteDBTaskCount(const std::string& db_name) {
+    return pika_repl_client_->GetUnfinishedAsyncWriteDBTaskCount(db_name);
   }
 
  private:

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -184,7 +184,7 @@ class PikaReplicaManager {
   void ScheduleWriteBinlogTask(const std::string& db_name,
                                const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                const std::shared_ptr<net::PbConn>& conn, void* res_private_data);
-  void ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const LogOffset& offset, const std::string& db_name);
+  void ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr);
   void ScheduleReplClientBGTaskByDBName(net::TaskFunc , void* arg, const std::string &db_name);
   void ReplServerRemoveClientConn(int fd);
   void ReplServerUpdateClientConnMap(const std::string& ip_port, int fd);
@@ -205,6 +205,12 @@ class PikaReplicaManager {
     return sync_slave_dbs_;
   }
 
+  std::shared_mutex& GetApplyBinlogMtx() {
+    return apply_binlog_mtx_;
+  }
+
+  bool IsAllDBWrokerIdle() { return pika_repl_client_->IsAllDBWorkerIdle(); }
+
  private:
   void InitDB();
   pstd::Status SelectLocalIp(const std::string& remote_ip, int remote_port, std::string* local_ip);
@@ -212,6 +218,12 @@ class PikaReplicaManager {
   std::shared_mutex dbs_rw_;
   std::unordered_map<DBInfo, std::shared_ptr<SyncMasterDB>, hash_db_info> sync_master_dbs_;
   std::unordered_map<DBInfo, std::shared_ptr<SyncSlaveDB>, hash_db_info> sync_slave_dbs_;
+
+  //for non-flushdb binlog, need hold shared_lock of this mtx to writeBinlog and writeDB
+  //for flushdb, an exclusive lock must be hold to writeBinlog and WriteDB
+  //it's use to ensure that when a flushdb-binlog is applying, all other binlog's applying must be blocked
+  //in other word, flushdb's exec is exvlusive
+  std::shared_mutex apply_binlog_mtx_;
 
   pstd::Mutex write_queue_mu_;
 

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -184,7 +184,7 @@ class PikaReplicaManager {
   void ScheduleWriteBinlogTask(const std::string& db_name,
                                const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                const std::shared_ptr<net::PbConn>& conn, void* res_private_data);
-  void ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, std::function<void()>& call_back_fun);
+  void ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, const std::string& db_name);
   void ScheduleReplClientBGTaskByDBName(net::TaskFunc , void* arg, const std::string &db_name);
   void ReplServerRemoveClientConn(int fd);
   void ReplServerUpdateClientConnMap(const std::string& ip_port, int fd);
@@ -203,6 +203,10 @@ class PikaReplicaManager {
   }
   std::unordered_map<DBInfo, std::shared_ptr<SyncSlaveDB>, hash_db_info>& GetSyncSlaveDBs() {
     return sync_slave_dbs_;
+  }
+
+  int32_t GetUnfinishedAsyncDBTaskCount(const std::string& db_name) {
+    return pika_repl_client_->GetUnfinishedAsyncDBTaskCount(db_name);
   }
 
  private:

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -184,7 +184,7 @@ class PikaReplicaManager {
   void ScheduleWriteBinlogTask(const std::string& db_name,
                                const std::shared_ptr<InnerMessage::InnerResponse>& res,
                                const std::shared_ptr<net::PbConn>& conn, void* res_private_data);
-  void ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, const std::string& db_name);
+  void ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const std::string& db_name);
   void ScheduleReplClientBGTaskByDBName(net::TaskFunc , void* arg, const std::string &db_name);
   void ReplServerRemoveClientConn(int fd);
   void ReplServerUpdateClientConnMap(const std::string& ip_port, int fd);

--- a/src/net/include/bg_thread.h
+++ b/src/net/include/bg_thread.h
@@ -26,7 +26,7 @@ struct TimerItem {
 
 class BGThread final : public Thread {
  public:
-  explicit BGThread(int full = 100000) :  full_(full) {}
+  explicit BGThread(int full = 100000) :  full_(full), is_working_(false) {}
 
   ~BGThread() override {
     // call virtual in destructor, BGThread must be final
@@ -50,7 +50,7 @@ class BGThread final : public Thread {
   void QueueSize(int* pri_size, int* qu_size);
   void QueueClear();
   void SwallowReadyTasks();
-
+  bool IsExecutingTask() { return is_working_.load(std::memory_order::memory_order_seq_cst); }
  private:
   struct BGItem {
     void (*function)(void*);
@@ -63,6 +63,7 @@ class BGThread final : public Thread {
 
   size_t full_;
   pstd::Mutex mu_;
+  std::atomic<bool> is_working_;
   pstd::CondVar rsignal_;
   pstd::CondVar wsignal_;
   void* ThreadMain() override;

--- a/src/net/include/bg_thread.h
+++ b/src/net/include/bg_thread.h
@@ -8,7 +8,7 @@
 
 #include <atomic>
 #include <queue>
-
+#include <functional>
 #include "net/include/net_thread.h"
 
 #include "pstd/include/pstd_mutex.h"
@@ -41,7 +41,7 @@ class BGThread final : public Thread {
   }
 
   void Schedule(void (*function)(void*), void* arg);
-
+  void Schedule(void (*function)(void*), void* arg, std::function<void()>& call_back);
   /*
    * timeout is in millionsecond
    */
@@ -52,13 +52,22 @@ class BGThread final : public Thread {
   void SwallowReadyTasks();
 
  private:
-  struct BGItem {
+  class BGItem {
+   public:
     void (*function)(void*);
     void* arg;
+    //dtor_call_back is an optional call back fun
+    std::function<void()> dtor_call_back;
     BGItem(void (*_function)(void*), void* _arg) : function(_function), arg(_arg) {}
+    BGItem(void (*_function)(void*), void* _arg, std::function<void()>& _dtor_call_back) : function(_function), arg(_arg), dtor_call_back(_dtor_call_back) {}
+    ~BGItem() {
+      if (dtor_call_back) {
+        dtor_call_back();
+      }
+    }
   };
 
-  std::queue<BGItem> queue_;
+  std::queue<std::unique_ptr<BGItem>> queue_;
   std::priority_queue<TimerItem> timer_queue_;
 
   size_t full_;

--- a/src/net/include/bg_thread.h
+++ b/src/net/include/bg_thread.h
@@ -26,7 +26,7 @@ struct TimerItem {
 
 class BGThread final : public Thread {
  public:
-  explicit BGThread(int full = 100000) :  full_(full), is_working_(false) {}
+  explicit BGThread(int full = 100000) :  full_(full) {}
 
   ~BGThread() override {
     // call virtual in destructor, BGThread must be final
@@ -50,7 +50,7 @@ class BGThread final : public Thread {
   void QueueSize(int* pri_size, int* qu_size);
   void QueueClear();
   void SwallowReadyTasks();
-  bool IsExecutingTask() { return is_working_.load(std::memory_order::memory_order_seq_cst); }
+
  private:
   struct BGItem {
     void (*function)(void*);
@@ -63,7 +63,6 @@ class BGThread final : public Thread {
 
   size_t full_;
   pstd::Mutex mu_;
-  std::atomic<bool> is_working_;
   pstd::CondVar rsignal_;
   pstd::CondVar wsignal_;
   void* ThreadMain() override;

--- a/src/net/src/bg_thread.cc
+++ b/src/net/src/bg_thread.cc
@@ -84,10 +84,8 @@ void* BGThread::ThreadMain() {
       auto [exec_time, function, arg] = timer_queue_.top();
       if (unow >= exec_time) {
         timer_queue_.pop();
-        is_working_.store(true, std::memory_order::memory_order_seq_cst);
         lock.unlock();
         (*function)(arg);
-        is_working_.store(false, std::memory_order::memory_order_seq_cst);
         continue;
       } else if (queue_.empty() && !should_stop()) {
         rsignal_.wait_for(lock, std::chrono::microseconds(exec_time - unow));
@@ -101,10 +99,8 @@ void* BGThread::ThreadMain() {
       auto [function, arg] = queue_.front();
       queue_.pop();
       wsignal_.notify_one();
-      is_working_.store(true, std::memory_order::memory_order_seq_cst);
       lock.unlock();
       (*function)(arg);
-      is_working_.store(false, std::memory_order::memory_order_seq_cst);
     }
   }
   // swalloc all the remain tasks in ready and timer queue

--- a/src/net/src/bg_thread.cc
+++ b/src/net/src/bg_thread.cc
@@ -84,8 +84,10 @@ void* BGThread::ThreadMain() {
       auto [exec_time, function, arg] = timer_queue_.top();
       if (unow >= exec_time) {
         timer_queue_.pop();
+        is_working_.store(true, std::memory_order::memory_order_seq_cst);
         lock.unlock();
         (*function)(arg);
+        is_working_.store(false, std::memory_order::memory_order_seq_cst);
         continue;
       } else if (queue_.empty() && !should_stop()) {
         rsignal_.wait_for(lock, std::chrono::microseconds(exec_time - unow));
@@ -99,8 +101,10 @@ void* BGThread::ThreadMain() {
       auto [function, arg] = queue_.front();
       queue_.pop();
       wsignal_.notify_one();
+      is_working_.store(true, std::memory_order::memory_order_seq_cst);
       lock.unlock();
       (*function)(arg);
+      is_working_.store(false, std::memory_order::memory_order_seq_cst);
     }
   }
   // swalloc all the remain tasks in ready and timer queue

--- a/src/pika_consensus.cc
+++ b/src/pika_consensus.cc
@@ -358,7 +358,7 @@ Status ConsensusCoordinator::ProcessLeaderLog(const std::shared_ptr<Cmd>& cmd_pt
     // this is a flushdb-binlog, both apply binlog and apply db are in sync way
     // ensure all writeDB task that submitted before has finished before we exec this flushdb
     int32_t wait_ms = 250;
-    while (unfinished_async_write_db_task_count_.load(std::memory_order::memory_order_seq_cst) > 0) {
+    while (async_write_db_task_count_.load(std::memory_order::memory_order_seq_cst) > 0) {
       std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
       wait_ms *= 2;
       wait_ms = wait_ms < 3000 ? wait_ms : 3000;

--- a/src/pika_consensus.cc
+++ b/src/pika_consensus.cc
@@ -355,10 +355,8 @@ Status ConsensusCoordinator::ProcessLeaderLog(const std::shared_ptr<Cmd>& cmd_pt
     std::function<void()> call_back = [this]() { this->DecrUnfinishedAsyncWriteDbTaskCount(1); };
     InternalApplyFollower(cmd_ptr, call_back);
   } else {
-    LOG(INFO) << "Writing flushdb binlog in sync way";
     // this is a flushdb-binlog, both apply binlog and apply db are in sync way
-    // and flushdb should wait until all async WriteDB task submitted before flushdb finished exec
-    //ensure all writeDB task has finished before we exec flushdb
+    // ensure all writeDB task that submitted before has finished before we exec this flushdb
     int32_t wait_ms = 250;
     while (unfinished_async_write_db_task_count_.load(std::memory_order::memory_order_seq_cst) > 0) {
       std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));

--- a/src/pika_consensus.cc
+++ b/src/pika_consensus.cc
@@ -424,7 +424,7 @@ uint32_t ConsensusCoordinator::term() {
 }
 
 void ConsensusCoordinator::InternalApplyFollower(const std::shared_ptr<Cmd>& cmd_ptr) {
-  g_pika_rm->ScheduleWriteDBTask(std::move(cmd_ptr), db_name_);
+  g_pika_rm->ScheduleWriteDBTask(cmd_ptr, db_name_);
 }
 
 int ConsensusCoordinator::InitCmd(net::RedisParser* parser, const net::RedisCmdArgsType& argv) {

--- a/src/pika_consensus.cc
+++ b/src/pika_consensus.cc
@@ -356,7 +356,7 @@ Status ConsensusCoordinator::ProcessLeaderLog(const std::shared_ptr<Cmd>& cmd_pt
     // this is a flushdb-binlog, both apply binlog and apply db are in sync way
     // ensure all writeDB task that submitted before has finished before we exec this flushdb
     int32_t wait_ms = 250;
-    while (g_pika_rm->GetUnfinishedAsyncDBTaskCount(db_name_) > 0) {
+    while (g_pika_rm->GetUnfinishedAsyncWriteDBTaskCount(db_name_) > 0) {
       std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
       wait_ms *= 2;
       wait_ms = wait_ms < 3000 ? wait_ms : 3000;

--- a/src/pika_consensus.cc
+++ b/src/pika_consensus.cc
@@ -423,7 +423,7 @@ uint32_t ConsensusCoordinator::term() {
   return term_;
 }
 
-void ConsensusCoordinator::InternalApplyFollower(std::shared_ptr<Cmd> cmd_ptr) {
+void ConsensusCoordinator::InternalApplyFollower(const std::shared_ptr<Cmd>& cmd_ptr) {
   g_pika_rm->ScheduleWriteDBTask(std::move(cmd_ptr), db_name_);
 }
 

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -165,6 +165,7 @@ void PikaReplBgWorker::HandleBGWorkerWriteBinlog(void* arg) {
   g_pika_rm->SendBinlogSyncAckRequest(db_name, ack_start, ack_end);
 }
 
+//这里是经过解析之后写binlog，依旧处于binlogWorker中
 int PikaReplBgWorker::HandleWriteBinlog(net::RedisParser* parser, const net::RedisCmdArgsType& argv) {
   std::string opt = argv[0];
   auto worker = static_cast<PikaReplBgWorker*>(parser->data);
@@ -204,6 +205,7 @@ int PikaReplBgWorker::HandleWriteBinlog(net::RedisParser* parser, const net::Red
   return 0;
 }
 
+//这个是真正的writeDB写入，由writeDBWorker运行
 void PikaReplBgWorker::HandleBGWorkerWriteDB(void* arg) {
   std::unique_ptr<ReplClientWriteDBTaskArg> task_arg(static_cast<ReplClientWriteDBTaskArg*>(arg));
   const std::shared_ptr<Cmd> c_ptr = task_arg->cmd_ptr;

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -209,9 +209,11 @@ int PikaReplBgWorker::HandleWriteBinlog(net::RedisParser* parser, const net::Red
 void PikaReplBgWorker::HandleBGWorkerWriteDB(void* arg) {
   std::unique_ptr<ReplClientWriteDBTaskArg> task_arg(static_cast<ReplClientWriteDBTaskArg*>(arg));
   const std::shared_ptr<Cmd> c_ptr = task_arg->cmd_ptr;
+  WriteDBInSyncWay(c_ptr);
+}
+
+void PikaReplBgWorker::WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr) {
   const PikaCmdArgsType& argv = c_ptr->argv();
-  LogOffset offset = task_arg->offset;
-  std::string db_name = task_arg->db_name;
 
   uint64_t start_us = 0;
   if (g_pika_conf->slowlog_slower_than() >= 0) {

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -164,7 +164,6 @@ void PikaReplBgWorker::HandleBGWorkerWriteBinlog(void* arg) {
   g_pika_rm->SendBinlogSyncAckRequest(db_name, ack_start, ack_end);
 }
 
-//这里是经过解析之后写binlog，依旧处于binlogWorker中
 int PikaReplBgWorker::HandleWriteBinlog(net::RedisParser* parser, const net::RedisCmdArgsType& argv) {
   std::string opt = argv[0];
   auto worker = static_cast<PikaReplBgWorker*>(parser->data);

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -128,7 +128,6 @@ void PikaReplBgWorker::HandleBGWorkerWriteBinlog(void* arg) {
 
     // empty binlog treated as keepalive packet
     if (binlog_res.binlog().empty()) {
-      g_pika_rm->PrintAsyncCount();
       continue;
     }
     if (!PikaBinlogTransverter::BinlogItemWithoutContentDecode(TypeFirst, binlog_res.binlog(), &worker->binlog_item_)) {

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -32,6 +32,10 @@ int PikaReplBgWorker::StopThread() { return bg_thread_.StopThread(); }
 
 void PikaReplBgWorker::Schedule(net::TaskFunc func, void* arg) { bg_thread_.Schedule(func, arg); }
 
+void PikaReplBgWorker::Schedule(net::TaskFunc func, void* arg, std::function<void()>& call_back) {
+  bg_thread_.Schedule(func, arg, call_back);
+}
+
 void PikaReplBgWorker::ParseBinlogOffset(const InnerMessage::BinlogOffset& pb_offset, LogOffset* offset) {
   offset->b_offset.filenum = pb_offset.filenum();
   offset->b_offset.offset = pb_offset.offset();
@@ -206,7 +210,6 @@ void PikaReplBgWorker::HandleBGWorkerWriteDB(void* arg) {
   std::unique_ptr<ReplClientWriteDBTaskArg> task_arg(static_cast<ReplClientWriteDBTaskArg*>(arg));
   const std::shared_ptr<Cmd> c_ptr = task_arg->cmd_ptr;
   WriteDBInSyncWay(c_ptr);
-  task_arg->call_back_fun();
 }
 
 void PikaReplBgWorker::WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr) {

--- a/src/pika_repl_client.cc
+++ b/src/pika_repl_client.cc
@@ -98,11 +98,11 @@ void PikaReplClient::ScheduleWriteBinlogTask(const std::string& db_name,
   write_binlog_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteBinlog, static_cast<void*>(task_arg));
 }
 
-void PikaReplClient::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr) {
+void PikaReplClient::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, std::function<void()>& call_back_fun) {
   const PikaCmdArgsType& argv = cmd_ptr->argv();
   std::string dispatch_key = argv.size() >= 2 ? argv[1] : argv[0];
   size_t index = GetHashIndexByKey(dispatch_key);
-  auto task_arg = new ReplClientWriteDBTaskArg(std::move(cmd_ptr));
+  auto task_arg = new ReplClientWriteDBTaskArg(std::move(cmd_ptr), call_back_fun);
   write_db_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg));
 }
 

--- a/src/pika_repl_client.cc
+++ b/src/pika_repl_client.cc
@@ -101,7 +101,7 @@ void PikaReplClient::ScheduleWriteBinlogTask(const std::string& db_name,
   write_binlog_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteBinlog, static_cast<void*>(task_arg));
 }
 
-void PikaReplClient::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, const std::string& db_name) {
+void PikaReplClient::ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const std::string& db_name) {
   const PikaCmdArgsType& argv = cmd_ptr->argv();
   std::string dispatch_key = argv.size() >= 2 ? argv[1] : argv[0];
   size_t index = GetHashIndexByKey(dispatch_key);

--- a/src/pika_repl_client.cc
+++ b/src/pika_repl_client.cc
@@ -105,7 +105,7 @@ void PikaReplClient::ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, co
   const PikaCmdArgsType& argv = cmd_ptr->argv();
   std::string dispatch_key = argv.size() >= 2 ? argv[1] : argv[0];
   size_t index = GetHashIndexByKey(dispatch_key);
-  auto task_arg = new ReplClientWriteDBTaskArg(std::move(cmd_ptr));
+  auto task_arg = new ReplClientWriteDBTaskArg(cmd_ptr);
 
   IncrAsyncWriteDBTaskCount(db_name, 1);
   std::function<void()> task_finish_call_back = [this, db_name]() { this->DecrAsyncWriteDBTaskCount(db_name, 1); };

--- a/src/pika_repl_client.cc
+++ b/src/pika_repl_client.cc
@@ -102,8 +102,8 @@ void PikaReplClient::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, std::func
   const PikaCmdArgsType& argv = cmd_ptr->argv();
   std::string dispatch_key = argv.size() >= 2 ? argv[1] : argv[0];
   size_t index = GetHashIndexByKey(dispatch_key);
-  auto task_arg = new ReplClientWriteDBTaskArg(std::move(cmd_ptr), call_back_fun);
-  write_db_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg));
+  auto task_arg = new ReplClientWriteDBTaskArg(std::move(cmd_ptr));
+  write_db_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg), call_back_fun);
 }
 
 size_t PikaReplClient::GetBinlogWorkerIndexByDBName(const std::string &db_name) {

--- a/src/pika_repl_client.cc
+++ b/src/pika_repl_client.cc
@@ -98,12 +98,11 @@ void PikaReplClient::ScheduleWriteBinlogTask(const std::string& db_name,
   write_binlog_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteBinlog, static_cast<void*>(task_arg));
 }
 
-void PikaReplClient::ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const LogOffset& offset,
-                                         const std::string& db_name) {
+void PikaReplClient::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr) {
   const PikaCmdArgsType& argv = cmd_ptr->argv();
   std::string dispatch_key = argv.size() >= 2 ? argv[1] : argv[0];
   size_t index = GetHashIndexByKey(dispatch_key);
-  auto task_arg = new ReplClientWriteDBTaskArg(cmd_ptr, offset, db_name);
+  auto task_arg = new ReplClientWriteDBTaskArg(std::move(cmd_ptr));
   write_db_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg));
 }
 

--- a/src/pika_repl_client.cc
+++ b/src/pika_repl_client.cc
@@ -24,7 +24,10 @@ using pstd::Status;
 extern PikaServer* g_pika_server;
 extern std::unique_ptr<PikaReplicaManager> g_pika_rm;
 
-PikaReplClient::PikaReplClient(int cron_interval, int keepalive_timeout)  {
+PikaReplClient::PikaReplClient(int cron_interval, int keepalive_timeout) {
+  for (int i = 0; i < MAX_DB_NUM; i++) {
+    async_write_db_task_counts_[i].store(0, std::memory_order::memory_order_seq_cst);
+  }
   client_thread_ = std::make_unique<PikaReplClientThread>(cron_interval, keepalive_timeout);
   client_thread_->set_thread_name("PikaReplClient");
   for (int i = 0; i < g_pika_conf->sync_binlog_thread_num(); i++) {
@@ -98,12 +101,17 @@ void PikaReplClient::ScheduleWriteBinlogTask(const std::string& db_name,
   write_binlog_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteBinlog, static_cast<void*>(task_arg));
 }
 
-void PikaReplClient::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, std::function<void()>& call_back_fun) {
+void PikaReplClient::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, const std::string& db_name) {
   const PikaCmdArgsType& argv = cmd_ptr->argv();
   std::string dispatch_key = argv.size() >= 2 ? argv[1] : argv[0];
   size_t index = GetHashIndexByKey(dispatch_key);
   auto task_arg = new ReplClientWriteDBTaskArg(std::move(cmd_ptr));
-  write_db_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg), call_back_fun);
+
+  IncrAsyncWriteDBTaskCount(db_name, 1);
+  std::function<void()> task_finish_call_back = [this, db_name]() { this->DecrAsyncWriteDBTaskCount(db_name, 1); };
+
+  write_db_workers_[index]->Schedule(&PikaReplBgWorker::HandleBGWorkerWriteDB, static_cast<void*>(task_arg),
+                                     task_finish_call_back);
 }
 
 size_t PikaReplClient::GetBinlogWorkerIndexByDBName(const std::string &db_name) {

--- a/src/pika_rm.cc
+++ b/src/pika_rm.cc
@@ -683,9 +683,8 @@ void PikaReplicaManager::ScheduleWriteBinlogTask(const std::string& db,
   pika_repl_client_->ScheduleWriteBinlogTask(db, res, conn, res_private_data);
 }
 
-void PikaReplicaManager::ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const LogOffset& offset,
-                                             const std::string& db_name) {
-  pika_repl_client_->ScheduleWriteDBTask(cmd_ptr, offset, db_name);
+void PikaReplicaManager::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr) {
+  pika_repl_client_->ScheduleWriteDBTask(std::move(cmd_ptr));
 }
 
 void PikaReplicaManager::ReplServerRemoveClientConn(int fd) { pika_repl_server_->RemoveClientConn(fd); }

--- a/src/pika_rm.cc
+++ b/src/pika_rm.cc
@@ -37,7 +37,8 @@ std::string SyncDB::DBName() {
 /* SyncMasterDB*/
 
 SyncMasterDB::SyncMasterDB(const std::string& db_name)
-    : SyncDB(db_name),  coordinator_(db_name) {}
+    : SyncDB(db_name),  coordinator_(db_name) {
+}
 
 int SyncMasterDB::GetNumberOfSlaveNode() { return coordinator_.SyncPros().SlaveSize(); }
 
@@ -683,8 +684,8 @@ void PikaReplicaManager::ScheduleWriteBinlogTask(const std::string& db,
   pika_repl_client_->ScheduleWriteBinlogTask(db, res, conn, res_private_data);
 }
 
-void PikaReplicaManager::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr) {
-  pika_repl_client_->ScheduleWriteDBTask(std::move(cmd_ptr));
+void PikaReplicaManager::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, std::function<void()>& call_back_fun) {
+  pika_repl_client_->ScheduleWriteDBTask(std::move(cmd_ptr), call_back_fun);
 }
 
 void PikaReplicaManager::ReplServerRemoveClientConn(int fd) { pika_repl_server_->RemoveClientConn(fd); }

--- a/src/pika_rm.cc
+++ b/src/pika_rm.cc
@@ -683,8 +683,8 @@ void PikaReplicaManager::ScheduleWriteBinlogTask(const std::string& db,
   pika_repl_client_->ScheduleWriteBinlogTask(db, res, conn, res_private_data);
 }
 
-void PikaReplicaManager::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, std::function<void()>& call_back_fun) {
-  pika_repl_client_->ScheduleWriteDBTask(std::move(cmd_ptr), call_back_fun);
+void PikaReplicaManager::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, const std::string& db_name) {
+  pika_repl_client_->ScheduleWriteDBTask(std::move(cmd_ptr), db_name);
 }
 
 void PikaReplicaManager::ReplServerRemoveClientConn(int fd) { pika_repl_server_->RemoveClientConn(fd); }

--- a/src/pika_rm.cc
+++ b/src/pika_rm.cc
@@ -683,8 +683,8 @@ void PikaReplicaManager::ScheduleWriteBinlogTask(const std::string& db,
   pika_repl_client_->ScheduleWriteBinlogTask(db, res, conn, res_private_data);
 }
 
-void PikaReplicaManager::ScheduleWriteDBTask(std::shared_ptr<Cmd> cmd_ptr, const std::string& db_name) {
-  pika_repl_client_->ScheduleWriteDBTask(std::move(cmd_ptr), db_name);
+void PikaReplicaManager::ScheduleWriteDBTask(const std::shared_ptr<Cmd>& cmd_ptr, const std::string& db_name) {
+  pika_repl_client_->ScheduleWriteDBTask(cmd_ptr, db_name);
 }
 
 void PikaReplicaManager::ReplServerRemoveClientConn(int fd) { pika_repl_server_->RemoveClientConn(fd); }

--- a/src/pika_rm.cc
+++ b/src/pika_rm.cc
@@ -37,8 +37,7 @@ std::string SyncDB::DBName() {
 /* SyncMasterDB*/
 
 SyncMasterDB::SyncMasterDB(const std::string& db_name)
-    : SyncDB(db_name),  coordinator_(db_name) {
-}
+    : SyncDB(db_name),  coordinator_(db_name) {}
 
 int SyncMasterDB::GetNumberOfSlaveNode() { return coordinator_.SyncPros().SlaveSize(); }
 


### PR DESCRIPTION
fix Issue #2708 
discussion #2807  

**问题简述**：因为Slave端消费Binlog线程模型的缘故，原有代码中主从执行flushdb后可能出现主从不一致的现象 

**背景**：Pika Slave在消费一条Binlog时，按事件顺序分为两步，一是同步Apply Binlog, 也就是将收到的Binlog也追加到自己的BinlogFile中，二是异步多线程Apply DB, 也即将Binlog中抽取出来的命令写DB。具体地，Slave收到的所有Binlog都会顺序提交到一个固定的Binlog-Worker线程去消费，在这个Binlog-Worker线程上，会原地完成Apply Binlog的动作（同步地追加Binlog），之后会向另外一个WriteDBWorker线程池提交一个异步的WriteDB任务（按key来做hash决定使用池子里的哪一个DBworker）。**长话短说就是**：写Binlog的动作是单线程同步完成的，而写完Binlog之后，从Binlog中提取的WriteDB任务是提交到另一个线程池异步并发做的，并且**按照key hash来选择worker thread**。 **问题就在于：Flushdb这样的命令没有key，按照这样的执行方式根本无法在slave保证正确的执行顺序。**

**Case举例**：
>   **flushdb是一个会写binlog，却没有key的命令**，每次都会固定取某个线程来执行ApplyDB/写DB的操作（应该是使用flushdb命令名做了hash）。
>   考虑这样一个case：
>   主节点实际落盘的顺序（同时也是Binlog的顺序）是：
>   1. set key1 a1
>   2. set key1 a2
>   3. flushdb
>   4. set key1 a3
>   主节点执行完上述操作，**主实际写DB的顺序是1， 2， 3， 4**。 最后DB的状态是：有一个pair为：{key1, a3}
> 
>   但**从节点在Apply完Binlog之后，会将这4条命令提交到WriteDBWorker线程池中的不同线程**（按key做hash来分配，flushdb没有key，所以直接用的”flushdb“这个string来做hash），**以下就是一种很有可能的分配结果**: 
>
>   WriteDBWorkerThread**1**执行：set key a1; set key1 a2; set key1 a3;
>   WriteDBWorkerThread**2**执行：flushdb 
>
>   **假如因为线程调度原因，thread1先执行完了这3个set，thread2才去执行flushdb, **那从节点实际落盘的顺序就是1, 2, 4, 3,** 和主节点的落盘顺序不一致，进而导致主从不一致**：flushdb是最后执行的（但实际上flushdb应该发生于set key1 a3命令之前），会导致整个从库DB是空的。但是按照正确预期, 主从应该一致，从库也应当有key1，值为a3。 
>
> 这个case中flushdb被延后执行了，还有另一种正好相反的case：flushdb被提前执行了，就会出现主节点为空，从节点上却有数据的情况，性质和上述case几乎一样，就不具体阐述了。

**解决方案**：
- **必须确保flushdb命令之后的Binlog一定在flushdb执行完之后才被消费**。**具体变动为**：消费flushdb的Binlog时，将写Binlog以及WriteDB两个操作都放在WriteBinlogWorker上同步执行（原本是只有写Binlog任务在这里同步执行，WriteDB任务被分发到DBWorker线程池），说白了就是flushdb特殊化一下，WriteDB的动作从异步改为同步。**修改之后：能确保位于flushdb命令之后的Binlog不可能在flushdb执行完毕之前被提交到异步的DBWorker池子里，也就不可能会比flushdb更早执行**。 

- **必须确保flushdb命令在真正执行之前，位于flushdb之前的所有WriteDB任务都已经完成了**（操作已经写入RocksDB, 而不是还在某个WriteDBWorker的任务队列中排队）。**具体变动为：在BinlogWorker上新增一个提交计数/正在异步执行的WriteDB任务的计数**。每次BinlogWorker向WriteDBWorker池子中提交WriteDB任务时，都对这个计数加1，每当有相应的WriteDB任务完成，都对这个计数减1（加一个回调函数即可）。在**消费到flushdb的binlog时，需要在BinlogWorker上将flushdb进行同步地WriteDB前，需要先检查这个任务计数是否为0，如果不为0，就sleep一会（等待前面的异步WriteDB任务被执行完），再次检查该计数，一直等到该任务计数归0，才去原地将flushdb的操作apply到DB**。（为什么这个任务计数一定能等到归0：这个任务计数只有在BinlogWorker向WriteDBWorker池子异步提交任务时才会做自增，而这里的sleep等待实际上就是BinlogWorker在等待，换而言之，在这条同步消费的flushdb完全完成之前，下一条Binlog都不会被消费，也不会有任何的WriteDB任务被提交到WriteDBWoker的池子）。修改之后: 能确保flushdb之前的Binlog所对应的WriteDB任务一定都执行完了，才会执行flushdb，**能避免出现**：执行完flushdb之后（即写了binlog，也已经清空了DB），滞留在WriteDBWorker队列中的WriteDB任务才执行（即先于flushdb的命令在flushdb之后才执行)。

**Problem Summary**: Due to the Slave end's Binlog consumption thread model, executing flushdb on both master and slave in the original code may result in inconsistencies between master and slave.

**Background**: When Pika Slave consumes a Binlog, it follows two steps in order: first, Apply Binlog, which appends the received Binlog to its own BinlogFile; second, Apply DB, which extracts the commands from the Binlog and writes them to the DB. Specifically, all Binlogs received by the Slave are sequentially submitted to a fixed Binlog-Worker thread for consumption. On the Binlog-Worker thread, the Apply Binlog action (synchronously appending the Binlog) is completed in place. Subsequently, an asynchronous WriteDB task is submitted to another WriteDBWorker thread pool (the specific DBworker in the pool is assigned based on the key). **In short**: the Binlog writing action is completed synchronously by a single thread, while the WriteDB tasks extracted from the Binlog are submitted to another thread pool for asynchronous concurrent execution.

**Example Case**:

> After Pika's Slave applies the Binlog, it distributes the corresponding WriteDB tasks to multiple threads, using key hash to assign threads.
> **flushdb is a command that writes to the Binlog but does not have a key**, and it always uses a fixed thread to execute the ApplyDB/WriteDB operation.
> Consider this case:
> The actual write order on the master (which is also the Binlog order) is:
> 1. set key1 a1
> 2. set key1 a2
> 3. flushdb
> 4. set key1 a3
> After the master executes the above operations, **the actual DB write order on the master is 1, 2, 3, 4**. The final DB state is: there is one pair: {key1, a3}
> 
> However, **after the slave applies the Binlog, it submits these 4 commands to different threads in the WriteDBWorker thread pool** (assigned by key hash, flushdb has no key, so the string "flushdb" is used for hashing). **The following is a very likely assignment result**:
>
> WriteDBWorkerThread**1** executes: set key a1; set key1 a2; set key1 a3;
> WriteDBWorkerThread**2** executes: flushdb
>
> **If due to thread scheduling reasons, thread1 completes these 3 sets first, and then thread2 executes flushdb, **then the actual write order on the slave is 1, 2, 4, 3,** which is inconsistent with the master's write order, leading to master-slave inconsistency**: flushdb is executed last (but in fact, flushdb should occur before set key1 a3), resulting in the entire slave DB being empty. However, as expected, the master and slave should be consistent, and the slave DB should also have key1 with value a3.
>
> In this case, flushdb is delayed. Another similar case is when flushdb is executed earlier, leading to a situation where the master DB is empty, but the slave DB has data. The nature is almost the same as the above case, so it will not be elaborated further.

**Solution**:
- **Ensure that Binlogs after the flushdb command are not consumed until flushdb is executed**. **Specifically**: when consuming the flushdb Binlog, both the Binlog writing and the WriteDB operations are performed synchronously on the WriteBinlogWorker (originally only the Binlog writing task was done synchronously here, while the WriteDB task was dispatched to the DBWorker thread pool). Simply put, flushdb is treated specially, changing the WriteDB action from asynchronous to synchronous. **After the change: it ensures that Binlogs following the flushdb command cannot be submitted to the asynchronous DBWorker pool before flushdb is completed, and thus cannot be executed earlier than flushdb**.

- **Ensure that before the flushdb command is actually executed, all WriteDB tasks prior to flushdb have been completed** (operations have been written to RocksDB, not just queued in some WriteDBWorker's task queue). **Specifically**: add a counter for submitted/ongoing asynchronous WriteDB tasks on the BinlogWorker. Each time the BinlogWorker submits a WriteDB task to the WriteDBWorker pool, this counter is incremented by 1. When a corresponding WriteDB task is completed, the counter is decremented by 1 (adding a callback function). When consuming the flushdb Binlog, before synchronously executing WriteDB for flushdb on the BinlogWorker, it needs to check if this task count is 0. If not, it sleeps for a while (waiting for the previous asynchronous WriteDB tasks to complete), then rechecks the count, and waits until this task count reaches 0 before applying the flushdb operation to the DB in place. (Why this task count can definitely reach 0: this task count only increments when the BinlogWorker submits tasks asynchronously to the WriteDBWorker pool. The sleep wait here means the BinlogWorker is waiting. In other words, before this synchronous flushdb consumption is fully completed, the next Binlog will not be consumed, and no WriteDB task will be submitted to the WriteDBWorker pool). After the change: it ensures that all WriteDB tasks corresponding to Binlogs before flushdb are completed before executing flushdb, **avoiding the situation where**: after executing flushdb (i.e., writing the Binlog and clearing the DB), the WriteDB tasks remaining in the WriteDBWorker queue are executed (i.e., commands prior to flushdb are executed after flushdb).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced methods to manage asynchronous database write tasks.
  - Added support for callback functions in task scheduling methods.
  - Enhanced synchronous writing capabilities for better database command control.

- **Bug Fixes**
  - Updated method signatures to improve callback and task handling.

- **Refactor**
  - Removed obsolete parameters from constructors and methods for clarity.
  - Consolidated and streamlined task handling logic for improved performance.

- **Performance Improvements**
  - Enhanced asynchronous processing for command handling and database operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->