### PR TITLE
fix: execute hincrby cmd more than one times after delete a field which is existing

### DIFF
--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -308,7 +308,8 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
       batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       HashesDataKey hashes_data_key(key, version, field);
       Int64ToStr(value_buf, 32, value);
-      batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), value_buf);
+      BaseDataValue internal_value(value_buf);
+      batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
       *ret = value;
     } else {
       version = parsed_hashes_meta_value.Version();

--- a/tests/integration/hash_test.go
+++ b/tests/integration/hash_test.go
@@ -140,6 +140,27 @@ var _ = Describe("Hash Commands", func() {
 			Expect(hIncrBy.Val()).To(Equal(int64(-5)))
 		})
 
+		It("should HIncrBy against wrong metadata", func() {
+			hSet := client.HSet(ctx, "hash", "key", "5")
+			Expect(hSet.Err()).NotTo(HaveOccurred())
+
+			hIncrBy := client.HIncrBy(ctx, "hash", "key", 1)
+			Expect(hIncrBy.Err()).NotTo(HaveOccurred())
+			Expect(hIncrBy.Val()).To(Equal(int64(6)))
+			
+			hDel := client.HDel(ctx, "hash", "key")
+			Expect(hDel.Err()).NotTo(HaveOccurred())
+			Expect(hDel.Val()).To(Equal(int64(1)))
+
+			hIncrBy = client.HIncrBy(ctx, "hash", "key", 1)
+			Expect(hIncrBy.Err()).NotTo(HaveOccurred())
+			Expect(hIncrBy.Val()).To(Equal(int64(1)))
+
+			hIncrBy = client.HIncrBy(ctx, "hash", "key", 2)
+			Expect(hIncrBy.Err()).NotTo(HaveOccurred())
+			Expect(hIncrBy.Val()).To(Equal(int64(3)))
+		})
+
 		It("should HIncrByFloat", func() {
 			hSet := client.HSet(ctx, "hash", "field", "10.50")
 			Expect(hSet.Err()).NotTo(HaveOccurred())


### PR DESCRIPTION
fix: #2835 
![image](https://github.com/user-attachments/assets/11d9b004-df67-432f-a5a2-2941e13a6b09)
It can work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data processing in the Redis storage method, enhancing data integrity and consistency during storage operations.

- **Tests**
	- Added a new integration test for the `HIncrBy` command to verify its behavior with modified hash keys, improving test coverage for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->