### PR TITLE
feat:Added the periodically clearing serverlog function

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -64,11 +64,6 @@ sync-binlog-thread-num : 1
 # is used for replication.
 log-path : ./log/
 
-# log retention time of serverlogs(pika.{hostname}.{username}.log.{loglevel}.YYYYMMDD-HHMMSS) files that stored within log-path.
-# Any serverlogs files that exceed this time will be cleaned up.
-# The unit of serverlogs is in [days] and the default value is 7(days).
-log-retention-time : 7
-
 # Directory to store the data of Pika.
 db-path : ./db/
 

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -64,6 +64,11 @@ sync-binlog-thread-num : 1
 # is used for replication.
 log-path : ./log/
 
+# log retention time of serverlogs(pika.{hostname}.{username}.log.{loglevel}.YYYYMMDD-HHMMSS) files that stored within log-path.
+# Any serverlogs files that exceed this time will be cleaned up.
+# The unit of serverlogs is in [days] and the default value is 7(days).
+log-retention-time : 7
+
 # Directory to store the data of Pika.
 db-path : ./db/
 

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -77,10 +77,6 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return log_path_;
   }
-  int log_retention_time() {
-    std::shared_lock l(rwlock_);
-    return log_retention_time_;
-  }
   std::string log_level() {
     std::shared_lock l(rwlock_);
     return log_level_;
@@ -908,7 +904,6 @@ class PikaConf : public pstd::BaseConf {
   int db_sync_speed_ = 0;
   std::string slaveof_;
   std::string log_path_;
-  int log_retention_time_;
   std::string log_level_;
   std::string db_path_;
   int db_instance_num_ = 0;

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -77,6 +77,10 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return log_path_;
   }
+  int log_retention_time() {
+    std::shared_lock l(rwlock_);
+    return log_retention_time_;
+  }
   std::string log_level() {
     std::shared_lock l(rwlock_);
     return log_level_;
@@ -904,6 +908,7 @@ class PikaConf : public pstd::BaseConf {
   int db_sync_speed_ = 0;
   std::string slaveof_;
   std::string log_path_;
+  int log_retention_time_;
   std::string log_level_;
   std::string db_path_;
   int db_instance_num_ = 0;

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -513,7 +513,8 @@ class PikaServer : public pstd::noncopyable {
    */
   void DoTimingTask();
   void AutoCompactRange();
-  void AutoPurge();
+  void AutoBinlogPurge();
+  void AutoServerlogPurge();
   void AutoDeleteExpiredDump();
   void AutoUpdateNetworkMetric();
   void PrintThreadPoolQueueStatus();

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -513,8 +513,7 @@ class PikaServer : public pstd::noncopyable {
    */
   void DoTimingTask();
   void AutoCompactRange();
-  void AutoBinlogPurge();
-  void AutoServerlogPurge();
+  void AutoPurge();
   void AutoDeleteExpiredDump();
   void AutoUpdateNetworkMetric();
   void PrintThreadPoolQueueStatus();

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -128,6 +128,10 @@ int PikaConf::Load() {
   if (log_path_[log_path_.length() - 1] != '/') {
     log_path_ += "/";
   }
+  GetConfInt("log-retention-time",&log_retention_time_);
+  if(log_retention_time_ < 0){
+    LOG(FATAL) << "log-retention-time invalid";
+  }
   GetConfStr("loglevel", &log_level_);
   GetConfStr("db-path", &db_path_);
   GetConfInt("db-instance-num", &db_instance_num_);

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1085,8 +1085,10 @@ int PikaServer::ClientPubSubChannelPatternSize(const std::shared_ptr<NetConn>& c
 void PikaServer::DoTimingTask() {
   // Maybe schedule compactrange
   AutoCompactRange();
-  // Purge log
-  AutoPurge();
+  // Purge serverlog
+  AutoServerlogPurge();
+  // Purge binlog
+  AutoBinlogPurge();
   // Delete expired dump
   AutoDeleteExpiredDump();
   // Cheek Rsync Status
@@ -1206,7 +1208,82 @@ void PikaServer::AutoCompactRange() {
   }
 }
 
-void PikaServer::AutoPurge() { DoSameThingEveryDB(TaskType::kPurgeLog); }
+void PikaServer::AutoBinlogPurge() { DoSameThingEveryDB(TaskType::kPurgeLog); }
+
+void PikaServer::AutoServerlogPurge(){
+std::string log_path = g_pika_conf->log_path();
+  int retention_time = g_pika_conf->log_retention_time();
+  if (retention_time <= 0) {
+    return;
+  }
+  std::vector<std::string> log_files;
+
+  if (!pstd::FileExists(log_path)) {
+    return;
+  }
+
+  if (pstd::GetChildren(log_path, log_files) != 0) {
+    return;
+  }
+
+  time_t t = time(nullptr);
+  struct tm* now = localtime(&t);
+  int now_year = now->tm_year + 1900;
+  int now_month = now->tm_mon + 1;
+  int now_day = now->tm_mday;
+
+  //logformat: pika.[hostname].[user name].log.[severity level].[date].[time].[pid]
+  for (const auto& file : log_files) {
+    if (file.substr(0, 5) != "pika.") {
+      continue;
+    }
+
+    size_t log_pos = file.find(".log.");
+    if (log_pos == std::string::npos) {
+      continue;
+    }
+
+    // Start at the end of ".log." to find the date and time
+    size_t date_pos = file.find('.', log_pos + 5);
+    if (date_pos == std::string::npos || date_pos + 16 > file.length()) {
+      continue;
+    }
+
+    std::string date = file.substr(date_pos + 1, 8);
+    std::string time = file.substr(date_pos + 10, 6);
+    
+    int log_year = std::atoi(date.substr(0, 4).c_str());
+    int log_month = std::atoi(date.substr(4, 2).c_str());
+    int log_day = std::atoi(date.substr(6, 2).c_str());
+
+    struct tm log_time;
+    struct tm now_time;
+
+    log_time.tm_year = log_year - 1900;
+    log_time.tm_mon = log_month - 1;
+    log_time.tm_mday = log_day;
+    log_time.tm_hour = 0;
+    log_time.tm_min = 0;
+    log_time.tm_sec = 0;
+
+    now_time.tm_year = now_year - 1900;
+    now_time.tm_mon = now_month - 1;
+    now_time.tm_mday = now_day;
+    now_time.tm_hour = 0;
+    now_time.tm_min = 0;
+    now_time.tm_sec = 0;
+
+    int64_t log_timestamp = mktime(&log_time);
+    int64_t now_timestamp = mktime(&now_time);
+    int64_t interval_days = (now_timestamp - log_timestamp) / 86400;
+
+    if (interval_days > retention_time) {
+      std::string log_file = log_path + "/" + file;
+      LOG(INFO) << "Deleting out of date log file: " << log_file;
+      pstd::DeleteFile(log_file);
+    }
+  }
+}
 
 void PikaServer::AutoDeleteExpiredDump() {
   std::string db_sync_prefix = g_pika_conf->bgsave_prefix();

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1280,7 +1280,9 @@ std::string log_path = g_pika_conf->log_path();
     if (interval_days > retention_time) {
       std::string log_file = log_path + "/" + file;
       LOG(INFO) << "Deleting out of date log file: " << log_file;
-      pstd::DeleteFile(log_file);
+      if (!pstd::DeleteFile(log_file)) {
+        LOG(ERROR) << "Failed to delete log file: " << log_file;
+      }
     }
   }
 }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1213,7 +1213,7 @@ void PikaServer::AutoBinlogPurge() { DoSameThingEveryDB(TaskType::kPurgeLog); }
 void PikaServer::AutoServerlogPurge() {
   std::string log_path = g_pika_conf->log_path();
   int retention_time = g_pika_conf->log_retention_time();
-  if (retention_time <= 0) {
+  if (retention_time < 0) {
     return;
   }
   std::vector<std::string> log_files;
@@ -1227,19 +1227,11 @@ void PikaServer::AutoServerlogPurge() {
   }
   //Get the current time of system
   time_t t = time(nullptr);
-  struct tm* now = localtime(&t);
-  int now_year = now->tm_year + 1900;
-  int now_month = now->tm_mon + 1;
-  int now_day = now->tm_mday;
-
-  struct tm now_time;
-  now_time.tm_year = now_year - 1900;
-  now_time.tm_mon = now_month - 1;
-  now_time.tm_mday = now_day;
-  now_time.tm_hour = 0;
-  now_time.tm_min = 0;
-  now_time.tm_sec = 0;
-  int64_t now_timestamp = mktime(&now_time);
+  struct tm* now_time = localtime(&t);
+  now_time->tm_hour = 0;
+  now_time->tm_min = 0;
+  now_time->tm_sec = 0;
+  time_t now_timestamp = mktime(now_time);
 
   std::map<std::string, std::vector<std::pair<std::string, int64_t>>> log_files_by_level;
 
@@ -1260,6 +1252,7 @@ void PikaServer::AutoServerlogPurge() {
     if (sscanf(file_parts[5].c_str(), "%4d%2d%2d", &log_year, &log_month, &log_day) != 3) {
       continue;
     }
+
     //Get the time when the server log file was originally created
     struct tm log_time;
     log_time.tm_year = log_year - 1900;
@@ -1268,10 +1261,10 @@ void PikaServer::AutoServerlogPurge() {
     log_time.tm_hour = 0;
     log_time.tm_min = 0;
     log_time.tm_sec = 0;
-
-    int64_t log_timestamp = mktime(&log_time);
+    log_time.tm_isdst = -1;
+    time_t log_timestamp = mktime(&log_time);
     log_files_by_level[severity_level].push_back({file, log_timestamp});
-  }
+}
 
   // Process files for each log level
   for (auto& [level, files] : log_files_by_level) {
@@ -1279,17 +1272,21 @@ void PikaServer::AutoServerlogPurge() {
     std::sort(files.begin(), files.end(),
               [](const auto& a, const auto& b) { return a.second > b.second; });
 
-    bool keep_newest = false;
+    bool has_recent_file = false;
     for (const auto& [file, log_timestamp] : files) {
-      int64_t interval_days = (now_timestamp - log_timestamp) / 86400;
-
-      if (interval_days > retention_time && keep_newest) {
-        std::string log_file = log_path + "/" + file;
-        LOG(INFO) << "Deleting out of date log file: " << log_file;
-        if(!pstd::DeleteFile(log_file)) LOG(ERROR) << "Failed to delete log file: " << log_file;
-      } else {
-        keep_newest = true;
+      double diff_seconds = difftime(now_timestamp, log_timestamp);
+      int64_t interval_days = static_cast<int64_t>(diff_seconds / 86400);
+      if (interval_days <= retention_time) {
+        has_recent_file = true;
+        continue;
       }
+      if (!has_recent_file) {
+        has_recent_file = true;
+        continue;
+      }
+      std::string log_file = log_path + "/" + file;
+      LOG(INFO) << "Deleting out of date log file: " << log_file;
+      if(!pstd::DeleteFile(log_file)) LOG(ERROR) << "Failed to delete log file: " << log_file;
     }
   }
 }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1085,10 +1085,8 @@ int PikaServer::ClientPubSubChannelPatternSize(const std::shared_ptr<NetConn>& c
 void PikaServer::DoTimingTask() {
   // Maybe schedule compactrange
   AutoCompactRange();
-  // Purge serverlog
-  AutoServerlogPurge();
-  // Purge binlog
-  AutoBinlogPurge();
+  // Purge log
+  AutoPurge();
   // Delete expired dump
   AutoDeleteExpiredDump();
   // Cheek Rsync Status
@@ -1208,82 +1206,7 @@ void PikaServer::AutoCompactRange() {
   }
 }
 
-void PikaServer::AutoBinlogPurge() { DoSameThingEveryDB(TaskType::kPurgeLog); }
-
-void PikaServer::AutoServerlogPurge(){
-std::string log_path = g_pika_conf->log_path();
-  int retention_time = g_pika_conf->log_retention_time();
-  if (retention_time <= 0) {
-    return;
-  }
-  std::vector<std::string> log_files;
-
-  if (!pstd::FileExists(log_path)) {
-    return;
-  }
-
-  if (pstd::GetChildren(log_path, log_files) != 0) {
-    return;
-  }
-
-  time_t t = time(nullptr);
-  struct tm* now = localtime(&t);
-  int now_year = now->tm_year + 1900;
-  int now_month = now->tm_mon + 1;
-  int now_day = now->tm_mday;
-
-  //logformat: pika.[hostname].[user name].log.[severity level].[date].[time].[pid]
-  for (const auto& file : log_files) {
-    if (file.substr(0, 5) != "pika.") {
-      continue;
-    }
-
-    size_t log_pos = file.find(".log.");
-    if (log_pos == std::string::npos) {
-      continue;
-    }
-
-    // Start at the end of ".log." to find the date and time
-    size_t date_pos = file.find('.', log_pos + 5);
-    if (date_pos == std::string::npos || date_pos + 16 > file.length()) {
-      continue;
-    }
-
-    std::string date = file.substr(date_pos + 1, 8);
-    std::string time = file.substr(date_pos + 10, 6);
-    
-    int log_year = std::atoi(date.substr(0, 4).c_str());
-    int log_month = std::atoi(date.substr(4, 2).c_str());
-    int log_day = std::atoi(date.substr(6, 2).c_str());
-
-    struct tm log_time;
-    struct tm now_time;
-
-    log_time.tm_year = log_year - 1900;
-    log_time.tm_mon = log_month - 1;
-    log_time.tm_mday = log_day;
-    log_time.tm_hour = 0;
-    log_time.tm_min = 0;
-    log_time.tm_sec = 0;
-
-    now_time.tm_year = now_year - 1900;
-    now_time.tm_mon = now_month - 1;
-    now_time.tm_mday = now_day;
-    now_time.tm_hour = 0;
-    now_time.tm_min = 0;
-    now_time.tm_sec = 0;
-
-    int64_t log_timestamp = mktime(&log_time);
-    int64_t now_timestamp = mktime(&now_time);
-    int64_t interval_days = (now_timestamp - log_timestamp) / 86400;
-
-    if (interval_days > retention_time) {
-      std::string log_file = log_path + "/" + file;
-      LOG(INFO) << "Deleting out of date log file: " << log_file;
-      pstd::DeleteFile(log_file);
-    }
-  }
-}
+void PikaServer::AutoPurge() { DoSameThingEveryDB(TaskType::kPurgeLog); }
 
 void PikaServer::AutoDeleteExpiredDump() {
   std::string db_sync_prefix = g_pika_conf->bgsave_prefix();


### PR DESCRIPTION
#2811 
Configure the log-retention-time field in pika.conf. Serverlogs that exceed this time period are cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a configuration option for log retention time, enhancing log management capabilities.
  - Added methods for targeted log purging, allowing more precise control over server and binlog file retention.

- **Bug Fixes**
  - Improved server performance with detailed log purging logic based on specified retention periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->