### PR TITLE
fix:slave_prorority need to be 100 when used redis sentinel

### DIFF
--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -891,7 +891,7 @@ class PikaConf : public pstd::BaseConf {
  private:
   // TODO: replace mutex with atomic value
   int port_ = 0;
-  int slave_priority_ = 0;
+  int slave_priority_ = 100;
   int thread_num_ = 0;
   int thread_pool_size_ = 0;
   int slow_cmd_thread_pool_size_ = 0;


### PR DESCRIPTION
https://github.com/OpenAtomFoundation/pika/issues/2793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the default slave priority setting from 0 to 100 to improve failover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->