### PR TITLE
fix: change storage ttl time from seconds to milliseconds

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{ env.BUILD_TYPE }}
+        run: ctest -C ${{ env.BUILD_TYPE }} --verbose
 
       - name: Unit Test
         working-directory: ${{ github.workspace }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Test
         working-directory: ${{ github.workspace }}/build
-        run: ctest --rerun-failed --output-on-failure -C ${{ env.BUILD_TYPE }}
+        run: ctest -C ${{ env.BUILD_TYPE }} --verbose
 
       - name: Unit Test
         working-directory: ${{ github.workspace }}

--- a/include/pika_cache.h
+++ b/include/pika_cache.h
@@ -67,7 +67,7 @@ class PikaCache : public pstd::noncopyable, public std::enable_shared_from_this<
 
   rocksdb::Status Del(const std::vector<std::string>& keys);
   rocksdb::Status Expire(std::string& key, int64_t ttl);
-  rocksdb::Status Expireat(std::string& key, int64_t ttl);
+  rocksdb::Status Expireat(std::string& key, int64_t ttl_sec);
   rocksdb::Status TTL(std::string& key, int64_t* ttl);
   rocksdb::Status Persist(std::string& key);
   rocksdb::Status Type(std::string& key, std::string* value);

--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -36,12 +36,12 @@ class SetCmd : public Cmd {
   std::string value_;
   std::string target_;
   int32_t success_ = 0;
-  int64_t sec_ = 0;
+  int64_t ttl_millsec = 0;
   bool has_ttl_ = false;
   SetCmd::SetCondition condition_{kNONE};
   void DoInitial() override;
   void Clear() override {
-    sec_ = 0;
+    ttl_millsec = 0;
     success_ = 0;
     condition_ = kNONE;
   }
@@ -69,7 +69,7 @@ class GetCmd : public Cmd {
  private:
   std::string key_;
   std::string value_;
-  int64_t sec_ = 0;
+  int64_t ttl_millsec_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
 };
@@ -342,7 +342,7 @@ class SetexCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t sec_ = 0;
+  int64_t ttl_sec_ = 0;
   std::string value_;
   void DoInitial() override;
   rocksdb::Status s_;
@@ -367,7 +367,7 @@ class PsetexCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t usec_ = 0;
+  int64_t ttl_millsec = 0;
   std::string value_;
   void DoInitial() override;
   rocksdb::Status s_;
@@ -531,7 +531,7 @@ class StrlenCmd : public Cmd {
  private:
   std::string key_;
   std::string value_;
-  int64_t sec_ = 0;
+  int64_t ttl_millsec = 0;
   void DoInitial() override;
   rocksdb::Status s_;
 };
@@ -800,9 +800,9 @@ class PKSetexAtCmd : public Cmd {
  private:
   std::string key_;
   std::string value_;
-  int64_t time_stamp_ = 0;
+  int64_t time_stamp_sec_ = 0;
   void DoInitial() override;
-  void Clear() override { time_stamp_ = 0; }
+  void Clear() override { time_stamp_sec_ = 0; }
   rocksdb::Status s_;
 };
 

--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -572,7 +572,7 @@ class ExpireCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t sec_ = 0;
+  int64_t ttl_sec_ = 0;
   void DoInitial() override;
   std::string ToRedisProtocol() override;
   rocksdb::Status s_;
@@ -596,7 +596,7 @@ class PexpireCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t msec_ = 0;
+  int64_t ttl_millsec = 0;
   void DoInitial() override;
   std::string ToRedisProtocol() override;
   rocksdb::Status s_;
@@ -620,7 +620,7 @@ class ExpireatCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t time_stamp_ = 0;
+  int64_t time_stamp_sec_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
 };
@@ -643,10 +643,9 @@ class PexpireatCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t time_stamp_ms_ = 0;
+  int64_t time_stamp_millsec_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
-  std::string ToRedisProtocol() override;
 };
 
 class TtlCmd : public Cmd {

--- a/src/net/examples/performance/server.cc
+++ b/src/net/examples/performance/server.cc
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
 
   std::unique_ptr<ServerThread> st_thread(NewDispatchThread(ip, port, 24, &conn_factory, 1000));
   st_thread->StartThread();
-  uint64_t st, ed;
+  pstd::TimeType st, ed;
 
   while (!should_stop) {
     st = NowMicros();

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2730,8 +2730,8 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
                    "The rsync rate limit now is "
                 << new_throughput_limit << "(Which Is Around " << (new_throughput_limit >> 20) << " MB/s)";
     res_.AppendStringRaw("+OK\r\n");
-  } else if(set_item == "rsync-timeout-ms"){
-    if(pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0){
+  } else if (set_item == "rsync-timeout-ms") {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0) {
       res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'rsync-timeout-ms'\r\n");
       return;
     }
@@ -2926,9 +2926,9 @@ void DbsizeCmd::Do() {
   if (!dbs) {
     res_.SetRes(CmdRes::kInvalidDB);
   } else {
-    if (g_pika_conf->slotmigrate()){
+    if (g_pika_conf->slotmigrate()) {
       int64_t dbsize = 0;
-      for (int i = 0; i < g_pika_conf->default_slot_num(); ++i){
+      for (int i = 0; i < g_pika_conf->default_slot_num(); ++i) {
         int32_t card = 0;
         rocksdb::Status s = dbs->storage()->SCard(SlotKeyPrefix+std::to_string(i), &card);
         if (s.ok() && card >= 0) {

--- a/src/pika_bit.cc
+++ b/src/pika_bit.cc
@@ -114,7 +114,7 @@ void BitGetCmd::DoThroughDB() {
   Do();
 }
 
-void BitGetCmd::DoUpdateCache(){
+void BitGetCmd::DoUpdateCache() {
   if (s_.ok()) {
     db_->cache()->PushKeyToAsyncLoadQueue(PIKA_KEY_TYPE_KV, key_, db_);
   }

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -126,10 +126,10 @@ Status PikaCache::Expire(std::string& key, int64_t ttl) {
   return caches_[cache_index]->Expire(key, ttl);
 }
 
-Status PikaCache::Expireat(std::string& key, int64_t ttl) {
+Status PikaCache::Expireat(std::string& key, int64_t milliseconds) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  return caches_[cache_index]->Expireat(key, ttl);
+  return caches_[cache_index]->Expireat(key, milliseconds);
 }
 
 Status PikaCache::TTL(std::string& key, int64_t *ttl) {

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -126,10 +126,10 @@ Status PikaCache::Expire(std::string& key, int64_t ttl) {
   return caches_[cache_index]->Expire(key, ttl);
 }
 
-Status PikaCache::Expireat(std::string& key, int64_t milliseconds) {
+Status PikaCache::Expireat(std::string& key, int64_t ttl_sec) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  return caches_[cache_index]->Expireat(key, milliseconds);
+  return caches_[cache_index]->Expireat(key, ttl_sec);
 }
 
 Status PikaCache::TTL(std::string& key, int64_t *ttl) {

--- a/src/pika_cache_load_thread.cc
+++ b/src/pika_cache_load_thread.cc
@@ -115,13 +115,13 @@ bool PikaCacheLoadThread::LoadSet(std::string& key, const std::shared_ptr<DB>& d
   }
 
   std::vector<std::string> values;
-  int64_t ttl = -1;
-  rocksdb::Status s = db->storage()->SMembersWithTTL(key, &values, &ttl);
+  int64_t ttl_millsec = -1;
+  rocksdb::Status s = db->storage()->SMembersWithTTL(key, &values, &ttl_millsec);
   if (!s.ok()) {
     LOG(WARNING) << "load set failed, key=" << key;
     return false;
   }
-  db->cache()->WriteSetToCache(key, values, ttl);
+  db->cache()->WriteSetToCache(key, values, ttl_millsec > 0 ? ttl_millsec / 1000 : ttl_millsec);
   return true;
 }
 

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -180,7 +180,7 @@ int PikaConf::Load() {
 
   std::string admin_cmd_list;
   GetConfStr("admin-cmd-list", &admin_cmd_list);
-  if (admin_cmd_list == ""){
+  if (admin_cmd_list == "") {
     admin_cmd_list = "info, monitor, ping";
     SetAdminCmd(admin_cmd_list);
   }
@@ -704,7 +704,7 @@ int PikaConf::Load() {
 
   int64_t tmp_rsync_timeout_ms = -1;
   GetConfInt64("rsync-timeout-ms", &tmp_rsync_timeout_ms);
-  if(tmp_rsync_timeout_ms <= 0){
+  if (tmp_rsync_timeout_ms <= 0) {
     rsync_timeout_ms_.store(1000);
   } else {
     rsync_timeout_ms_.store(tmp_rsync_timeout_ms);

--- a/src/pika_geo.cc
+++ b/src/pika_geo.cc
@@ -366,7 +366,7 @@ static void GetAllNeighbors(const std::shared_ptr<DB>& db, std::string& key, Geo
     int32_t count = 0;
     int32_t card = db->storage()->Exists({range.storekey});
     if (card) {
-      if (db->storage()->Del({range.storekey}) > 0){
+      if (db->storage()->Del({range.storekey}) > 0) {
         db->cache()->Del({range.storekey});
       }
     }

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1442,7 +1442,7 @@ void PttlCmd::Do() {
 }
 
 void PttlCmd::ReadCache() {
-  // redis cache donnot support pttl cache, so read directly from db
+  // redis cache don't support pttl cache, so read directly from db
   DoThroughDB();
 }
 

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1433,7 +1433,7 @@ void PttlCmd::DoInitial() {
 }
 
 void PttlCmd::Do() {
-  int64_t timestamp = db_->storage()->TTL(key_);
+  int64_t timestamp = db_->storage()->PTTL(key_);
   if (timestamp == -3) {
     res_.SetRes(CmdRes::kErrOther, "ttl internal error");
   } else {
@@ -1442,19 +1442,8 @@ void PttlCmd::Do() {
 }
 
 void PttlCmd::ReadCache() {
-  int64_t timestamp = db_->cache()->TTL(key_);
-  if (timestamp == -3) {
-    res_.SetRes(CmdRes::kErrOther, "ttl internal error");
-  } else if (timestamp != -2) {
-    if (timestamp == -1) {
-      res_.AppendInteger(-1);
-    } else {
-      res_.AppendInteger(timestamp * 1000);
-    }
-  } else {
-    // mean this key not exist
-    res_.SetRes(CmdRes::kCacheMiss);
-  }
+  // redis cache donnot support pttl cache, so read directly from db
+  DoThroughDB();
 }
 
 void PttlCmd::DoThroughDB() {

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -491,7 +491,7 @@ void AppendCmd::Do() {
   }
 }
 
-void AppendCmd::DoThroughDB(){
+void AppendCmd::DoThroughDB() {
   Do();
 }
 
@@ -529,7 +529,7 @@ void MgetCmd::AssembleResponseFromCache() {
 void MgetCmd::Do() {
   // Without using the cache and querying only the DB, we need to use keys_.
   // This line will only be assigned when querying the DB directly.
-  if(cache_miss_keys_.size() == 0) {
+  if (cache_miss_keys_.size() == 0) {
     cache_miss_keys_ = keys_;
   }
   db_value_status_array_.clear();
@@ -944,7 +944,7 @@ void MsetCmd::DoBinlog() {
   set_argv[0] = "set";
   set_cmd_->SetConn(GetConn());
   set_cmd_->SetResp(resp_.lock());
-  for(auto& kv: kvs_){
+  for(auto& kv: kvs_) {
     set_argv[1] = kv.key;
     set_argv[2] = kv.value;
     set_cmd_->Initial(set_argv, db_name_);
@@ -1293,7 +1293,7 @@ std::string PexpireCmd::ToRedisProtocol() {
   return content;
 }
 
-void PexpireCmd::DoThroughDB(){
+void PexpireCmd::DoThroughDB() {
   Do();
 }
 

--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -130,7 +130,7 @@ void LLenCmd::Do() {
 void LLenCmd::ReadCache() {
   uint64_t llen = 0;
   auto s = db_->cache()->LLen(key_, &llen);
-  if (s.ok()){
+  if (s.ok()) {
     res_.AppendInteger(llen);
   } else if (s.IsNotFound()) {
     res_.SetRes(CmdRes::kCacheMiss);

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -604,7 +604,7 @@ int32_t PikaServer::GetSlaveListString(std::string& slave_list_str) {
               master_boffset.offset - sent_slave_boffset.offset;
           tmp_stream << "(" << db->DBName() << ":" << lag << ")";
         }
-      } else if (s.ok() && slave_state == SlaveState::kSlaveDbSync){
+      } else if (s.ok() && slave_state == SlaveState::kSlaveDbSync) {
         tmp_stream << "(" << db->DBName() << ":full syncing)";
       } else {
         tmp_stream << "(" << db->DBName() << ":not syncing)";
@@ -1500,7 +1500,7 @@ void DoBgslotsreload(void* arg) {
   rocksdb::Status s;
   std::vector<std::string> keys;
   int64_t cursor_ret = -1;
-  while(cursor_ret != 0 && p->GetSlotsreloading()){
+  while(cursor_ret != 0 && p->GetSlotsreloading()) {
     cursor_ret = reload.db->storage()->Scan(storage::DataType::kAll, reload.cursor, reload.pattern, reload.count, &keys);
 
     std::vector<std::string>::const_iterator iter;
@@ -1508,8 +1508,8 @@ void DoBgslotsreload(void* arg) {
       std::string key_type;
       int s = GetKeyType(*iter, key_type, reload.db);
       //if key is slotkey, can't add to SlotKey
-      if (s > 0){
-        if (key_type == "s" && ((*iter).find(SlotKeyPrefix) != std::string::npos || (*iter).find(SlotTagPrefix) != std::string::npos)){
+      if (s > 0) {
+        if (key_type == "s" && ((*iter).find(SlotKeyPrefix) != std::string::npos || (*iter).find(SlotTagPrefix) != std::string::npos)) {
           continue;
         }
 
@@ -1618,7 +1618,7 @@ void DoBgslotscleanup(void* arg) {
   std::vector<std::string> keys;
   int64_t cursor_ret = -1;
   std::vector<int> cleanupSlots(cleanup.cleanup_slots);
-  while (cursor_ret != 0 && p->GetSlotscleaningup()){
+  while (cursor_ret != 0 && p->GetSlotscleaningup()) {
     cursor_ret = g_pika_server->bgslots_cleanup_.db->storage()->Scan(storage::DataType::kAll, cleanup.cursor, cleanup.pattern, cleanup.count, &keys);
 
     std::string key_type;
@@ -1627,12 +1627,12 @@ void DoBgslotscleanup(void* arg) {
       if ((*iter).find(SlotKeyPrefix) != std::string::npos || (*iter).find(SlotTagPrefix) != std::string::npos) {
         continue;
       }
-      if (std::find(cleanupSlots.begin(), cleanupSlots.end(), GetSlotID(g_pika_conf->default_slot_num(), *iter)) != cleanupSlots.end()){
+      if (std::find(cleanupSlots.begin(), cleanupSlots.end(), GetSlotID(g_pika_conf->default_slot_num(), *iter)) != cleanupSlots.end()) {
         if (GetKeyType(*iter, key_type, g_pika_server->bgslots_cleanup_.db) <= 0) {
           LOG(WARNING) << "slots clean get key type for slot " << GetSlotID(g_pika_conf->default_slot_num(), *iter) << " key " << *iter << " error";
           continue;
         }
-        if (DeleteKey(*iter, key_type[0], g_pika_server->bgslots_cleanup_.db) <= 0){
+        if (DeleteKey(*iter, key_type[0], g_pika_server->bgslots_cleanup_.db) <= 0) {
           LOG(WARNING) << "slots clean del for slot " << GetSlotID(g_pika_conf->default_slot_num(), *iter) << " key "<< *iter << " error";
         }
       }
@@ -1643,7 +1643,7 @@ void DoBgslotscleanup(void* arg) {
     keys.clear();
   }
 
-  for (int cleanupSlot : cleanupSlots){
+  for (int cleanupSlot : cleanupSlots) {
     WriteDelKeyToBinlog(GetSlotKey(cleanupSlot), g_pika_server->bgslots_cleanup_.db);
     WriteDelKeyToBinlog(GetSlotsTagKey(cleanupSlot), g_pika_server->bgslots_cleanup_.db);
   }

--- a/src/pika_zset.cc
+++ b/src/pika_zset.cc
@@ -77,7 +77,7 @@ void ZCardCmd::Do() {
   }
 }
 
-void ZCardCmd::ReadCache(){
+void ZCardCmd::ReadCache() {
   res_.SetRes(CmdRes::kCacheMiss);
 }
 
@@ -590,7 +590,7 @@ void ZRevrangebyscoreCmd::Do() {
   }
 }
 
-void ZRevrangebyscoreCmd::ReadCache(){
+void ZRevrangebyscoreCmd::ReadCache() {
   if (min_score_ == storage::ZSET_SCORE_MAX || max_score_ == storage::ZSET_SCORE_MIN
       || max_score_ < min_score_) {
     res_.AppendContent("*0");
@@ -827,7 +827,7 @@ void ZUnionstoreCmd::DoBinlog() {
   del_cmd->SetResp(resp_.lock());
   del_cmd->DoBinlog();
 
-  if(value_to_dest_.empty()){
+  if (value_to_dest_.empty()) {
     // The union operation got an empty set, only use del to simulate overwrite the dest_key with empty set
     return;
   }
@@ -975,7 +975,7 @@ void ZRankCmd::ReadCache() {
   auto s = db_->cache()->ZRank(key_, member_, &rank, db_);
   if (s.ok()) {
     res_.AppendInteger(rank);
-  } else if (s.IsNotFound()){
+  } else if (s.IsNotFound()) {
     res_.SetRes(CmdRes::kCacheMiss);
   }  else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
@@ -1020,7 +1020,7 @@ void ZRevrankCmd::ReadCache() {
   auto s = db_->cache()->ZRevrank(key_, member_, &revrank, db_);
   if (s.ok()) {
     res_.AppendInteger(revrank);
-  } else if (s.IsNotFound()){
+  } else if (s.IsNotFound()) {
     res_.SetRes(CmdRes::kCacheMiss);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());

--- a/src/pstd/include/env.h
+++ b/src/pstd/include/env.h
@@ -17,6 +17,8 @@ class SequentialFile;
 class RWFile;
 class RandomRWFile;
 
+using TimeType = uint64_t;
+
 /*
  *  Set the resource limits of a process
  */
@@ -61,9 +63,9 @@ class FileLock : public pstd::noncopyable {
 int GetChildren(const std::string& dir, std::vector<std::string>& result);
 void GetDescendant(const std::string& dir, std::vector<std::string>& result);
 
-uint64_t NowMicros();
+TimeType NowMicros();
 
-uint64_t NowMillis();
+TimeType NowMillis();
 
 void SleepForMicroseconds(int micros);
 

--- a/src/pstd/include/env.h
+++ b/src/pstd/include/env.h
@@ -62,6 +62,9 @@ int GetChildren(const std::string& dir, std::vector<std::string>& result);
 void GetDescendant(const std::string& dir, std::vector<std::string>& result);
 
 uint64_t NowMicros();
+
+uint64_t NowMillis();
+
 void SleepForMicroseconds(int micros);
 
 Status NewSequentialFile(const std::string& fname, std::unique_ptr<SequentialFile>& result);

--- a/src/pstd/src/env.cc
+++ b/src/pstd/src/env.cc
@@ -222,6 +222,11 @@ uint64_t NowMicros() {
   return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
 }
 
+uint64_t NowMillis() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+}
+
 void SleepForMicroseconds(int micros) { std::this_thread::sleep_for(std::chrono::microseconds(micros)); }
 
 SequentialFile::~SequentialFile() = default;

--- a/src/pstd/src/env.cc
+++ b/src/pstd/src/env.cc
@@ -217,12 +217,12 @@ uint64_t Du(const std::string& path) {
   return sum;
 }
 
-uint64_t NowMicros() {
+TimeType NowMicros() {
   auto now = std::chrono::system_clock::now();
   return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
 }
 
-uint64_t NowMillis() {
+TimeType NowMillis() {
   auto now = std::chrono::system_clock::now();
   return std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 }

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -1027,6 +1027,13 @@ class Storage {
   // return > 0 TTL in seconds
   int64_t TTL(const Slice& key);
 
+  // Returns the remaining time to live of a key that has a timeout.
+  // return -3 operation exception errors happen in database
+  // return -2 if the key does not exist
+  // return -1 if the key exists but has not associated expire
+  // return > 0 TTL in milliseconds
+  int64_t PTTL(const Slice& key);
+
   // Reutrns the data all type of the key
   // if single is true, the query will return the first one
   Status GetType(const std::string& key, enum DataType& type);

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -105,8 +105,8 @@ struct KeyInfo {
 struct ValueStatus {
   std::string value;
   Status status;
-  int64_t  ttl;
-  bool operator==(const ValueStatus& vs) const { return (vs.value == value && vs.status == status && vs.ttl == ttl); }
+  int64_t ttl_millsec;
+  bool operator==(const ValueStatus& vs) const { return (vs.value == value && vs.status == status && vs.ttl_millsec == ttl_millsec); }
 };
 
 struct FieldValue {
@@ -190,7 +190,7 @@ class Storage {
   Status Set(const Slice& key, const Slice& value);
 
   // Set key to hold the string value. if key exist
-  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
+  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
 
   // Get the value of key. If the key does not exist
   // the special value nil is returned
@@ -198,7 +198,7 @@ class Storage {
 
   // Get the value and ttl of key. If the key does not exist
   // the special value nil is returned. If the key has no ttl, ttl is -1
-  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
+  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
 
   // Atomically sets key to value and returns the old value stored at key
   // Returns an error when key exists but does not hold a string value.
@@ -227,7 +227,7 @@ class Storage {
   // Set key to hold string value if key does not exist
   // return 1 if the key was set
   // return 0 if the key was not set
-  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
+  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
 
   // Sets the given keys to their respective values.
   // MSETNX will not perform any operation at all even
@@ -238,7 +238,7 @@ class Storage {
   // return 1 if the key currently hold the give value And override success
   // return 0 if the key doesn't exist And override fail
   // return -1 if the key currently does not hold the given value And override fail
-  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl = 0);
+  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl_millsec = 0);
 
   // delete the key that holds a given value
   // return 1 if the key currently hold the give value And delete success
@@ -255,7 +255,7 @@ class Storage {
   Status Getrange(const Slice& key, int64_t start_offset, int64_t end_offset, std::string* ret);
 
   Status GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
-                           std::string* ret, std::string* value, int64_t* ttl);
+                           std::string* ret, std::string* value, int64_t* ttl_millsec);
 
   // If key already exists and is a string, this command appends the value at
   // the end of the string
@@ -293,7 +293,7 @@ class Storage {
 
   // Set key to hold the string value and set key to timeout after a given
   // number of seconds
-  Status Setex(const Slice& key, const Slice& value, int64_t ttl);
+  Status Setex(const Slice& key, const Slice& value, int64_t ttl_millsec);
 
   // Returns the length of the string value stored at key. An error
   // is returned when key holds a non-string value.
@@ -303,7 +303,7 @@ class Storage {
   // specifying the number of seconds representing the TTL (time to live), it
   // takes an absolute Unix timestamp (seconds since January 1, 1970). A
   // timestamp in the past will delete the key immediately.
-  Status PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp);
+  Status PKSetexAt(const Slice& key, const Slice& value, int64_t time_stamp_millsec_);
 
   // Hashes Commands
 
@@ -334,7 +334,7 @@ class Storage {
   // reply is twice the size of the hash.
   Status HGetall(const Slice& key, std::vector<FieldValue>* fvs);
 
-  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl);
+  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl_millsec);
 
   // Returns all field names in the hash stored at key.
   Status HKeys(const Slice& key, std::vector<std::string>* fields);
@@ -467,7 +467,7 @@ class Storage {
   // This has the same effect as running SINTER with one argument key.
   Status SMembers(const Slice& key, std::vector<std::string>* members);
 
-  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t *ttl);
+  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t * ttl_millsec);
 
   // Remove the specified members from the set stored at key. Specified members
   // that are not a member of this set are ignored. If key does not exist, it is
@@ -540,7 +540,7 @@ class Storage {
   // (the head of the list), 1 being the next element and so on.
   Status LRange(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret);
 
-  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t *ttl);
+  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t * ttl_millsec);
 
   // Removes the first count occurrences of elements equal to value from the
   // list stored at key. The count argument influences the operation in the
@@ -703,7 +703,7 @@ class Storage {
   Status ZRange(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members);
 
   Status ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members,
-                                int64_t *ttl);
+                                int64_t * ttl_millsec);
 
   // Returns all the elements in the sorted set at key with a score between min
   // and max (including elements with score equal to min or max). The elements
@@ -1122,7 +1122,7 @@ class Storage {
 
   // For scan keys in data base
   std::atomic<bool> scan_keynum_exit_ = {false};
-  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
+  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
 };
 
 }  //  namespace storage

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -957,10 +957,10 @@ class Storage {
   // While any error happens, you need to check type_status for
   // the error message
 
-  // Set a timeout on key
+  // Set a timeout on key, milliseconds unit
   // return -1 operation exception errors happen in database
   // return >=0 success
-  int32_t Expire(const Slice& key, int64_t ttl);
+  int32_t Expire(const Slice& key, int64_t ttl_millsec);
 
   // Removes the specified keys
   // return -1 operation exception errors happen in database
@@ -1005,12 +1005,12 @@ class Storage {
 
   // EXPIREAT has the same effect and semantic as EXPIRE, but instead of
   // specifying the number of seconds representing the TTL (time to live), it
-  // takes an absolute Unix timestamp (seconds since January 1, 1970). A
+  // takes an absolute Unix timestamp (milliseconds since January 1, 1970). A
   // timestamp in the past will delete the key immediately.
   // return -1 operation exception errors happen in database
   // return 0 if key does not exist
   // return >=1 if the timueout was set
-  int32_t Expireat(const Slice& key, int64_t timestamp);
+  int32_t Expireat(const Slice& key, int64_t timestamp_millsec);
 
   // Remove the existing timeout on key, turning the key from volatile (a key
   // with an expire set) to persistent (a key that will never expire as no

--- a/src/storage/src/base_data_value_format.h
+++ b/src/storage/src/base_data_value_format.h
@@ -40,7 +40,8 @@ public:
     dst += user_value_.size();
     memcpy(dst, reserve_, kSuffixReserveLength);
     dst += kSuffixReserveLength;
-    EncodeFixed64(dst, ctime_);
+    uint64_t ctime = (ctime_ |= (1LL << 63));
+    EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
     return rocksdb::Slice(start_pos, needed);
   }
@@ -58,7 +59,8 @@ public:
     if (value_->size() >= kBaseDataValueSuffixLength) {
       user_value_ = rocksdb::Slice(value_->data(), value_->size() - kBaseDataValueSuffixLength);
       memcpy(reserve_, value_->data() + user_value_.size(), kSuffixReserveLength);
-      ctime_ = DecodeFixed64(value_->data() + user_value_.size() + kSuffixReserveLength);
+      uint64_t ctime = DecodeFixed64(value_->data() + user_value_.size() + kSuffixReserveLength);
+      ctime_ = (ctime &= ~(1LL << 63));
     }
   }
 
@@ -70,7 +72,8 @@ public:
     if (value.size() >= kBaseDataValueSuffixLength) {
       user_value_ = rocksdb::Slice(value.data(), value.size() - kBaseDataValueSuffixLength);
       memcpy(reserve_, value.data() + user_value_.size(), kSuffixReserveLength);
-      ctime_ = DecodeFixed64(value.data() + user_value_.size() + kSuffixReserveLength);
+      uint64_t ctime = DecodeFixed64(value.data() + user_value_.size() + kSuffixReserveLength);
+      ctime_ = (ctime &= ~(1LL << 63));
     }
   }
 

--- a/src/storage/src/base_data_value_format.h
+++ b/src/storage/src/base_data_value_format.h
@@ -84,7 +84,7 @@ public:
   void SetCtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - kTimestampLength;
-      uint64_t ctime = (ctime_ | (1LL << 63));
+      uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
       EncodeFixed64(dst, ctime);
     }
   }

--- a/src/storage/src/base_data_value_format.h
+++ b/src/storage/src/base_data_value_format.h
@@ -40,7 +40,7 @@ public:
     dst += user_value_.size();
     memcpy(dst, reserve_, kSuffixReserveLength);
     dst += kSuffixReserveLength;
-    uint64_t ctime = (ctime_ |= (1LL << 63));
+    uint64_t ctime = (ctime_ | (1ULL << 63));
     EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
     return rocksdb::Slice(start_pos, needed);
@@ -60,7 +60,7 @@ public:
       user_value_ = rocksdb::Slice(value_->data(), value_->size() - kBaseDataValueSuffixLength);
       memcpy(reserve_, value_->data() + user_value_.size(), kSuffixReserveLength);
       uint64_t ctime = DecodeFixed64(value_->data() + user_value_.size() + kSuffixReserveLength);
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
     }
   }
 
@@ -73,7 +73,7 @@ public:
       user_value_ = rocksdb::Slice(value.data(), value.size() - kBaseDataValueSuffixLength);
       memcpy(reserve_, value.data() + user_value_.size(), kSuffixReserveLength);
       uint64_t ctime = DecodeFixed64(value.data() + user_value_.size() + kSuffixReserveLength);
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
     }
   }
 
@@ -84,7 +84,8 @@ public:
   void SetCtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - kTimestampLength;
-      EncodeFixed64(dst, ctime_);
+      uint64_t ctime = (ctime_ | (1LL << 63));
+      EncodeFixed64(dst, ctime);
     }
   }
 

--- a/src/storage/src/base_data_value_format.h
+++ b/src/storage/src/base_data_value_format.h
@@ -40,7 +40,7 @@ public:
     dst += user_value_.size();
     memcpy(dst, reserve_, kSuffixReserveLength);
     dst += kSuffixReserveLength;
-    uint64_t ctime = (ctime_ | (1ULL << 63));
+    uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
     EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
     return rocksdb::Slice(start_pos, needed);

--- a/src/storage/src/base_filter.h
+++ b/src/storage/src/base_filter.h
@@ -179,8 +179,8 @@ class BaseDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time = pstd::NowMillis();
-    if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
+    pstd::TimeType unix_time = pstd::NowMillis();
+    if (cur_meta_etime_ != 0 && cur_meta_etime_ < unix_time) {
       TRACE("Drop[Timeout]");
       return true;
     }

--- a/src/storage/src/base_filter.h
+++ b/src/storage/src/base_filter.h
@@ -28,7 +28,7 @@ class BaseMetaFilter : public rocksdb::CompactionFilter {
   BaseMetaFilter() = default;
   bool Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value, std::string* new_value,
               bool* value_changed) const override {
-    auto cur_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    auto cur_time = pstd::NowMillis();
     /*
      * For the filtering of meta information, because the field designs of string
      * and list are different, their filtering policies are written separately.
@@ -179,7 +179,7 @@ class BaseDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/base_filter.h
+++ b/src/storage/src/base_filter.h
@@ -28,9 +28,7 @@ class BaseMetaFilter : public rocksdb::CompactionFilter {
   BaseMetaFilter() = default;
   bool Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value, std::string* new_value,
               bool* value_changed) const override {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
-    auto cur_time = static_cast<uint64_t>(unix_time);
+    auto cur_time = rocksdb::Env::Default()->NowMicros() / 1000;
     /*
      * For the filtering of meta information, because the field designs of string
      * and list are different, their filtering policies are written separately.
@@ -181,8 +179,7 @@ class BaseDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -46,7 +46,7 @@ class BaseMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = pstd::NowMicros() / 1000000;
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
     if (version_ >= unix_time) {
       version_++;
     } else {
@@ -171,7 +171,7 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -140,7 +140,7 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   void SetCtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - 2 * kTimestampLength;
-      uint64_t ctime = (ctime_ | (1LL << 63));
+      uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
       EncodeFixed64(dst, ctime);
     }
   }
@@ -148,7 +148,7 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   void SetEtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - kTimestampLength;
-      uint64_t etime = (etime_ | (1LL << 63));
+      uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
       EncodeFixed64(dst, etime);
     }
   }

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -46,7 +46,7 @@ class BaseMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (version_ >= unix_time) {
       version_++;
     } else {
@@ -171,7 +171,7 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -41,10 +41,10 @@ class BaseMetaValue : public InternalValue {
     dst += sizeof(reserve_);
     // The most significant bit is 1 for milliseconds and 0 for seconds.
     // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
-    uint64_t ctime = (ctime_ |= (1LL << 63));
+    uint64_t ctime = (ctime_ | (1ULL << 63));
     EncodeFixed64(dst, ctime);
     dst += sizeof(ctime_);
-    uint64_t etime = (etime_ |= (1LL << 63));
+    uint64_t etime = (etime_ | (1ULL << 63));
     EncodeFixed64(dst, etime);
     return {start_, needed};
   }
@@ -79,12 +79,12 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
       offset += sizeof(ctime_);
       uint64_t etime = DecodeFixed64(internal_value_str->data() + offset);
 
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
       if(ctime_ == ctime) {
         ctime_ *= 1000;
       }
-      etime_ = (etime &= ~(1LL << 63));
+      etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
       if(etime == etime_) {
         etime_ *= 1000;
@@ -110,12 +110,12 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
       offset += sizeof(ctime_);
       uint64_t etime = DecodeFixed64(internal_value_slice.data() + offset);
 
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_!=ctime, means ctime_ storaged in seconds
       if(ctime_ == ctime) {
         ctime_ *= 1000;
       }
-      etime_ = (etime &= ~(1LL << 63));
+      etime_ = (etime & ~(1ULL << 63));
       // if etime_!=etime, means etime_ storaged in seconds
       if(etime == etime_) {
         etime_ *= 1000;
@@ -140,14 +140,16 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   void SetCtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - 2 * kTimestampLength;
-      EncodeFixed64(dst, ctime_);
+      uint64_t ctime = (ctime_ | (1LL << 63));
+      EncodeFixed64(dst, ctime);
     }
   }
 
   void SetEtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - kTimestampLength;
-      EncodeFixed64(dst, etime_);
+      uint64_t etime = (etime_ | (1LL << 63));
+      EncodeFixed64(dst, etime);
     }
   }
 

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -50,11 +50,11 @@ class BaseMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     if (version_ >= unix_time) {
       version_++;
     } else {
-      version_ = uint64_t(unix_time);
+      version_ = unix_time;
     }
     return version_;
   }
@@ -199,11 +199,11 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = pstd::NowMillis();
-    if (version_ >= static_cast<uint64_t>(unix_time)) {
+    pstd::TimeType unix_time = pstd::NowMillis();
+    if (version_ >= unix_time) {
       version_++;
     } else {
-      version_ = static_cast<uint64_t>(unix_time);
+      version_ = unix_time;
     }
     SetVersionToValue();
     return version_;

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -39,9 +39,13 @@ class BaseMetaValue : public InternalValue {
     dst += sizeof(version_);
     memcpy(dst, reserve_, sizeof(reserve_));
     dst += sizeof(reserve_);
-    EncodeFixed64(dst, ctime_);
+    // The most significant bit is 1 for milliseconds and 0 for seconds.
+    // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
+    uint64_t ctime = (ctime_ |= (1LL << 63));
+    EncodeFixed64(dst, ctime);
     dst += sizeof(ctime_);
-    EncodeFixed64(dst, etime_);
+    uint64_t etime = (etime_ |= (1LL << 63));
+    EncodeFixed64(dst, etime);
     return {start_, needed};
   }
 
@@ -71,9 +75,20 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
       offset += sizeof(version_);
       memcpy(reserve_, internal_value_str->data() + offset, sizeof(reserve_));
       offset += sizeof(reserve_);
-      ctime_ = DecodeFixed64(internal_value_str->data() + offset);
+      uint64_t ctime = DecodeFixed64(internal_value_str->data() + offset);
       offset += sizeof(ctime_);
-      etime_ = DecodeFixed64(internal_value_str->data() + offset);
+      uint64_t etime = DecodeFixed64(internal_value_str->data() + offset);
+
+      ctime_ = (ctime &= ~(1LL << 63));
+      // if ctime_==ctime, means ctime_ storaged in seconds
+      if(ctime_ == ctime) {
+        ctime_ *= 1000;
+      }
+      etime_ = (etime &= ~(1LL << 63));
+      // if etime_==etime, means etime_ storaged in seconds
+      if(etime == etime_) {
+        etime_ *= 1000;
+      }
     }
     count_ = DecodeFixed32(internal_value_str->data() + kTypeLength);
   }
@@ -91,9 +106,20 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
       offset += sizeof(uint64_t);
       memcpy(reserve_, internal_value_slice.data() + offset, sizeof(reserve_));
       offset += sizeof(reserve_);
-      ctime_ = DecodeFixed64(internal_value_slice.data() + offset);
+      uint64_t ctime = DecodeFixed64(internal_value_slice.data() + offset);
       offset += sizeof(ctime_);
-      etime_ = DecodeFixed64(internal_value_slice.data() + offset);
+      uint64_t etime = DecodeFixed64(internal_value_slice.data() + offset);
+
+      ctime_ = (ctime &= ~(1LL << 63));
+      // if ctime_!=ctime, means ctime_ storaged in seconds
+      if(ctime_ == ctime) {
+        ctime_ *= 1000;
+      }
+      etime_ = (etime &= ~(1LL << 63));
+      // if etime_!=etime, means etime_ storaged in seconds
+      if(etime == etime_) {
+        etime_ *= 1000;
+      }
     }
     count_ = DecodeFixed32(internal_value_slice.data() + kTypeLength);
   }

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -81,12 +81,12 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
 
       ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
-      if(ctime_ == ctime) {
+      if (ctime_ == ctime) {
         ctime_ *= 1000;
       }
       etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
-      if(etime == etime_) {
+      if (etime == etime_) {
         etime_ *= 1000;
       }
     }
@@ -112,12 +112,12 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
 
       ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_!=ctime, means ctime_ storaged in seconds
-      if(ctime_ == ctime) {
+      if (ctime_ == ctime) {
         ctime_ *= 1000;
       }
       etime_ = (etime & ~(1ULL << 63));
       // if etime_!=etime, means etime_ storaged in seconds
-      if(etime == etime_) {
+      if (etime == etime_) {
         etime_ *= 1000;
       }
     }

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -46,7 +46,7 @@ class BaseMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     if (version_ >= unix_time) {
       version_++;
     } else {
@@ -171,7 +171,7 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -171,8 +171,7 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -41,10 +41,10 @@ class BaseMetaValue : public InternalValue {
     dst += sizeof(reserve_);
     // The most significant bit is 1 for milliseconds and 0 for seconds.
     // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
-    uint64_t ctime = (ctime_ | (1ULL << 63));
+    uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
     EncodeFixed64(dst, ctime);
     dst += sizeof(ctime_);
-    uint64_t etime = (etime_ | (1ULL << 63));
+    uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
     EncodeFixed64(dst, etime);
     return {start_, needed};
   }

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -52,8 +52,8 @@ public:
   void SetEtime(uint64_t etime = 0) { etime_ = etime; }
   void setCtime(uint64_t ctime) { ctime_ = ctime; }
   rocksdb::Status SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time = pstd::NowMillis();
-    etime_ = uint64_t(unix_time) + ttl * 1000;
+    pstd::TimeType unix_time = pstd::NowMillis();
+    etime_ = unix_time + ttl * 1000;
     return rocksdb::Status::OK();
   }
   void SetVersion(uint64_t version = 0) { version_ = version; }
@@ -122,7 +122,7 @@ public:
   }
 
   void SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     etime_ = unix_time + ttl * 1000;
     SetEtimeToValue();
   }
@@ -133,7 +133,7 @@ public:
     if (etime_ == 0) {
       return false;
     }
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     return etime_ < unix_time;
   }
 

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -41,7 +41,7 @@ constexpr char DataTypeToTag(DataType type) {
 class InternalValue {
 public:
  explicit InternalValue(DataType type, const rocksdb::Slice& user_value) : type_(type), user_value_(user_value) {
-   ctime_ = pstd::NowMicros() / 1e6;
+   ctime_ = pstd::NowMillis();
  }
 
  virtual ~InternalValue() {
@@ -52,7 +52,7 @@ public:
   void SetEtime(uint64_t etime = 0) { etime_ = etime; }
   void setCtime(uint64_t ctime) { ctime_ = ctime; }
   rocksdb::Status SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     etime_ = uint64_t(unix_time) + ttl * 1000;
     return rocksdb::Status::OK();
   }
@@ -122,7 +122,7 @@ public:
   }
 
   void SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     etime_ = unix_time + ttl * 1000;
     SetEtimeToValue();
   }
@@ -133,7 +133,7 @@ public:
     if (etime_ == 0) {
       return false;
     }
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     return etime_ < unix_time;
   }
 

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -121,9 +121,9 @@ public:
     SetCtimeToValue();
   }
 
-  void SetRelativeTimestamp(int64_t ttl) {
+  void SetRelativeTimestamp(int64_t ttl_millsec) {
     pstd::TimeType unix_time = pstd::NowMillis();
-    etime_ = unix_time + ttl * 1000;
+    etime_ = unix_time + ttl_millsec;
     SetEtimeToValue();
   }
 

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -52,9 +52,8 @@ public:
   void SetEtime(uint64_t etime = 0) { etime_ = etime; }
   void setCtime(uint64_t ctime) { ctime_ = ctime; }
   rocksdb::Status SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
-    etime_ = uint64_t(unix_time + ttl);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    etime_ = uint64_t(unix_time) + ttl * 1000;
     return rocksdb::Status::OK();
   }
   void SetVersion(uint64_t version = 0) { version_ = version; }
@@ -123,9 +122,8 @@ public:
   }
 
   void SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
-    etime_ = unix_time + ttl;
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    etime_ = unix_time + ttl * 1000;
     SetEtimeToValue();
   }
 
@@ -135,8 +133,7 @@ public:
     if (etime_ == 0) {
       return false;
     }
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     return etime_ < unix_time;
   }
 

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -51,9 +51,9 @@ public:
   }
   void SetEtime(uint64_t etime = 0) { etime_ = etime; }
   void setCtime(uint64_t ctime) { ctime_ = ctime; }
-  rocksdb::Status SetRelativeTimestamp(int64_t ttl) {
+  rocksdb::Status SetRelativeTimeByMillsec(int64_t ttl_millsec) {
     pstd::TimeType unix_time = pstd::NowMillis();
-    etime_ = unix_time + ttl * 1000;
+    etime_ = unix_time + ttl_millsec;
     return rocksdb::Status::OK();
   }
   void SetVersion(uint64_t version = 0) { version_ = version; }

--- a/src/storage/src/lists_filter.h
+++ b/src/storage/src/lists_filter.h
@@ -88,7 +88,7 @@ class ListsDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/lists_filter.h
+++ b/src/storage/src/lists_filter.h
@@ -88,8 +88,7 @@ class ListsDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/lists_filter.h
+++ b/src/storage/src/lists_filter.h
@@ -88,7 +88,7 @@ class ListsDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -51,7 +51,7 @@ class ListsMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {
@@ -197,7 +197,7 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -51,7 +51,7 @@ class ListsMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {
@@ -197,7 +197,7 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -55,7 +55,7 @@ class ListsMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {
@@ -225,7 +225,7 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -46,10 +46,10 @@ class ListsMetaValue : public InternalValue {
     dst += kSuffixReserveLength;
     // The most significant bit is 1 for milliseconds and 0 for seconds.
     // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
-    uint64_t ctime = (ctime_ | (1ULL << 63));
+    uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
     EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
-    uint64_t etime = (etime_ | (1ULL << 63));
+    uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
     EncodeFixed64(dst, etime);
     return {start_, needed};
   }

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -46,10 +46,10 @@ class ListsMetaValue : public InternalValue {
     dst += kSuffixReserveLength;
     // The most significant bit is 1 for milliseconds and 0 for seconds.
     // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
-    uint64_t ctime = (ctime_ |= (1LL << 63));
+    uint64_t ctime = (ctime_ | (1ULL << 63));
     EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
-    uint64_t etime = (etime_ |= (1LL << 63));
+    uint64_t etime = (etime_ | (1ULL << 63));
     EncodeFixed64(dst, etime);
     return {start_, needed};
   }
@@ -103,12 +103,12 @@ class ParsedListsMetaValue : public ParsedInternalValue {
       uint64_t etime = DecodeFixed64(internal_value_str->data() + offset);
       offset += kTimestampLength;
 
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
       if(ctime_ == ctime) {
         ctime_ *= 1000;
       }
-      etime_ = (etime &= ~(1LL << 63));
+      etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
       if(etime == etime_) {
         etime_ *= 1000;
@@ -141,12 +141,12 @@ class ParsedListsMetaValue : public ParsedInternalValue {
       uint64_t etime = DecodeFixed64(internal_value_slice.data() + offset);
       offset += kTimestampLength;
 
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
       if(ctime_ == ctime) {
         ctime_ *= 1000;
       }
-      etime_ = (etime &= ~(1LL << 63));
+      etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
       if(etime == etime_) {
         etime_ *= 1000;
@@ -171,14 +171,16 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   void SetCtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - 2 * kTimestampLength;
-      EncodeFixed64(dst, ctime_);
+      uint64_t ctime = (ctime_ | (1LL << 63));
+      EncodeFixed64(dst, ctime);
     }
   }
 
   void SetEtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - kTimestampLength;
-      EncodeFixed64(dst, etime_);
+      uint64_t etime = (etime_ | (1LL << 63));
+      EncodeFixed64(dst, etime);
     }
   }
 

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -51,8 +51,7 @@ class ListsMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {
@@ -198,8 +197,7 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -105,12 +105,12 @@ class ParsedListsMetaValue : public ParsedInternalValue {
 
       ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
-      if(ctime_ == ctime) {
+      if (ctime_ == ctime) {
         ctime_ *= 1000;
       }
       etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
-      if(etime == etime_) {
+      if (etime == etime_) {
         etime_ *= 1000;
       }
     }
@@ -143,12 +143,12 @@ class ParsedListsMetaValue : public ParsedInternalValue {
 
       ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
-      if(ctime_ == ctime) {
+      if (ctime_ == ctime) {
         ctime_ *= 1000;
       }
       etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
-      if(etime == etime_) {
+      if (etime == etime_) {
         etime_ *= 1000;
       }
     }

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -171,7 +171,7 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   void SetCtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - 2 * kTimestampLength;
-      uint64_t ctime = (ctime_ | (1LL << 63));
+      uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
       EncodeFixed64(dst, ctime);
     }
   }
@@ -179,7 +179,7 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   void SetEtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - kTimestampLength;
-      uint64_t etime = (etime_ | (1LL << 63));
+      uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
       EncodeFixed64(dst, etime);
     }
   }

--- a/src/storage/src/lists_meta_value_format.h
+++ b/src/storage/src/lists_meta_value_format.h
@@ -51,7 +51,7 @@ class ListsMetaValue : public InternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {
@@ -197,7 +197,7 @@ class ParsedListsMetaValue : public ParsedInternalValue {
   }
 
   uint64_t UpdateVersion() {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros();
     if (version_ >= static_cast<uint64_t>(unix_time)) {
       version_++;
     } else {

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -189,7 +189,7 @@ class Redis {
   Status Expireat(const Slice& key, int64_t timestamp_millsec);
   Status Persist(const Slice& key);
   Status TTL(const Slice& key, int64_t* ttl_millsec);
-  Status PKPatternMatchDelWithRemoveKeys(const std::string& pattern, int32_t* ret);
+  Status PKPatternMatchDelWithRemoveKeys(const std::string& pattern, int64_t* ret, std::vector<std::string>* remove_keys, const int64_t& max_count);
 
   Status GetType(const Slice& key, enum DataType& type);
   Status IsExist(const Slice& key);

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -117,11 +117,11 @@ class Redis {
   Status ScanStreamsKeyNum(KeyInfo* key_info);
 
   // Keys Commands
-  virtual Status StringsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status HashesExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status ZsetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status SetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
+  virtual Status StringsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status HashesExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ListsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ZsetsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status SetsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
 
   virtual Status StringsDel(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status HashesDel(const Slice& key, std::string&& prefetch_meta = {});
@@ -130,11 +130,11 @@ class Redis {
   virtual Status SetsDel(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status StreamsDel(const Slice& key, std::string&& prefetch_meta = {});
 
-  virtual Status StringsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status HashesExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status ListsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status SetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status ZsetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
+  virtual Status StringsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status HashesExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status ListsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status SetsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status ZsetsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
 
   virtual Status StringsPersist(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status HashesPersist(const Slice& key, std::string&& prefetch_meta = {});
@@ -185,8 +185,8 @@ class Redis {
 
   Status Exists(const Slice& key);
   Status Del(const Slice& key);
-  Status Expire(const Slice& key, int64_t timestamp);
-  Status Expireat(const Slice& key, int64_t timestamp);
+  Status Expire(const Slice& key, int64_t ttl_millsec);
+  Status Expireat(const Slice& key, int64_t timestamp_millsec);
   Status Persist(const Slice& key);
   Status TTL(const Slice& key, int64_t* timestamp);
   Status PKPatternMatchDel(const std::string& pattern, int32_t* ret);

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -142,11 +142,11 @@ class Redis {
   virtual Status ZsetsPersist(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status SetsPersist(const Slice& key, std::string&& prefetch_meta = {});
 
-  virtual Status StringsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status HashesTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status ZsetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status SetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
+  virtual Status StringsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status HashesTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ListsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ZsetsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status SetsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
 
   // Strings Commands
   Status Append(const Slice& key, const Slice& value, int32_t* ret);
@@ -156,12 +156,12 @@ class Redis {
   Status Get(const Slice& key, std::string* value);
   Status HyperloglogGet(const Slice& key, std::string* value);
   Status MGet(const Slice& key, std::string* value);
-  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
-  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
+  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
+  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
   Status GetBit(const Slice& key, int64_t offset, int32_t* ret);
   Status Getrange(const Slice& key, int64_t start_offset, int64_t end_offset, std::string* ret);
   Status GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
-                           std::string* ret, std::string* value, int64_t* ttl);
+                           std::string* ret, std::string* value, int64_t* ttl_millsec);
   Status GetSet(const Slice& key, const Slice& value, std::string* old_value);
   Status Incrby(const Slice& key, int64_t value, int64_t* ret);
   Status Incrbyfloat(const Slice& key, const Slice& value, std::string* ret);
@@ -169,11 +169,11 @@ class Redis {
   Status MSetnx(const std::vector<KeyValue>& kvs, int32_t* ret);
   Status Set(const Slice& key, const Slice& value);
   Status HyperloglogSet(const Slice& key, const Slice& value);
-  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
+  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
   Status SetBit(const Slice& key, int64_t offset, int32_t value, int32_t* ret);
-  Status Setex(const Slice& key, const Slice& value, int64_t ttl);
-  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
-  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl = 0);
+  Status Setex(const Slice& key, const Slice& value, int64_t ttl_millsec);
+  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
+  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl_millsec = 0);
   Status Delvx(const Slice& key, const Slice& value, int32_t* ret);
   Status Setrange(const Slice& key, int64_t start_offset, const Slice& value, int32_t* ret);
   Status Strlen(const Slice& key, int32_t* len);
@@ -181,14 +181,14 @@ class Redis {
   Status BitPos(const Slice& key, int32_t bit, int64_t* ret);
   Status BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_t* ret);
   Status BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_t end_offset, int64_t* ret);
-  Status PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp);
+  Status PKSetexAt(const Slice& key, const Slice& value, int64_t time_stamp_millsec_);
 
   Status Exists(const Slice& key);
   Status Del(const Slice& key);
   Status Expire(const Slice& key, int64_t ttl_millsec);
   Status Expireat(const Slice& key, int64_t timestamp_millsec);
   Status Persist(const Slice& key);
-  Status TTL(const Slice& key, int64_t* timestamp);
+  Status TTL(const Slice& key, int64_t* ttl_millsec);
   Status PKPatternMatchDel(const std::string& pattern, int32_t* ret);
 
   Status GetType(const Slice& key, enum DataType& type);
@@ -198,7 +198,7 @@ class Redis {
   Status HExists(const Slice& key, const Slice& field);
   Status HGet(const Slice& key, const Slice& field, std::string* value);
   Status HGetall(const Slice& key, std::vector<FieldValue>* fvs);
-  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl);
+  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl_millsec);
   Status HIncrby(const Slice& key, const Slice& field, int64_t value, int64_t* ret);
   Status HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by, std::string* new_value);
   Status HKeys(const Slice& key, std::vector<std::string>* fields);
@@ -255,7 +255,7 @@ class Redis {
   Status SInterstore(const Slice& destination, const std::vector<std::string>& keys, std::vector<std::string>& value_to_dest, int32_t* ret);
   Status SIsmember(const Slice& key, const Slice& member, int32_t* ret);
   Status SMembers(const Slice& key, std::vector<std::string>* members);
-  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t* ttl);
+  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t* ttl_millsec);
   Status SMove(const Slice& source, const Slice& destination, const Slice& member, int32_t* ret);
   Status SPop(const Slice& key, std::vector<std::string>* members, int64_t cnt);
   Status SRandmember(const Slice& key, int32_t count, std::vector<std::string>* members);
@@ -276,7 +276,7 @@ class Redis {
   Status LPush(const Slice& key, const std::vector<std::string>& values, uint64_t* ret);
   Status LPushx(const Slice& key, const std::vector<std::string>& values, uint64_t* len);
   Status LRange(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret);
-  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t* ttl);
+  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t* ttl_millsec);
   Status LRem(const Slice& key, int64_t count, const Slice& value, uint64_t* ret);
   Status LSet(const Slice& key, int64_t index, const Slice& value);
   Status LTrim(const Slice& key, int64_t start, int64_t stop);
@@ -291,7 +291,7 @@ class Redis {
   Status ZCount(const Slice& key, double min, double max, bool left_close, bool right_close, int32_t* ret);
   Status ZIncrby(const Slice& key, const Slice& member, double increment, double* ret);
   Status ZRange(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members);
-  Status ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members, int64_t* ttl);
+  Status ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members, int64_t* ttl_millsec);
   Status ZRangebyscore(const Slice& key, double min, double max, bool left_close, bool right_close, int64_t count,
                        int64_t offset, std::vector<ScoreMember>* score_members);
   Status ZRank(const Slice& key, const Slice& member, int32_t* rank);

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -1119,7 +1119,7 @@ Status Redis::PKHRScanRange(const Slice& key, const Slice& field_start, const st
       return Status::NotFound();
     } else {
       uint64_t version = parsed_hashes_meta_value.Version();
-      int32_t start_key_version = start_no_limit ? version + 1 : version;
+      uint64_t start_key_version = start_no_limit ? version + 1 : version;
       std::string start_key_field = start_no_limit ? "" : field_start.ToString();
       HashesDataKey hashes_data_prefix(key, version, Slice());
       HashesDataKey hashes_start_data_key(key, start_key_version, start_key_field);

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -31,7 +31,7 @@ Status Redis::ScanHashesKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -252,7 +252,7 @@ Status Redis::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1343,7 +1343,7 @@ Status Redis::HashesTTL(const Slice& key, int64_t* timestamp, std::string&& pref
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -31,7 +31,7 @@ Status Redis::ScanHashesKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = pstd::NowMillis();
+  pstd::TimeType curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -252,7 +252,7 @@ Status Redis::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1343,7 +1343,7 @@ Status Redis::HashesTTL(const Slice& key, int64_t* timestamp, std::string&& pref
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -115,7 +115,7 @@ Status Redis::HDel(const Slice& key, const std::vector<std::string>& fields, int
         }
       }
       *ret = del_cnt;
-      if (!parsed_hashes_meta_value.CheckModifyCount(-del_cnt)){
+      if (!parsed_hashes_meta_value.CheckModifyCount(-del_cnt)) {
         return Status::InvalidArgument("hash size overflow");
       }
       parsed_hashes_meta_value.ModifyCount(-del_cnt);
@@ -329,7 +329,7 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
         statistic++;
       } else if (s.IsNotFound()) {
         Int64ToStr(value_buf, 32, value);
-        if (!parsed_hashes_meta_value.CheckModifyCount(1)){
+        if (!parsed_hashes_meta_value.CheckModifyCount(1)) {
           return Status::InvalidArgument("hash size overflow");
         }
         BaseDataValue internal_value(value_buf);
@@ -423,7 +423,7 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
         statistic++;
       } else if (s.IsNotFound()) {
         LongDoubleToStr(long_double_by, new_value);
-        if (!parsed_hashes_meta_value.CheckModifyCount(1)){
+        if (!parsed_hashes_meta_value.CheckModifyCount(1)) {
           return Status::InvalidArgument("hash size overflow");
         }
         parsed_hashes_meta_value.ModifyCount(1);
@@ -651,7 +651,7 @@ Status Redis::HMSet(const Slice& key, const std::vector<FieldValue>& fvs) {
           return s;
         }
       }
-      if (!parsed_hashes_meta_value.CheckModifyCount(count)){
+      if (!parsed_hashes_meta_value.CheckModifyCount(count)) {
         return Status::InvalidArgument("hash size overflow");
       }
       parsed_hashes_meta_value.ModifyCount(count);
@@ -719,7 +719,7 @@ Status Redis::HSet(const Slice& key, const Slice& field, const Slice& value, int
           statistic++;
         }
       } else if (s.IsNotFound()) {
-        if (!parsed_hashes_meta_value.CheckModifyCount(1)){
+        if (!parsed_hashes_meta_value.CheckModifyCount(1)) {
           return Status::InvalidArgument("hash size overflow");
         }
         parsed_hashes_meta_value.ModifyCount(1);
@@ -786,7 +786,7 @@ Status Redis::HSetnx(const Slice& key, const Slice& field, const Slice& value, i
       if (s.ok()) {
         *ret = 0;
       } else if (s.IsNotFound()) {
-        if (!parsed_hashes_meta_value.CheckModifyCount(1)){
+        if (!parsed_hashes_meta_value.CheckModifyCount(1)) {
           return Status::InvalidArgument("hash size overflow");
         }
         parsed_hashes_meta_value.ModifyCount(1);

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -1154,7 +1154,7 @@ Status Redis::PKHRScanRange(const Slice& key, const Slice& field_start, const st
   return Status::OK();
 }
 
-Status Redis::HashesExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+Status Redis::HashesExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1183,8 +1183,8 @@ Status Redis::HashesExpire(const Slice& key, int64_t ttl, std::string&& prefetch
       return Status::NotFound();
     }
 
-    if (ttl > 0) {
-      parsed_hashes_meta_value.SetRelativeTimestamp(ttl);
+    if (ttl_millsec > 0) {
+      parsed_hashes_meta_value.SetRelativeTimestamp(ttl_millsec);
       s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     } else {
       parsed_hashes_meta_value.InitialMetaValue();
@@ -1231,7 +1231,7 @@ Status Redis::HashesDel(const Slice& key, std::string&& prefetch_meta) {
   return s;
 }
 
-Status Redis::HashesExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+Status Redis::HashesExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1259,8 +1259,8 @@ Status Redis::HashesExpireat(const Slice& key, int64_t timestamp, std::string&& 
     } else if (parsed_hashes_meta_value.Count() == 0) {
       return Status::NotFound();
     } else {
-      if (timestamp > 0) {
-        parsed_hashes_meta_value.SetEtime(static_cast<uint64_t>(timestamp));
+      if (timestamp_millsec > 0) {
+        parsed_hashes_meta_value.SetEtime(static_cast<uint64_t>(timestamp_millsec));
       } else {
         parsed_hashes_meta_value.InitialMetaValue();
       }

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -31,8 +31,7 @@ Status Redis::ScanHashesKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
+  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -253,8 +252,7 @@ Status Redis::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1345,8 +1343,7 @@ Status Redis::HashesTTL(const Slice& key, int64_t* timestamp, std::string&& pref
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -30,8 +30,7 @@ Status Redis::ScanListsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
+  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -503,8 +502,7 @@ Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1287,8 +1285,7 @@ Status Redis::ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefe
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -30,7 +30,7 @@ Status Redis::ScanListsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -502,7 +502,7 @@ Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1285,7 +1285,7 @@ Status Redis::ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefe
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -1095,7 +1095,7 @@ Status Redis::RPushx(const Slice& key, const std::vector<std::string>& values, u
   return s;
 }
 
-Status Redis::ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+Status Redis::ListsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1124,8 +1124,8 @@ Status Redis::ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_
       return Status::NotFound();
     }
 
-    if (ttl > 0) {
-      parsed_lists_meta_value.SetRelativeTimestamp(ttl);
+    if (ttl_millsec > 0) {
+      parsed_lists_meta_value.SetRelativeTimestamp(ttl_millsec);
       s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     } else {
       parsed_lists_meta_value.InitialMetaValue();
@@ -1172,7 +1172,7 @@ Status Redis::ListsDel(const Slice& key, std::string&& prefetch_meta) {
   return s;
 }
 
-Status Redis::ListsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+Status Redis::ListsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1200,8 +1200,8 @@ Status Redis::ListsExpireat(const Slice& key, int64_t timestamp, std::string&& p
     } else if (parsed_lists_meta_value.Count() == 0) {
       return Status::NotFound();
     } else {
-      if (timestamp > 0) {
-        parsed_lists_meta_value.SetEtime(static_cast<uint64_t>(timestamp));
+      if (timestamp_millsec > 0) {
+        parsed_lists_meta_value.SetEtime(static_cast<uint64_t>(timestamp_millsec));
       } else {
         parsed_lists_meta_value.InitialMetaValue();
       }

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -30,7 +30,7 @@ Status Redis::ScanListsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = pstd::NowMillis();
+  pstd::TimeType curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -502,7 +502,7 @@ Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1285,7 +1285,7 @@ Status Redis::ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefe
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -123,7 +123,7 @@ rocksdb::Status Redis::SAdd(const Slice& key, const std::vector<std::string>& me
       if (cnt == 0) {
         return rocksdb::Status::OK();
       } else {
-        if (!parsed_sets_meta_value.CheckModifyCount(cnt)){
+        if (!parsed_sets_meta_value.CheckModifyCount(cnt)) {
           return Status::InvalidArgument("set size overflow");
         }
         parsed_sets_meta_value.ModifyCount(cnt);
@@ -836,7 +836,7 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
       s = db_->Get(default_read_options_, handles_[kSetsDataCF], sets_member_key.Encode(), &member_value);
       if (s.ok()) {
         *ret = 1;
-        if (!parsed_sets_meta_value.CheckModifyCount(-1)){
+        if (!parsed_sets_meta_value.CheckModifyCount(-1)) {
           return Status::InvalidArgument("set size overflow");
         }
         parsed_sets_meta_value.ModifyCount(-1);
@@ -884,7 +884,7 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
       SetsMemberKey sets_member_key(destination, version, member);
       s = db_->Get(default_read_options_, handles_[kSetsDataCF], sets_member_key.Encode(), &member_value);
       if (s.IsNotFound()) {
-        if (!parsed_sets_meta_value.CheckModifyCount(1)){
+        if (!parsed_sets_meta_value.CheckModifyCount(1)) {
           return Status::InvalidArgument("set size overflow");
         }
         parsed_sets_meta_value.ModifyCount(1);
@@ -996,7 +996,7 @@ rocksdb::Status Redis::SPop(const Slice& key, std::vector<std::string>* members,
           }
         }
 
-        if (!parsed_sets_meta_value.CheckModifyCount(static_cast<int32_t>(-cnt))){
+        if (!parsed_sets_meta_value.CheckModifyCount(static_cast<int32_t>(-cnt))) {
           return Status::InvalidArgument("set size overflow");
         }
         parsed_sets_meta_value.ModifyCount(static_cast<int32_t>(-cnt));
@@ -1145,7 +1145,7 @@ rocksdb::Status Redis::SRem(const Slice& key, const std::vector<std::string>& me
         }
       }
       *ret = cnt;
-      if (!parsed_sets_meta_value.CheckModifyCount(-cnt)){
+      if (!parsed_sets_meta_value.CheckModifyCount(-cnt)) {
         return Status::InvalidArgument("set size overflow");
       }
       parsed_sets_meta_value.ModifyCount(-cnt);

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -34,8 +34,7 @@ rocksdb::Status Redis::ScanSetsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
+  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -775,8 +774,7 @@ Status Redis::SMembersWithTTL(const Slice& key,
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1596,8 +1594,7 @@ rocksdb::Status Redis::SetsTTL(const Slice& key, int64_t* timestamp, std::string
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -34,7 +34,7 @@ rocksdb::Status Redis::ScanSetsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = pstd::NowMillis();
+  pstd::TimeType curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -774,7 +774,7 @@ Status Redis::SMembersWithTTL(const Slice& key,
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1592,7 +1592,7 @@ rocksdb::Status Redis::SetsTTL(const Slice& key, int64_t* timestamp, std::string
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -1403,7 +1403,7 @@ rocksdb::Status Redis::SScan(const Slice& key, int64_t cursor, const std::string
   return rocksdb::Status::OK();
 }
 
-rocksdb::Status Redis::SetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+rocksdb::Status Redis::SetsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1432,8 +1432,8 @@ rocksdb::Status Redis::SetsExpire(const Slice& key, int64_t ttl, std::string&& p
       return rocksdb::Status::NotFound();
     }
 
-    if (ttl > 0) {
-      parsed_sets_meta_value.SetRelativeTimestamp(ttl);
+    if (ttl_millsec > 0) {
+      parsed_sets_meta_value.SetRelativeTimestamp(ttl_millsec);
       s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     } else {
       parsed_sets_meta_value.InitialMetaValue();
@@ -1480,7 +1480,7 @@ rocksdb::Status Redis::SetsDel(const Slice& key, std::string&& prefetch_meta) {
   return s;
 }
 
-rocksdb::Status Redis::SetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+rocksdb::Status Redis::SetsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1508,8 +1508,8 @@ rocksdb::Status Redis::SetsExpireat(const Slice& key, int64_t timestamp, std::st
     } else if (parsed_sets_meta_value.Count() == 0) {
       return rocksdb::Status::NotFound();
     } else {
-      if (timestamp > 0) {
-        parsed_sets_meta_value.SetEtime(static_cast<uint64_t>(timestamp));
+      if (timestamp_millsec > 0) {
+        parsed_sets_meta_value.SetEtime(static_cast<uint64_t>(timestamp_millsec));
       } else {
         parsed_sets_meta_value.InitialMetaValue();
       }

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -34,7 +34,7 @@ rocksdb::Status Redis::ScanSetsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -774,7 +774,7 @@ Status Redis::SMembersWithTTL(const Slice& key,
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -918,8 +918,6 @@ rocksdb::Status Redis::SPop(const Slice& key, std::vector<std::string>* members,
   std::string meta_value;
   rocksdb::WriteBatch batch;
   ScopeRecordLock l(lock_mgr_, key);
-
-  uint64_t start_us = pstd::NowMicros();
 
   BaseMetaKey base_meta_key(key);
   Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
@@ -1594,7 +1592,7 @@ rocksdb::Status Redis::SetsTTL(const Slice& key, int64_t* timestamp, std::string
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_streams.cc
+++ b/src/storage/src/redis_streams.cc
@@ -338,9 +338,6 @@ Status Redis::ScanStreamsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
-
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     if (!ExpectedMetaValue(DataType::kStreams, iter->value().ToString())) {

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -33,7 +33,7 @@ Status Redis::ScanStringsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t curtime = pstd::NowMillis();
 
   // Note: This is a string type and does not need to pass the column family as
   // a parameter, use the default column family
@@ -377,7 +377,7 @@ void ClearValueAndSetTTL(std::string* value, int64_t* ttl, int64_t ttl_value) {
 }
 
 int64_t CalculateTTL(int64_t expiry_time) {
-  int64_t current_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t current_time = pstd::NowMillis();
   return expiry_time - current_time >= 0 ? expiry_time - current_time : -2;
 }
 
@@ -553,7 +553,7 @@ Status Redis::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t 
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1466,7 +1466,7 @@ Status Redis::StringsTTL(const Slice& key, int64_t* timestamp, std::string&& pre
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -33,7 +33,7 @@ Status Redis::ScanStringsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = pstd::NowMillis();
+  pstd::TimeType curtime = pstd::NowMillis();
 
   // Note: This is a string type and does not need to pass the column family as
   // a parameter, use the default column family
@@ -377,7 +377,7 @@ void ClearValueAndSetTTL(std::string* value, int64_t* ttl, int64_t ttl_value) {
 }
 
 int64_t CalculateTTL(int64_t expiry_time) {
-  int64_t current_time = pstd::NowMillis();
+  pstd::TimeType current_time = pstd::NowMillis();
   return expiry_time - current_time >= 0 ? expiry_time - current_time : -2;
 }
 
@@ -553,7 +553,7 @@ Status Redis::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t 
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1468,7 +1468,7 @@ Status Redis::StringsTTL(const Slice& key, int64_t* timestamp, std::string&& pre
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1286,7 +1286,9 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_
 //TODO(wangshaoyi): timestamp uint64_t
 Status Redis::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
   StringsValue strings_value(value);
-
+  if(timestamp < 0) {
+    timestamp = pstd::NowMillis()-1;
+  }
   BaseKey base_key(key);
   ScopeRecordLock l(lock_mgr_, key);
   strings_value.SetEtime(uint64_t(timestamp));

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1286,7 +1286,7 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_
 //TODO(wangshaoyi): timestamp uint64_t
 Status Redis::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
   StringsValue strings_value(value);
-  if(timestamp < 0) {
+  if (timestamp < 0) {
     timestamp = pstd::NowMillis() - 1;
   }
   BaseKey base_key(key);

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1287,7 +1287,7 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_
 Status Redis::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
   StringsValue strings_value(value);
   if(timestamp < 0) {
-    timestamp = pstd::NowMillis()-1;
+    timestamp = pstd::NowMillis() - 1;
   }
   BaseKey base_key(key);
   ScopeRecordLock l(lock_mgr_, key);

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -381,19 +381,19 @@ int64_t CalculateTTL(int64_t expiry_time) {
   return expiry_time - current_time >= 0 ? expiry_time - current_time : -2;
 }
 
-Status HandleParsedStringsValue(ParsedStringsValue& parsed_strings_value, std::string* value, int64_t* ttl) {
+Status HandleParsedStringsValue(ParsedStringsValue& parsed_strings_value, std::string* value, int64_t* ttl_millsec) {
   if (parsed_strings_value.IsStale()) {
-    ClearValueAndSetTTL(value, ttl, -2);
+    ClearValueAndSetTTL(value, ttl_millsec, -2);
     return Status::NotFound("Stale");
   } else {
     parsed_strings_value.StripSuffix();
     int64_t expiry_time = parsed_strings_value.Etime();
-    *ttl = (expiry_time == 0) ? -1 : CalculateTTL(expiry_time);
+    *ttl_millsec = (expiry_time == 0) ? -1 : CalculateTTL(expiry_time);
   }
   return Status::OK();
 }
 
-Status Redis::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
+Status Redis::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec) {
   value->clear();
   BaseKey base_key(key);
   Status s = db_->Get(default_read_options_, base_key.Encode(), value);
@@ -412,15 +412,15 @@ Status Redis::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
 
   if (s.ok()) {
     ParsedStringsValue parsed_strings_value(value);
-    return HandleParsedStringsValue(parsed_strings_value, value, ttl);
+    return HandleParsedStringsValue(parsed_strings_value, value, ttl_millsec);
   } else if (s.IsNotFound()) {
-    ClearValueAndSetTTL(value, ttl, -2);
+    ClearValueAndSetTTL(value, ttl_millsec, -2);
   }
 
   return s;
 }
 
-Status Redis::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
+Status Redis::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec) {
   value->clear();
   BaseKey base_key(key);
   Status s = db_->Get(default_read_options_, base_key.Encode(), value);
@@ -432,9 +432,9 @@ Status Redis::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
 
   if (s.ok()) {
     ParsedStringsValue parsed_strings_value(value);
-    return HandleParsedStringsValue(parsed_strings_value, value, ttl);
+    return HandleParsedStringsValue(parsed_strings_value, value, ttl_millsec);
   } else if (s.IsNotFound()) {
-    ClearValueAndSetTTL(value, ttl, -2);
+    ClearValueAndSetTTL(value, ttl_millsec, -2);
   }
 
   return s;
@@ -525,7 +525,7 @@ Status Redis::Getrange(const Slice& key, int64_t start_offset, int64_t end_offse
 }
 
 Status Redis::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
-                                std::string* ret, std::string* value, int64_t* ttl) {
+                                std::string* ret, std::string* value, int64_t* ttl_millsec) {
   *ret = "";
   BaseKey base_key(key);
   Status s = db_->Get(default_read_options_, base_key.Encode(), value);
@@ -544,17 +544,17 @@ Status Redis::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t 
     ParsedStringsValue parsed_strings_value(value);
     if (parsed_strings_value.IsStale()) {
       value->clear();
-      *ttl = -2;
+      *ttl_millsec = -2;
       return Status::NotFound("Stale");
     } else {
       parsed_strings_value.StripSuffix();
       // get ttl
-      *ttl = parsed_strings_value.Etime();
-      if (*ttl == 0) {
-        *ttl = -1;
+      *ttl_millsec = parsed_strings_value.Etime();
+      if (*ttl_millsec == 0) {
+        *ttl_millsec = -1;
       } else {
         pstd::TimeType curtime = pstd::NowMillis();
-        *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
+        *ttl_millsec = *ttl_millsec - curtime >= 0 ? *ttl_millsec - curtime : -2;
       }
 
       int64_t size = value->size();
@@ -580,7 +580,7 @@ Status Redis::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t 
     }
   } else if (s.IsNotFound()) {
     value->clear();
-    *ttl = -2;
+    *ttl_millsec = -2;
   }
   return s;
 }
@@ -773,7 +773,7 @@ Status Redis::Set(const Slice& key, const Slice& value) {
   return db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
 }
 
-Status Redis::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl) {
+Status Redis::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec) {
   bool not_found = true;
   std::string old_value;
   StringsValue strings_value(value);
@@ -805,8 +805,8 @@ Status Redis::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t 
     return s;
   } else {
     *ret = 1;
-    if (ttl > 0) {
-      strings_value.SetRelativeTimestamp(ttl);
+    if (ttl_millsec > 0) {
+      strings_value.SetRelativeTimeByMillsec(ttl_millsec);
     }
     return db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
   }
@@ -871,12 +871,12 @@ Status Redis::SetBit(const Slice& key, int64_t offset, int32_t on, int32_t* ret)
   }
 }
 
-Status Redis::Setex(const Slice& key, const Slice& value, int64_t ttl) {
-  if (ttl <= 0) {
+Status Redis::Setex(const Slice& key, const Slice& value, int64_t ttl_millsec) {
+  if (ttl_millsec <= 0) {
     return Status::InvalidArgument("invalid expire time");
   }
   StringsValue strings_value(value);
-  auto s = strings_value.SetRelativeTimestamp(ttl);
+  auto s = strings_value.SetRelativeTimeByMillsec(ttl_millsec);
   if (s != Status::OK()) {
     return s;
   }
@@ -886,7 +886,7 @@ Status Redis::Setex(const Slice& key, const Slice& value, int64_t ttl) {
   return db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
 }
 
-Status Redis::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl) {
+Status Redis::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec) {
   *ret = 0;
   std::string old_value;
 
@@ -903,8 +903,8 @@ Status Redis::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t 
   s = Status::NotFound();
 
   StringsValue strings_value(value);
-  if (ttl > 0) {
-    strings_value.SetRelativeTimestamp(ttl);
+  if (ttl_millsec > 0) {
+    strings_value.SetRelativeTimeByMillsec(ttl_millsec);
   }
   s = db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
   if (s.ok()) {
@@ -914,7 +914,7 @@ Status Redis::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t 
 }
 
 Status Redis::Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret,
-                    int64_t ttl) {
+                    int64_t ttl_millsec) {
   *ret = 0;
   std::string old_value;
 
@@ -938,8 +938,8 @@ Status Redis::Setvx(const Slice& key, const Slice& value, const Slice& new_value
     } else {
       if (value.compare(parsed_strings_value.UserValue()) == 0) {
         StringsValue strings_value(new_value);
-        if (ttl > 0) {
-          strings_value.SetRelativeTimestamp(ttl);
+        if (ttl_millsec > 0) {
+          strings_value.SetRelativeTimeByMillsec(ttl_millsec);
         }
         s = db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
         if (!s.ok()) {
@@ -1284,14 +1284,14 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_
 }
 
 //TODO(wangshaoyi): timestamp uint64_t
-Status Redis::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
+Status Redis::PKSetexAt(const Slice& key, const Slice& value, int64_t time_stamp_millsec_) {
   StringsValue strings_value(value);
-  if (timestamp < 0) {
-    timestamp = pstd::NowMillis() - 1;
+  if (time_stamp_millsec_ < 0) {
+    time_stamp_millsec_ = pstd::NowMillis() - 1;
   }
   BaseKey base_key(key);
   ScopeRecordLock l(lock_mgr_, key);
-  strings_value.SetEtime(uint64_t(timestamp));
+  strings_value.SetEtime(uint64_t(time_stamp_millsec_));
   return db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
 }
 
@@ -1437,7 +1437,7 @@ Status Redis::StringsPersist(const Slice& key, std::string&& prefetch_meta) {
   return s;
 }
 
-Status Redis::StringsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta) {
+Status Redis::StringsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta) {
   std::string value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseKey base_key(key);
@@ -1461,19 +1461,19 @@ Status Redis::StringsTTL(const Slice& key, int64_t* timestamp, std::string&& pre
   if (s.ok()) {
     ParsedStringsValue parsed_strings_value(&value);
     if (parsed_strings_value.IsStale()) {
-      *timestamp = -2;
+      *ttl_millsec = -2;
       return Status::NotFound("Stale");
     } else {
-      *timestamp = parsed_strings_value.Etime();
-      if (*timestamp == 0) {
-        *timestamp = -1;
+      *ttl_millsec = parsed_strings_value.Etime();
+      if (*ttl_millsec == 0) {
+        *ttl_millsec = -1;
       } else {
         pstd::TimeType curtime = pstd::NowMillis();
-        *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
+        *ttl_millsec = *ttl_millsec - curtime >= 0 ? *ttl_millsec - curtime : -2;
       }
     }
   } else if (s.IsNotFound()) {
-    *timestamp = -2;
+    *ttl_millsec = -2;
   }
   return s;
 }
@@ -1637,7 +1637,7 @@ rocksdb::Status Redis::Persist(const Slice& key) {
   return rocksdb::Status::NotFound();
 }
 
-rocksdb::Status Redis::TTL(const Slice& key, int64_t* timestamp) {
+rocksdb::Status Redis::TTL(const Slice& key, int64_t* ttl_millsec) {
   std::string meta_value;
   BaseMetaKey base_meta_key(key);
   rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
@@ -1645,15 +1645,15 @@ rocksdb::Status Redis::TTL(const Slice& key, int64_t* timestamp) {
     auto type = static_cast<DataType>(static_cast<uint8_t>(meta_value[0]));
     switch (type) {
       case DataType::kSets:
-        return SetsTTL(key, timestamp, std::move(meta_value));
+        return SetsTTL(key, ttl_millsec, std::move(meta_value));
       case DataType::kZSets:
-        return ZsetsTTL(key, timestamp, std::move(meta_value));
+        return ZsetsTTL(key, ttl_millsec, std::move(meta_value));
       case DataType::kHashes:
-        return HashesTTL(key, timestamp, std::move(meta_value));
+        return HashesTTL(key, ttl_millsec, std::move(meta_value));
       case DataType::kLists:
-        return ListsTTL(key, timestamp, std::move(meta_value));
+        return ListsTTL(key, ttl_millsec, std::move(meta_value));
       case DataType::kStrings:
-        return StringsTTL(key, timestamp, std::move(meta_value));
+        return StringsTTL(key, ttl_millsec, std::move(meta_value));
       default:
         return rocksdb::Status::NotFound();
     }

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -33,8 +33,7 @@ Status Redis::ScanStringsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
+  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
 
   // Note: This is a string type and does not need to pass the column family as
   // a parameter, use the default column family
@@ -378,8 +377,7 @@ void ClearValueAndSetTTL(std::string* value, int64_t* ttl, int64_t ttl_value) {
 }
 
 int64_t CalculateTTL(int64_t expiry_time) {
-  int64_t current_time;
-  rocksdb::Env::Default()->GetCurrentTime(&current_time);
+  int64_t current_time = rocksdb::Env::Default()->NowMicros() / 1000;
   return expiry_time - current_time >= 0 ? expiry_time - current_time : -2;
 }
 
@@ -555,8 +553,7 @@ Status Redis::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t 
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1469,8 +1466,7 @@ Status Redis::StringsTTL(const Slice& key, int64_t* timestamp, std::string&& pre
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -36,7 +36,7 @@ Status Redis::ScanZsetsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = pstd::NowMillis();
+  pstd::TimeType curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -567,7 +567,7 @@ Status Redis::ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1943,7 +1943,7 @@ Status Redis::ZsetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefe
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = pstd::NowMillis();
+        pstd::TimeType curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -36,7 +36,7 @@ Status Redis::ScanZsetsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -567,7 +567,7 @@ Status Redis::ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1943,7 +1943,7 @@ Status Redis::ZsetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefe
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
+        int64_t curtime = pstd::NowMillis();
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -36,8 +36,7 @@ Status Redis::ScanZsetsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
+  int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -568,8 +567,7 @@ Status Redis::ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::
       if (*ttl == 0) {
         *ttl = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
       }
 
@@ -1945,8 +1943,7 @@ Status Redis::ZsetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefe
       if (*timestamp == 0) {
         *timestamp = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
+        int64_t curtime = rocksdb::Env::Default()->NowMicros() / 1000;
         *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
       }
     }

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -107,7 +107,7 @@ Status Redis::ZPopMax(const Slice& key, const int64_t count, std::vector<ScoreMe
         batch.Delete(handles_[kZsetsScoreCF], iter->key());
       }
       delete iter;
-      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)){
+      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)) {
         return Status::InvalidArgument("zset size overflow");
       }
       parsed_zsets_meta_value.ModifyCount(-del_cnt);
@@ -165,7 +165,7 @@ Status Redis::ZPopMin(const Slice& key, const int64_t count, std::vector<ScoreMe
         batch.Delete(handles_[kZsetsScoreCF], iter->key());
       }
       delete iter;
-      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)){
+      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)) {
         return Status::InvalidArgument("zset size overflow");
       }
       parsed_zsets_meta_value.ModifyCount(-del_cnt);
@@ -260,7 +260,7 @@ Status Redis::ZAdd(const Slice& key, const std::vector<ScoreMember>& score_membe
         cnt++;
       }
     }
-    if (!parsed_zsets_meta_value.CheckModifyCount(cnt)){
+    if (!parsed_zsets_meta_value.CheckModifyCount(cnt)) {
       return Status::InvalidArgument("zset size overflow");
     }
     parsed_zsets_meta_value.ModifyCount(cnt);
@@ -443,7 +443,7 @@ Status Redis::ZIncrby(const Slice& key, const Slice& member, double increment, d
       statistic++;
     } else if (s.IsNotFound()) {
       score = increment;
-      if (!parsed_zsets_meta_value.CheckModifyCount(1)){
+      if (!parsed_zsets_meta_value.CheckModifyCount(1)) {
         return Status::InvalidArgument("zset size overflow");
       }
       parsed_zsets_meta_value.ModifyCount(1);
@@ -795,7 +795,7 @@ Status Redis::ZRem(const Slice& key, const std::vector<std::string>& members, in
         }
       }
       *ret = del_cnt;
-      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)){
+      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)) {
         return Status::InvalidArgument("zset size overflow");
       }
       parsed_zsets_meta_value.ModifyCount(-del_cnt);
@@ -862,7 +862,7 @@ Status Redis::ZRemrangebyrank(const Slice& key, int32_t start, int32_t stop, int
       }
       delete iter;
       *ret = del_cnt;
-      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)){
+      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)) {
         return Status::InvalidArgument("zset size overflow");
       }
       parsed_zsets_meta_value.ModifyCount(-del_cnt);
@@ -942,7 +942,7 @@ Status Redis::ZRemrangebyscore(const Slice& key, double min, double max, bool le
       }
       delete iter;
       *ret = del_cnt;
-      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)){
+      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)) {
         return Status::InvalidArgument("zset size overflow");
       }
       parsed_zsets_meta_value.ModifyCount(-del_cnt);
@@ -1654,7 +1654,7 @@ Status Redis::ZRemrangebylex(const Slice& key, const Slice& min, const Slice& ma
       delete iter;
     }
     if (del_cnt > 0) {
-      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)){
+      if (!parsed_zsets_meta_value.CheckModifyCount(-del_cnt)) {
         return Status::InvalidArgument("zset size overflow");
       }
       parsed_zsets_meta_value.ModifyCount(-del_cnt);

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -1669,7 +1669,7 @@ Status Redis::ZRemrangebylex(const Slice& key, const Slice& min, const Slice& ma
   return s;
 }
 
-Status Redis::ZsetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+Status Redis::ZsetsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1698,8 +1698,8 @@ Status Redis::ZsetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_
       return Status::NotFound();
     }
 
-    if (ttl > 0) {
-      parsed_zsets_meta_value.SetRelativeTimestamp(ttl);
+    if (ttl_millsec > 0) {
+      parsed_zsets_meta_value.SetRelativeTimestamp(ttl_millsec);
     } else {
       parsed_zsets_meta_value.InitialMetaValue();
     }
@@ -1745,7 +1745,7 @@ Status Redis::ZsetsDel(const Slice& key, std::string&& prefetch_meta) {
   return s;
 }
 
-Status Redis::ZsetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+Status Redis::ZsetsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1773,8 +1773,8 @@ Status Redis::ZsetsExpireat(const Slice& key, int64_t timestamp, std::string&& p
     } else if (parsed_zsets_meta_value.Count() == 0) {
       return Status::NotFound();
     } else {
-      if (timestamp > 0) {
-        parsed_zsets_meta_value.SetEtime(uint64_t(timestamp));
+      if (timestamp_millsec > 0) {
+        parsed_zsets_meta_value.SetEtime(uint64_t(timestamp_millsec));
       } else {
         parsed_zsets_meta_value.InitialMetaValue();
       }

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -138,9 +138,9 @@ Status Storage::Set(const Slice& key, const Slice& value) {
   return inst->Set(key, value);
 }
 
-Status Storage::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl) {
+Status Storage::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setxx(key, value, ret, ttl);
+  return inst->Setxx(key, value, ret, ttl_millsec);
 }
 
 Status Storage::Get(const Slice& key, std::string* value) {
@@ -148,14 +148,14 @@ Status Storage::Get(const Slice& key, std::string* value) {
   return inst->Get(key, value);
 }
 
-Status Storage::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
+Status Storage::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->GetWithTTL(key, value, ttl);
+  return inst->GetWithTTL(key, value, ttl_millsec);
 }
 
-Status Storage::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
+Status Storage::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->MGetWithTTL(key, value, ttl);
+  return inst->MGetWithTTL(key, value, ttl_millsec);
 }
 
 Status Storage::GetSet(const Slice& key, const Slice& value, std::string* old_value) {
@@ -210,12 +210,12 @@ Status Storage::MGetWithTTL(const std::vector<std::string>& keys, std::vector<Va
   for(const auto& key : keys) {
     auto& inst = GetDBInstance(key);
     std::string value;
-    int64_t ttl;
-    s = inst->MGetWithTTL(key, &value, &ttl);
+    int64_t ttl_millsec;
+    s = inst->MGetWithTTL(key, &value, &ttl_millsec);
     if (s.ok()) {
-      vss->push_back({value, Status::OK(), ttl});
+      vss->push_back({value, Status::OK(), ttl_millsec});
     } else if (s.IsNotFound()) {
-      vss->push_back({std::string(), Status::NotFound(), ttl});
+      vss->push_back({std::string(), Status::NotFound(), ttl_millsec});
     } else {
       vss->clear();
       return s;
@@ -224,9 +224,9 @@ Status Storage::MGetWithTTL(const std::vector<std::string>& keys, std::vector<Va
   return Status::OK();
 }
 
-Status Storage::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl) {
+Status Storage::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setnx(key, value, ret, ttl);
+  return inst->Setnx(key, value, ret, ttl_millsec);
 }
 
 // disallowed in codis, only runs in pika classic mode
@@ -255,9 +255,9 @@ Status Storage::MSetnx(const std::vector<KeyValue>& kvs, int32_t* ret) {
   return s;
 }
 
-Status Storage::Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl) {
+Status Storage::Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setvx(key, value, new_value, ret, ttl);
+  return inst->Setvx(key, value, new_value, ret, ttl_millsec);
 }
 
 Status Storage::Delvx(const Slice& key, const Slice& value, int32_t* ret) {
@@ -276,9 +276,9 @@ Status Storage::Getrange(const Slice& key, int64_t start_offset, int64_t end_off
 }
 
 Status Storage::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
-                                     std::string* ret, std::string* value, int64_t* ttl) {
+                                     std::string* ret, std::string* value, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->GetrangeWithValue(key, start_offset, end_offset, ret, value, ttl);
+  return inst->GetrangeWithValue(key, start_offset, end_offset, ret, value, ttl_millsec);
 }
 
 Status Storage::Append(const Slice& key, const Slice& value, int32_t* ret) {
@@ -355,9 +355,9 @@ Status Storage::Incrbyfloat(const Slice& key, const Slice& value, std::string* r
   return inst->Incrbyfloat(key, value, ret);
 }
 
-Status Storage::Setex(const Slice& key, const Slice& value, int64_t ttl) {
+Status Storage::Setex(const Slice& key, const Slice& value, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setex(key, value, ttl);
+  return inst->Setex(key, value, ttl_millsec);
 }
 
 Status Storage::Strlen(const Slice& key, int32_t* len) {
@@ -365,12 +365,12 @@ Status Storage::Strlen(const Slice& key, int32_t* len) {
   return inst->Strlen(key, len);
 }
 
-Status Storage::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
+Status Storage::PKSetexAt(const Slice& key, const Slice& value, int64_t time_stamp_millsec_) {
   auto& inst = GetDBInstance(key);
-  if (timestamp < 0) {
-    timestamp = pstd::NowMillis() - 1;
+  if (time_stamp_millsec_ < 0) {
+    time_stamp_millsec_ = pstd::NowMillis() - 1;
   }
-  return inst->PKSetexAt(key, value, timestamp);
+  return inst->PKSetexAt(key, value, time_stamp_millsec_);
 }
 
 // Hashes Commands
@@ -399,9 +399,9 @@ Status Storage::HGetall(const Slice& key, std::vector<FieldValue>* fvs) {
   return inst->HGetall(key, fvs);
 }
 
-Status Storage::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl) {
+Status Storage::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->HGetallWithTTL(key, fvs, ttl);
+  return inst->HGetallWithTTL(key, fvs, ttl_millsec);
 }
 
 Status Storage::HKeys(const Slice& key, std::vector<std::string>* fields) {
@@ -627,9 +627,9 @@ Status Storage::SMembers(const Slice& key, std::vector<std::string>* members) {
   return inst->SMembers(key, members);
 }
 
-Status Storage::SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t *ttl) {
+Status Storage::SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t * ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->SMembersWithTTL(key, members, ttl);
+  return inst->SMembersWithTTL(key, members, ttl_millsec);
 }
 
 Status Storage::SMove(const Slice& source, const Slice& destination, const Slice& member, int32_t* ret) {
@@ -754,9 +754,9 @@ Status Storage::LRange(const Slice& key, int64_t start, int64_t stop, std::vecto
   return inst->LRange(key, start, stop, ret);
 }
 
-Status Storage::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t *ttl) {
+Status Storage::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t * ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->LRangeWithTTL(key, start, stop, ret, ttl);
+  return inst->LRangeWithTTL(key, start, stop, ret, ttl_millsec);
 }
 
 Status Storage::LTrim(const Slice& key, int64_t start, int64_t stop) {
@@ -886,10 +886,10 @@ Status Storage::ZRange(const Slice& key, int32_t start, int32_t stop, std::vecto
   return inst->ZRange(key, start, stop, score_members);
 }
 Status Storage::ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members,
-                                 int64_t *ttl) {
+                                 int64_t * ttl_millsec) {
   score_members->clear();
   auto& inst = GetDBInstance(key);
-  return inst->ZRangeWithTTL(key, start, stop, score_members, ttl);
+  return inst->ZRangeWithTTL(key, start, stop, score_members, ttl_millsec);
 }
 
 Status Storage::ZRangebyscore(const Slice& key, double min, double max, bool left_close, bool right_close,
@@ -1472,27 +1472,27 @@ int32_t Storage::Persist(const Slice& key) {
 }
 
 int64_t Storage::PTTL(const Slice& key) {
-  int64_t timestamp = 0;
+  int64_t ttl_millsec = 0;
   auto& inst = GetDBInstance(key);
-  Status s = inst->TTL(key, &timestamp);
+  Status s = inst->TTL(key, &ttl_millsec);
   if (s.ok() || s.IsNotFound()) {
-    return timestamp;
+    return ttl_millsec;
   } else if (!s.IsNotFound()) {
     return -3;
   }
-  return timestamp;
+  return ttl_millsec;
 }
 
 int64_t Storage::TTL(const Slice& key) {
-  int64_t timestamp = 0;
+  int64_t ttl_millsec = 0;
   auto& inst = GetDBInstance(key);
-  Status s = inst->TTL(key, &timestamp);
+  Status s = inst->TTL(key, &ttl_millsec);
   if (s.ok() || s.IsNotFound()) {
-    return timestamp > 0 ? timestamp / 1000 : timestamp;
+    return ttl_millsec > 0 ? ttl_millsec / 1000 : ttl_millsec;
   } else if (!s.IsNotFound()) {
     return -3;
   }
-  return timestamp > 0 ? timestamp / 1000 : timestamp;
+  return ttl_millsec > 0 ? ttl_millsec / 1000 : ttl_millsec;
 }
 
 Status Storage::GetType(const std::string& key, enum DataType& type) {

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1472,9 +1472,7 @@ int64_t Storage::PTTL(const Slice& key) {
   int64_t timestamp = 0;
   auto& inst = GetDBInstance(key);
   Status s = inst->TTL(key, &timestamp);
-  if (s.ok() || s.IsNotFound()) {
-    return timestamp;
-  } else if (!s.IsNotFound()) {
+  if (!s.IsNotFound()) {
     return -3;
   }
   return timestamp;
@@ -1484,12 +1482,10 @@ int64_t Storage::TTL(const Slice& key) {
   int64_t timestamp = 0;
   auto& inst = GetDBInstance(key);
   Status s = inst->TTL(key, &timestamp);
-  if (s.ok() || s.IsNotFound()) {
-    return timestamp > 0 ? timestamp / 1000 : timestamp;
-  } else if (!s.IsNotFound()) {
+  if (!s.IsNotFound()) {
     return -3;
   }
-  return timestamp;
+  return timestamp > 0 ? timestamp / 1000 : timestamp;
 }
 
 Status Storage::GetType(const std::string& key, enum DataType& type) {

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -367,6 +367,9 @@ Status Storage::Strlen(const Slice& key, int32_t* len) {
 
 Status Storage::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
   auto& inst = GetDBInstance(key);
+  if(timestamp < 0) {
+    timestamp = pstd::NowMillis()-1;
+  }
   return inst->PKSetexAt(key, value, timestamp);
 }
 

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1171,10 +1171,10 @@ Status Storage::XInfo(const Slice& key, StreamInfoResult &result) {
 }
 
 // Keys Commands
-int32_t Storage::Expire(const Slice& key, int64_t ttl) {
+int32_t Storage::Expire(const Slice& key, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
   int32_t ret = 0;
-  Status s = inst->Expire(key, ttl);
+  Status s = inst->Expire(key, ttl_millsec);
   if (s.ok()) {
     ret++;
   } else if (!s.IsNotFound()) {
@@ -1446,11 +1446,11 @@ Status Storage::Scanx(const DataType& data_type, const std::string& start_key, c
   return Status::OK();
 }
 
-int32_t Storage::Expireat(const Slice& key, int64_t timestamp) {
+int32_t Storage::Expireat(const Slice& key, int64_t timestamp_millsec) {
   Status s;
   int32_t count = 0;
   auto& inst = GetDBInstance(key);
-  s = inst->Expireat(key, timestamp);
+  s = inst->Expireat(key, timestamp_millsec);
   if (s.ok()) {
     count++;
   } else if (!s.IsNotFound()) {

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1472,7 +1472,9 @@ int64_t Storage::PTTL(const Slice& key) {
   int64_t timestamp = 0;
   auto& inst = GetDBInstance(key);
   Status s = inst->TTL(key, &timestamp);
-  if (!s.IsNotFound()) {
+  if (s.ok() || s.IsNotFound()) {
+    return timestamp;
+  } else if (!s.IsNotFound()) {
     return -3;
   }
   return timestamp;
@@ -1482,7 +1484,9 @@ int64_t Storage::TTL(const Slice& key) {
   int64_t timestamp = 0;
   auto& inst = GetDBInstance(key);
   Status s = inst->TTL(key, &timestamp);
-  if (!s.IsNotFound()) {
+  if (s.ok() || s.IsNotFound()) {
+    return timestamp > 0 ? timestamp / 1000 : timestamp;
+  } else if (!s.IsNotFound()) {
     return -3;
   }
   return timestamp > 0 ? timestamp / 1000 : timestamp;

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -194,7 +194,7 @@ Status Storage::MGet(const std::vector<std::string>& keys, std::vector<ValueStat
     s = inst->MGet(key, &value);
     if (s.ok()) {
       vss->push_back({value, Status::OK()});
-    } else if(s.IsNotFound()) {
+    } else if (s.IsNotFound()) {
       vss->push_back({std::string(), Status::NotFound()});
     } else {
       vss->clear();
@@ -367,7 +367,7 @@ Status Storage::Strlen(const Slice& key, int32_t* len) {
 
 Status Storage::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
   auto& inst = GetDBInstance(key);
-  if(timestamp < 0) {
+  if (timestamp < 0) {
     timestamp = pstd::NowMillis() - 1;
   }
   return inst->PKSetexAt(key, value, timestamp);

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -368,7 +368,7 @@ Status Storage::Strlen(const Slice& key, int32_t* len) {
 Status Storage::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
   auto& inst = GetDBInstance(key);
   if(timestamp < 0) {
-    timestamp = pstd::NowMillis()-1;
+    timestamp = pstd::NowMillis() - 1;
   }
   return inst->PKSetexAt(key, value, timestamp);
 }

--- a/src/storage/src/strings_filter.h
+++ b/src/storage/src/strings_filter.h
@@ -20,7 +20,7 @@ class StringsFilter : public rocksdb::CompactionFilter {
   StringsFilter() = default;
   bool Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value, std::string* new_value,
               bool* value_changed) const override {
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     auto cur_time = static_cast<uint64_t>(unix_time);
     ParsedStringsValue parsed_strings_value(value);
     TRACE("==========================START==========================");

--- a/src/storage/src/strings_filter.h
+++ b/src/storage/src/strings_filter.h
@@ -20,7 +20,7 @@ class StringsFilter : public rocksdb::CompactionFilter {
   StringsFilter() = default;
   bool Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value, std::string* new_value,
               bool* value_changed) const override {
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     auto cur_time = static_cast<uint64_t>(unix_time);
     ParsedStringsValue parsed_strings_value(value);
     TRACE("==========================START==========================");

--- a/src/storage/src/strings_filter.h
+++ b/src/storage/src/strings_filter.h
@@ -20,8 +20,7 @@ class StringsFilter : public rocksdb::CompactionFilter {
   StringsFilter() = default;
   bool Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value, std::string* new_value,
               bool* value_changed) const override {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     auto cur_time = static_cast<uint64_t>(unix_time);
     ParsedStringsValue parsed_strings_value(value);
     TRACE("==========================START==========================");

--- a/src/storage/src/strings_value_format.h
+++ b/src/storage/src/strings_value_format.h
@@ -37,10 +37,10 @@ class StringsValue : public InternalValue {
     dst += kSuffixReserveLength;
     // The most significant bit is 1 for milliseconds and 0 for seconds.
     // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
-    uint64_t ctime = (ctime_ |= (1LL << 63));
+    uint64_t ctime = (ctime_ | (1ULL << 63));
     EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
-    uint64_t etime = (etime_ |= (1LL << 63));
+    uint64_t etime = (etime_ | (1ULL << 63));
     EncodeFixed64(dst, etime);
     return {start_, needed};
   }
@@ -86,12 +86,12 @@ class ParsedStringsValue : public ParsedInternalValue {
       offset += sizeof(ctime_);
       uint64_t etime = DecodeFixed64(internal_value_str->data() + offset);
 
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
       if(ctime_ == ctime) {
         ctime_ *= 1000;
       }
-      etime_ = (etime &= ~(1LL << 63));
+      etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
       if(etime == etime_) {
         etime_ *= 1000;
@@ -113,12 +113,12 @@ class ParsedStringsValue : public ParsedInternalValue {
       offset += kTimestampLength;
       uint64_t etime = DecodeFixed64(internal_value_slice.data() + offset);
 
-      ctime_ = (ctime &= ~(1LL << 63));
+      ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
       if(ctime_ == ctime) {
         ctime_ *= 1000;
       }
-      etime_ = (etime &= ~(1LL << 63));
+      etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
       if(etime == etime_) {
         etime_ *= 1000;
@@ -140,7 +140,8 @@ class ParsedStringsValue : public ParsedInternalValue {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() -
                   kStringsValueSuffixLength + kSuffixReserveLength;
-      EncodeFixed64(dst, ctime_);
+      uint64_t ctime = (ctime_ | (1LL << 63));
+      EncodeFixed64(dst, ctime);
     }
   }
 
@@ -148,7 +149,8 @@ class ParsedStringsValue : public ParsedInternalValue {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() -
                   kStringsValueSuffixLength + kSuffixReserveLength + kTimestampLength;
-      EncodeFixed64(dst, etime_);
+      uint64_t etime = (etime_ | (1LL << 63));
+      EncodeFixed64(dst, etime);
     }
   }
 

--- a/src/storage/src/strings_value_format.h
+++ b/src/storage/src/strings_value_format.h
@@ -140,7 +140,7 @@ class ParsedStringsValue : public ParsedInternalValue {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() -
                   kStringsValueSuffixLength + kSuffixReserveLength;
-      uint64_t ctime = (ctime_ | (1LL << 63));
+      uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
       EncodeFixed64(dst, ctime);
     }
   }
@@ -149,7 +149,7 @@ class ParsedStringsValue : public ParsedInternalValue {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() -
                   kStringsValueSuffixLength + kSuffixReserveLength + kTimestampLength;
-      uint64_t etime = (etime_ | (1LL << 63));
+      uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
       EncodeFixed64(dst, etime);
     }
   }

--- a/src/storage/src/strings_value_format.h
+++ b/src/storage/src/strings_value_format.h
@@ -37,10 +37,10 @@ class StringsValue : public InternalValue {
     dst += kSuffixReserveLength;
     // The most significant bit is 1 for milliseconds and 0 for seconds.
     // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
-    uint64_t ctime = (ctime_ | (1ULL << 63));
+    uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
     EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
-    uint64_t etime = (etime_ | (1ULL << 63));
+    uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
     EncodeFixed64(dst, etime);
     return {start_, needed};
   }

--- a/src/storage/src/strings_value_format.h
+++ b/src/storage/src/strings_value_format.h
@@ -88,12 +88,12 @@ class ParsedStringsValue : public ParsedInternalValue {
 
       ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
-      if(ctime_ == ctime) {
+      if (ctime_ == ctime) {
         ctime_ *= 1000;
       }
       etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
-      if(etime == etime_) {
+      if (etime == etime_) {
         etime_ *= 1000;
       }
     }
@@ -115,12 +115,12 @@ class ParsedStringsValue : public ParsedInternalValue {
 
       ctime_ = (ctime & ~(1ULL << 63));
       // if ctime_==ctime, means ctime_ storaged in seconds
-      if(ctime_ == ctime) {
+      if (ctime_ == ctime) {
         ctime_ *= 1000;
       }
       etime_ = (etime & ~(1ULL << 63));
       // if etime_==etime, means etime_ storaged in seconds
-      if(etime == etime_) {
+      if (etime == etime_) {
         etime_ *= 1000;
       }
     }

--- a/src/storage/src/strings_value_format.h
+++ b/src/storage/src/strings_value_format.h
@@ -35,9 +35,13 @@ class StringsValue : public InternalValue {
     dst += usize;
     memcpy(dst, reserve_, kSuffixReserveLength);
     dst += kSuffixReserveLength;
-    EncodeFixed64(dst, ctime_);
+    // The most significant bit is 1 for milliseconds and 0 for seconds.
+    // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
+    uint64_t ctime = (ctime_ |= (1LL << 63));
+    EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
-    EncodeFixed64(dst, etime_);
+    uint64_t etime = (etime_ |= (1LL << 63));
+    EncodeFixed64(dst, etime);
     return {start_, needed};
   }
 };
@@ -78,9 +82,20 @@ class ParsedStringsValue : public ParsedInternalValue {
       offset += user_value_.size();
       memcpy(reserve_, internal_value_str->data() + offset, kSuffixReserveLength);
       offset += kSuffixReserveLength;
-      ctime_ = DecodeFixed64(internal_value_str->data() + offset);
+      uint64_t ctime = DecodeFixed64(internal_value_str->data() + offset);
       offset += sizeof(ctime_);
-      etime_ = DecodeFixed64(internal_value_str->data() + offset);
+      uint64_t etime = DecodeFixed64(internal_value_str->data() + offset);
+
+      ctime_ = (ctime &= ~(1LL << 63));
+      // if ctime_==ctime, means ctime_ storaged in seconds
+      if(ctime_ == ctime) {
+        ctime_ *= 1000;
+      }
+      etime_ = (etime &= ~(1LL << 63));
+      // if etime_==etime, means etime_ storaged in seconds
+      if(etime == etime_) {
+        etime_ *= 1000;
+      }
     }
   }
 
@@ -94,9 +109,20 @@ class ParsedStringsValue : public ParsedInternalValue {
       offset += user_value_.size();
       memcpy(reserve_, internal_value_slice.data() + offset, kSuffixReserveLength);
       offset += kSuffixReserveLength;
-      ctime_ = DecodeFixed64(internal_value_slice.data() + offset);
+      uint64_t ctime = DecodeFixed64(internal_value_slice.data() + offset);
       offset += kTimestampLength;
-      etime_ = DecodeFixed64(internal_value_slice.data() + offset);
+      uint64_t etime = DecodeFixed64(internal_value_slice.data() + offset);
+
+      ctime_ = (ctime &= ~(1LL << 63));
+      // if ctime_==ctime, means ctime_ storaged in seconds
+      if(ctime_ == ctime) {
+        ctime_ *= 1000;
+      }
+      etime_ = (etime &= ~(1LL << 63));
+      // if etime_==etime, means etime_ storaged in seconds
+      if(etime == etime_) {
+        etime_ *= 1000;
+      }
     }
   }
 

--- a/src/storage/src/zsets_filter.h
+++ b/src/storage/src/zsets_filter.h
@@ -80,8 +80,7 @@ class ZSetsScoreFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/zsets_filter.h
+++ b/src/storage/src/zsets_filter.h
@@ -80,7 +80,7 @@ class ZSetsScoreFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+    int64_t unix_time = pstd::NowMillis();
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/zsets_filter.h
+++ b/src/storage/src/zsets_filter.h
@@ -80,7 +80,7 @@ class ZSetsScoreFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time = pstd::NowMillis();
+    pstd::TimeType unix_time = pstd::NowMillis();
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/tests/keys_test.cc
+++ b/src/storage/tests/keys_test.cc
@@ -5113,8 +5113,7 @@ TEST_F(KeysTest, ExpireatTest) {
   s = db.Set("EXPIREAT_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
 
-  int64_t unix_time;
-  rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+  int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
   int64_t timestamp = unix_time + 1;
   ret = db.Expireat("EXPIREAT_KEY", timestamp);
   ASSERT_EQ(ret, 1);

--- a/src/storage/tests/keys_test.cc
+++ b/src/storage/tests/keys_test.cc
@@ -5113,7 +5113,7 @@ TEST_F(KeysTest, ExpireatTest) {
   s = db.Set("EXPIREAT_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
 
-  int64_t unix_time = pstd::NowMillis();
+  pstd::TimeType unix_time = pstd::NowMillis();
   int64_t timestamp = unix_time + 1;
   ret = db.Expireat("EXPIREAT_KEY", timestamp);
   ASSERT_EQ(ret, 1);

--- a/src/storage/tests/keys_test.cc
+++ b/src/storage/tests/keys_test.cc
@@ -5113,7 +5113,7 @@ TEST_F(KeysTest, ExpireatTest) {
   s = db.Set("EXPIREAT_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
 
-  int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t unix_time = pstd::NowMillis();
   int64_t timestamp = unix_time + 1;
   ret = db.Expireat("EXPIREAT_KEY", timestamp);
   ASSERT_EQ(ret, 1);

--- a/src/storage/tests/lists_filter_test.cc
+++ b/src/storage/tests/lists_filter_test.cc
@@ -102,7 +102,7 @@ TEST_F(ListsFilterTest, DataFilterTest) {
   EncodeFixed64(str, 1);
   ListsMetaValue lists_meta_value2(Slice(str, sizeof(uint64_t)));
   version = lists_meta_value2.UpdateVersion();
-  lists_meta_value2.SetRelativeTimestamp(1);
+  lists_meta_value2.SetRelativeTimeByMillsec(1);
   s = meta_db->Put(rocksdb::WriteOptions(), handles[0], bmk.Encode(), lists_meta_value2.Encode());
   ASSERT_TRUE(s.ok());
   ListsDataKey lists_data_key2("FILTER_TEST_KEY", version, 1);
@@ -119,7 +119,7 @@ TEST_F(ListsFilterTest, DataFilterTest) {
   EncodeFixed64(str, 1);
   ListsMetaValue lists_meta_value3(Slice(str, sizeof(uint64_t)));
   version = lists_meta_value3.UpdateVersion();
-  lists_meta_value3.SetRelativeTimestamp(1);
+  lists_meta_value3.SetRelativeTimeByMillsec(1);
   s = meta_db->Put(rocksdb::WriteOptions(), handles[0], bmk.Encode(), lists_meta_value3.Encode());
   ASSERT_TRUE(s.ok());
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/src/storage/tests/strings_filter_test.cc
+++ b/src/storage/tests/strings_filter_test.cc
@@ -21,7 +21,7 @@ TEST(StringsFilterTest, FilterTest) {
 
   int64_t ttl = 1;
   StringsValue strings_value("FILTER_VALUE");
-  strings_value.SetRelativeTimestamp(ttl);
+  strings_value.SetRelativeTimeByMillsec(ttl);
   is_stale = filter->Filter(0, "FILTER_KEY", strings_value.Encode(), &new_value, &value_changed);
   ASSERT_FALSE(is_stale);
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -940,15 +940,13 @@ TEST_F(StringsTest, BitPosTest) {
 
 // PKSetexAt
 TEST_F(StringsTest, PKSetexAtTest) {
-#ifdef OS_MACOSX
-  return ;
-#endif
-  int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  int64_t unix_time;
   int64_t ttl_ret;
   std::map<storage::DataType, Status> type_status;
 
   // ***************** Group 1 Test *****************
-  s = db.PKSetexAt("GP1_PKSETEX_KEY", "VALUE", unix_time + 100);
+  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  s = db.PKSetexAt("GP1_PKSETEX_KEY", "VALUE", unix_time + 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -958,9 +956,10 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_GE(ttl_ret, 90);
 
   // ***************** Group 2 Test *****************
+  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
   s = db.Set("GP2_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
-  s = db.PKSetexAt("GP2_PKSETEX_KEY", "VALUE", unix_time + 100);
+  s = db.PKSetexAt("GP2_PKSETEX_KEY", "VALUE", unix_time + 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -970,7 +969,8 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_GE(ttl_ret, 90);
 
   // ***************** Group 3 Test *****************
-  s = db.PKSetexAt("GP3_PKSETEX_KEY", "VALUE", unix_time - 100);
+  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  s = db.PKSetexAt("GP3_PKSETEX_KEY", "VALUE", unix_time - 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -978,9 +978,10 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 4 Test *****************
+  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
   s = db.Set("GP4_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
-  s = db.PKSetexAt("GP4_PKSETEX_KEY", "VALUE", unix_time - 100);
+  s = db.PKSetexAt("GP4_PKSETEX_KEY", "VALUE", unix_time - 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -988,6 +989,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 5 Test *****************
+  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
   s = db.PKSetexAt("GP5_PKSETEX_KEY", "VALUE", -unix_time);
   ASSERT_TRUE(s.ok());
 
@@ -996,6 +998,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 6 Test *****************
+  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
   s = db.Set("GP6_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
   s = db.PKSetexAt("GP6_PKSETEX_KEY", "VALUE", -unix_time);

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -44,7 +44,7 @@ class StringsTest : public ::testing::Test {
 
 static bool make_expired(storage::Storage* const db, const Slice& key) {
   std::map<storage::DataType, rocksdb::Status> type_status;
-  int ret = db->Expire(key, 1);
+  int ret = db->Expire(key, 1 * 100);
   if ((ret == 0) || !type_status[storage::DataType::kStrings].ok()) {
     return false;
   }
@@ -86,7 +86,7 @@ TEST_F(StringsTest, AppendTest) {
   // ***************** Group 2 Test *****************
   s = db.Set("GP2_APPEND_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
-  ret = db.Expire("GP2_APPEND_KEY", 100);
+  ret = db.Expire("GP2_APPEND_KEY", 100 * 1000);
   ASSERT_EQ(ret, 1);
   type_status.clear();
   type_ttl = db.TTL("GP2_APPEND_KEY");
@@ -763,7 +763,7 @@ TEST_F(StringsTest, SetvxTest) {
   ASSERT_TRUE(s.ok());
 
   std::map<storage::DataType, Status> type_status;
-  ret = db.Expire("GP6_SETVX_KEY", 10);
+  ret = db.Expire("GP6_SETVX_KEY", 10 * 1000);
   ASSERT_EQ(ret, 1);
 
   sleep(1);

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -943,8 +943,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
 #ifdef OS_MACOSX
   return ;
 #endif
-  int64_t unix_time;
-  rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+  int64_t unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
   int64_t ttl_ret;
   std::map<storage::DataType, Status> type_status;
 

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -945,7 +945,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   std::map<storage::DataType, Status> type_status;
 
   // ***************** Group 1 Test *****************
-  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  unix_time = pstd::NowMillis();
   s = db.PKSetexAt("GP1_PKSETEX_KEY", "VALUE", unix_time + 100*1000);
   ASSERT_TRUE(s.ok());
 
@@ -956,7 +956,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_GE(ttl_ret, 90);
 
   // ***************** Group 2 Test *****************
-  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  unix_time = pstd::NowMillis();
   s = db.Set("GP2_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
   s = db.PKSetexAt("GP2_PKSETEX_KEY", "VALUE", unix_time + 100*1000);
@@ -969,7 +969,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_GE(ttl_ret, 90);
 
   // ***************** Group 3 Test *****************
-  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  unix_time = pstd::NowMillis();
   s = db.PKSetexAt("GP3_PKSETEX_KEY", "VALUE", unix_time - 100*1000);
   ASSERT_TRUE(s.ok());
 
@@ -978,7 +978,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 4 Test *****************
-  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  unix_time = pstd::NowMillis();
   s = db.Set("GP4_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
   s = db.PKSetexAt("GP4_PKSETEX_KEY", "VALUE", unix_time - 100*1000);
@@ -989,7 +989,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 5 Test *****************
-  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  unix_time = pstd::NowMillis();
   s = db.PKSetexAt("GP5_PKSETEX_KEY", "VALUE", -unix_time);
   ASSERT_TRUE(s.ok());
 
@@ -998,7 +998,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 6 Test *****************
-  unix_time = rocksdb::Env::Default()->NowMicros() / 1000;
+  unix_time = pstd::NowMillis();
   s = db.Set("GP6_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
   s = db.PKSetexAt("GP6_PKSETEX_KEY", "VALUE", -unix_time);

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -771,7 +771,7 @@ TEST_F(StringsTest, SetvxTest) {
   ASSERT_LT(0, ttl);
   ASSERT_GT(10, ttl);
 
-  s = db.Setvx("GP6_SETVX_KEY", "GP6_SETVX_VALUE", "GP6_SETVX_NEW_VALUE", &ret, 20);
+  s = db.Setvx("GP6_SETVX_KEY", "GP6_SETVX_VALUE", "GP6_SETVX_NEW_VALUE", &ret, 20 * 1000);
   ASSERT_TRUE(s.ok());
   ASSERT_EQ(ret, 1);
 

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -940,7 +940,7 @@ TEST_F(StringsTest, BitPosTest) {
 
 // PKSetexAt
 TEST_F(StringsTest, PKSetexAtTest) {
-  int64_t unix_time;
+  pstd::TimeType unix_time;
   int64_t ttl_ret;
   std::map<storage::DataType, Status> type_status;
 


### PR DESCRIPTION
fix https://github.com/OpenAtomFoundation/pika/issues/2821

1、将 floyd 存储的 date 字段的值从秒改为了 millseconds；
2、将 version 字段的值从秒改为了 micro-seconds；
3、floyd 中的 ctime 和 etime 字段，最高位的 bit，如果为1，表示毫秒单位，如果为0，表示秒级单位。因为之前存储的数据都是秒，这样能兼容历史版本的数据

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced time-to-live (TTL) functionality by introducing a precise PTTL (milliseconds) method for key timestamp retrieval.
	- Streamlined cache logic to directly access the database for PTTL operations, improving performance.
	- Added a new TTL method for clearer distinction in key expiration management.
	- Updated timestamp handling in various classes to support milliseconds, enhancing precision.
	- Improved API clarity by renaming time-related parameters to include "_millsec" in relevant methods.

- **Bug Fixes**
	- Improved error handling for negative timestamps to ensure appropriate internal error messages.

- **Refactor**
	- Implemented consistent time retrieval across various classes and methods using the new milliseconds approach.

- **Style**
	- Renamed time-related member variables for clarity regarding their units in several command classes.

- **Tests**
	- Enhanced precision of time management in unit tests by utilizing milliseconds for time calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->