### PR TITLE
fix: change storage ttl time from seconds to milliseconds 

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{ env.BUILD_TYPE }}
+        run: ctest -C ${{ env.BUILD_TYPE }} --verbose
 
       - name: Unit Test
         working-directory: ${{ github.workspace }}
@@ -64,6 +64,7 @@ jobs:
       - name: Start codis, pika master and pika slave
         working-directory: ${{ github.workspace }}/build
         run: |
+          echo "hello"
           chmod +x ../tests/integration/start_master_and_slave.sh
           ../tests/integration/start_master_and_slave.sh
           chmod +x ../tests/integration/start_codis.sh
@@ -177,7 +178,7 @@ jobs:
 
       - name: Test
         working-directory: ${{ github.workspace }}/build
-        run: ctest --rerun-failed --output-on-failure -C ${{ env.BUILD_TYPE }}
+        run: ctest -C ${{ env.BUILD_TYPE }} --verbose
 
       - name: Unit Test
         working-directory: ${{ github.workspace }}

--- a/include/pika_cache.h
+++ b/include/pika_cache.h
@@ -67,7 +67,7 @@ class PikaCache : public pstd::noncopyable, public std::enable_shared_from_this<
 
   rocksdb::Status Del(const std::vector<std::string>& keys);
   rocksdb::Status Expire(std::string& key, int64_t ttl);
-  rocksdb::Status Expireat(std::string& key, int64_t ttl);
+  rocksdb::Status Expireat(std::string& key, int64_t ttl_sec);
   rocksdb::Status TTL(std::string& key, int64_t* ttl);
   rocksdb::Status Persist(std::string& key);
   rocksdb::Status Type(std::string& key, std::string* value);

--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -36,12 +36,12 @@ class SetCmd : public Cmd {
   std::string value_;
   std::string target_;
   int32_t success_ = 0;
-  int64_t sec_ = 0;
+  int64_t ttl_millsec = 0;
   bool has_ttl_ = false;
   SetCmd::SetCondition condition_{kNONE};
   void DoInitial() override;
   void Clear() override {
-    sec_ = 0;
+    ttl_millsec = 0;
     success_ = 0;
     condition_ = kNONE;
   }
@@ -69,7 +69,7 @@ class GetCmd : public Cmd {
  private:
   std::string key_;
   std::string value_;
-  int64_t sec_ = 0;
+  int64_t ttl_millsec_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
 };
@@ -351,7 +351,7 @@ class SetexCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t sec_ = 0;
+  int64_t ttl_sec_ = 0;
   std::string value_;
   void DoInitial() override;
   rocksdb::Status s_;
@@ -376,7 +376,7 @@ class PsetexCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t usec_ = 0;
+  int64_t ttl_millsec = 0;
   std::string value_;
   void DoInitial() override;
   rocksdb::Status s_;
@@ -540,7 +540,7 @@ class StrlenCmd : public Cmd {
  private:
   std::string key_;
   std::string value_;
-  int64_t sec_ = 0;
+  int64_t ttl_millsec = 0;
   void DoInitial() override;
   rocksdb::Status s_;
 };
@@ -581,7 +581,7 @@ class ExpireCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t sec_ = 0;
+  int64_t ttl_sec_ = 0;
   void DoInitial() override;
   std::string ToRedisProtocol() override;
   rocksdb::Status s_;
@@ -605,7 +605,7 @@ class PexpireCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t msec_ = 0;
+  int64_t ttl_millsec = 0;
   void DoInitial() override;
   std::string ToRedisProtocol() override;
   rocksdb::Status s_;
@@ -629,7 +629,7 @@ class ExpireatCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t time_stamp_ = 0;
+  int64_t time_stamp_sec_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
 };
@@ -652,10 +652,9 @@ class PexpireatCmd : public Cmd {
 
  private:
   std::string key_;
-  int64_t time_stamp_ms_ = 0;
+  int64_t time_stamp_millsec_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
-  std::string ToRedisProtocol() override;
 };
 
 class TtlCmd : public Cmd {
@@ -810,9 +809,9 @@ class PKSetexAtCmd : public Cmd {
  private:
   std::string key_;
   std::string value_;
-  int64_t time_stamp_ = 0;
+  int64_t time_stamp_sec_ = 0;
   void DoInitial() override;
-  void Clear() override { time_stamp_ = 0; }
+  void Clear() override { time_stamp_sec_ = 0; }
   rocksdb::Status s_;
 };
 

--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -115,7 +115,7 @@ class IncrCmd : public Cmd {
   int64_t new_value_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
-  int64_t expired_timestamp_sec_ = 0;
+  int64_t expired_timestamp_millsec_ = 0;
   std::string ToRedisProtocol() override;
 };
 
@@ -140,7 +140,7 @@ class IncrbyCmd : public Cmd {
   int64_t by_ = 0, new_value_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
-  int64_t expired_timestamp_sec_ = 0;
+  int64_t expired_timestamp_millsec_ = 0;
   std::string ToRedisProtocol() override;
 };
 
@@ -165,7 +165,7 @@ class IncrbyfloatCmd : public Cmd {
   double by_ = 0;
   void DoInitial() override;
   rocksdb::Status s_;
-  int64_t expired_timestamp_sec_ = 0;
+  int64_t expired_timestamp_millsec_ = 0;
   std::string ToRedisProtocol() override;
 };
 
@@ -260,7 +260,7 @@ class AppendCmd : public Cmd {
   std::string new_value_;
   void DoInitial() override;
   rocksdb::Status s_;
-  int64_t expired_timestamp_sec_ = 0;
+  int64_t expired_timestamp_millsec_ = 0;
   std::string ToRedisProtocol() override;
 };
 

--- a/src/net/examples/performance/server.cc
+++ b/src/net/examples/performance/server.cc
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
 
   std::unique_ptr<ServerThread> st_thread(NewDispatchThread(ip, port, 24, &conn_factory, 1000));
   st_thread->StartThread();
-  uint64_t st, ed;
+  pstd::TimeType st, ed;
 
   while (!should_stop) {
     st = NowMicros();

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2765,8 +2765,8 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
                    "The rsync rate limit now is "
                 << new_throughput_limit << "(Which Is Around " << (new_throughput_limit >> 20) << " MB/s)";
     res_.AppendStringRaw("+OK\r\n");
-  } else if(set_item == "rsync-timeout-ms"){
-    if(pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0){
+  } else if (set_item == "rsync-timeout-ms") {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0) {
       res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'rsync-timeout-ms'\r\n");
       return;
     }
@@ -2961,9 +2961,9 @@ void DbsizeCmd::Do() {
   if (!dbs) {
     res_.SetRes(CmdRes::kInvalidDB);
   } else {
-    if (g_pika_conf->slotmigrate()){
+    if (g_pika_conf->slotmigrate()) {
       int64_t dbsize = 0;
-      for (int i = 0; i < g_pika_conf->default_slot_num(); ++i){
+      for (int i = 0; i < g_pika_conf->default_slot_num(); ++i) {
         int32_t card = 0;
         rocksdb::Status s = dbs->storage()->SCard(SlotKeyPrefix+std::to_string(i), &card);
         if (s.ok() && card >= 0) {

--- a/src/pika_bit.cc
+++ b/src/pika_bit.cc
@@ -114,7 +114,7 @@ void BitGetCmd::DoThroughDB() {
   Do();
 }
 
-void BitGetCmd::DoUpdateCache(){
+void BitGetCmd::DoUpdateCache() {
   if (s_.ok()) {
     db_->cache()->PushKeyToAsyncLoadQueue(PIKA_KEY_TYPE_KV, key_, db_);
   }

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -126,10 +126,10 @@ Status PikaCache::Expire(std::string& key, int64_t ttl) {
   return caches_[cache_index]->Expire(key, ttl);
 }
 
-Status PikaCache::Expireat(std::string& key, int64_t ttl) {
+Status PikaCache::Expireat(std::string& key, int64_t ttl_sec) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  return caches_[cache_index]->Expireat(key, ttl);
+  return caches_[cache_index]->Expireat(key, ttl_sec);
 }
 
 Status PikaCache::TTL(std::string& key, int64_t *ttl) {

--- a/src/pika_cache_load_thread.cc
+++ b/src/pika_cache_load_thread.cc
@@ -113,13 +113,13 @@ bool PikaCacheLoadThread::LoadSet(std::string& key, const std::shared_ptr<DB>& d
   }
 
   std::vector<std::string> values;
-  int64_t ttl = -1;
-  rocksdb::Status s = db->storage()->SMembersWithTTL(key, &values, &ttl);
+  int64_t ttl_millsec = -1;
+  rocksdb::Status s = db->storage()->SMembersWithTTL(key, &values, &ttl_millsec);
   if (!s.ok()) {
     LOG(WARNING) << "load set failed, key=" << key;
     return false;
   }
-  db->cache()->WriteSetToCache(key, values, ttl);
+  db->cache()->WriteSetToCache(key, values, ttl_millsec > 0 ? ttl_millsec / 1000 : ttl_millsec);
   return true;
 }
 

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -184,7 +184,7 @@ int PikaConf::Load() {
 
   std::string admin_cmd_list;
   GetConfStr("admin-cmd-list", &admin_cmd_list);
-  if (admin_cmd_list == ""){
+  if (admin_cmd_list == "") {
     admin_cmd_list = "info, monitor, ping";
     SetAdminCmd(admin_cmd_list);
   }
@@ -713,7 +713,7 @@ int PikaConf::Load() {
 
   int64_t tmp_rsync_timeout_ms = -1;
   GetConfInt64("rsync-timeout-ms", &tmp_rsync_timeout_ms);
-  if(tmp_rsync_timeout_ms <= 0){
+  if (tmp_rsync_timeout_ms <= 0) {
     rsync_timeout_ms_.store(1000);
   } else {
     rsync_timeout_ms_.store(tmp_rsync_timeout_ms);

--- a/src/pika_geo.cc
+++ b/src/pika_geo.cc
@@ -366,7 +366,7 @@ static void GetAllNeighbors(const std::shared_ptr<DB>& db, std::string& key, Geo
     int32_t count = 0;
     int32_t card = db->storage()->Exists({range.storekey});
     if (card) {
-      if (db->storage()->Del({range.storekey}) > 0){
+      if (db->storage()->Del({range.storekey}) > 0) {
         db->cache()->Del({range.storekey});
       }
     }

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -257,7 +257,7 @@ void IncrCmd::DoInitial() {
 }
 
 void IncrCmd::Do() {
-  s_ = db_->storage()->Incrby(key_, 1, &new_value_, &expired_timestamp_sec_);
+  s_ = db_->storage()->Incrby(key_, 1, &new_value_, &expired_timestamp_millsec_);
   if (s_.ok()) {
     res_.AppendContent(":" + std::to_string(new_value_));
     AddSlotKey("k", key_, db_);
@@ -296,7 +296,7 @@ std::string IncrCmd::ToRedisProtocol() {
   RedisAppendContent(content, key_);
   // time_stamp
   char buf[100];
-  auto time_stamp = expired_timestamp_sec_;
+  auto time_stamp = expired_timestamp_millsec_ > 0 ? expired_timestamp_millsec_ / 1000 : expired_timestamp_millsec_;
   pstd::ll2string(buf, sizeof(buf), time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");
@@ -321,7 +321,7 @@ void IncrbyCmd::DoInitial() {
 }
 
 void IncrbyCmd::Do() {
-  s_ = db_->storage()->Incrby(key_, by_, &new_value_, &expired_timestamp_sec_);
+  s_ = db_->storage()->Incrby(key_, by_, &new_value_, &expired_timestamp_millsec_);
   if (s_.ok()) {
     res_.AppendContent(":" + std::to_string(new_value_));
     AddSlotKey("k", key_, db_);
@@ -360,7 +360,7 @@ std::string IncrbyCmd::ToRedisProtocol() {
   RedisAppendContent(content, key_);
   // time_stamp
   char buf[100];
-  auto time_stamp = expired_timestamp_sec_;
+  auto time_stamp = expired_timestamp_millsec_ > 0 ? expired_timestamp_millsec_ / 1000 : expired_timestamp_millsec_;
   pstd::ll2string(buf, sizeof(buf), time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");
@@ -386,7 +386,7 @@ void IncrbyfloatCmd::DoInitial() {
 }
 
 void IncrbyfloatCmd::Do() {
-  s_ = db_->storage()->Incrbyfloat(key_, value_, &new_value_, &expired_timestamp_sec_);
+  s_ = db_->storage()->Incrbyfloat(key_, value_, &new_value_, &expired_timestamp_millsec_);
   if (s_.ok()) {
     res_.AppendStringLenUint64(new_value_.size());
     res_.AppendContent(new_value_);
@@ -429,7 +429,7 @@ std::string IncrbyfloatCmd::ToRedisProtocol() {
   RedisAppendContent(content, key_);
   // time_stamp
   char buf[100];
-  auto time_stamp = expired_timestamp_sec_;
+  auto time_stamp = expired_timestamp_millsec_ > 0 ? expired_timestamp_millsec_ / 1000 : expired_timestamp_millsec_;
   pstd::ll2string(buf, sizeof(buf), time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");
@@ -560,7 +560,7 @@ void AppendCmd::DoInitial() {
 
 void AppendCmd::Do() {
   int32_t new_len = 0;
-  s_ = db_->storage()->Append(key_, value_, &new_len, &expired_timestamp_sec_, new_value_);
+  s_ = db_->storage()->Append(key_, value_, &new_len, &expired_timestamp_millsec_, new_value_);
   if (s_.ok() || s_.IsNotFound()) {
     res_.AppendInteger(new_len);
     AddSlotKey("k", key_, db_);
@@ -595,7 +595,7 @@ std::string AppendCmd::ToRedisProtocol() {
   RedisAppendContent(content, key_);
   // time_stamp
   char buf[100];
-  auto time_stamp = expired_timestamp_sec_;
+  auto time_stamp = expired_timestamp_millsec_ > 0 ? expired_timestamp_millsec_ / 1000 : expired_timestamp_millsec_;
   pstd::ll2string(buf, sizeof(buf), time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");

--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -130,7 +130,7 @@ void LLenCmd::Do() {
 void LLenCmd::ReadCache() {
   uint64_t llen = 0;
   auto s = db_->cache()->LLen(key_, &llen);
-  if (s.ok()){
+  if (s.ok()) {
     res_.AppendInteger(llen);
   } else if (s.IsNotFound()) {
     res_.SetRes(CmdRes::kCacheMiss);

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -605,7 +605,7 @@ int32_t PikaServer::GetSlaveListString(std::string& slave_list_str) {
               master_boffset.offset - sent_slave_boffset.offset;
           tmp_stream << "(" << db->DBName() << ":" << lag << ")";
         }
-      } else if (s.ok() && slave_state == SlaveState::kSlaveDbSync){
+      } else if (s.ok() && slave_state == SlaveState::kSlaveDbSync) {
         tmp_stream << "(" << db->DBName() << ":full syncing)";
       } else {
         tmp_stream << "(" << db->DBName() << ":not syncing)";
@@ -1585,7 +1585,7 @@ void DoBgslotsreload(void* arg) {
   rocksdb::Status s;
   std::vector<std::string> keys;
   int64_t cursor_ret = -1;
-  while(cursor_ret != 0 && p->GetSlotsreloading()){
+  while(cursor_ret != 0 && p->GetSlotsreloading()) {
     cursor_ret = reload.db->storage()->Scan(storage::DataType::kAll, reload.cursor, reload.pattern, reload.count, &keys);
 
     std::vector<std::string>::const_iterator iter;
@@ -1593,8 +1593,8 @@ void DoBgslotsreload(void* arg) {
       std::string key_type;
       int s = GetKeyType(*iter, key_type, reload.db);
       //if key is slotkey, can't add to SlotKey
-      if (s > 0){
-        if (key_type == "s" && ((*iter).find(SlotKeyPrefix) != std::string::npos || (*iter).find(SlotTagPrefix) != std::string::npos)){
+      if (s > 0) {
+        if (key_type == "s" && ((*iter).find(SlotKeyPrefix) != std::string::npos || (*iter).find(SlotTagPrefix) != std::string::npos)) {
           continue;
         }
 
@@ -1703,7 +1703,7 @@ void DoBgslotscleanup(void* arg) {
   std::vector<std::string> keys;
   int64_t cursor_ret = -1;
   std::vector<int> cleanupSlots(cleanup.cleanup_slots);
-  while (cursor_ret != 0 && p->GetSlotscleaningup()){
+  while (cursor_ret != 0 && p->GetSlotscleaningup()) {
     cursor_ret = g_pika_server->bgslots_cleanup_.db->storage()->Scan(storage::DataType::kAll, cleanup.cursor, cleanup.pattern, cleanup.count, &keys);
 
     std::string key_type;
@@ -1712,12 +1712,12 @@ void DoBgslotscleanup(void* arg) {
       if ((*iter).find(SlotKeyPrefix) != std::string::npos || (*iter).find(SlotTagPrefix) != std::string::npos) {
         continue;
       }
-      if (std::find(cleanupSlots.begin(), cleanupSlots.end(), GetSlotID(g_pika_conf->default_slot_num(), *iter)) != cleanupSlots.end()){
+      if (std::find(cleanupSlots.begin(), cleanupSlots.end(), GetSlotID(g_pika_conf->default_slot_num(), *iter)) != cleanupSlots.end()) {
         if (GetKeyType(*iter, key_type, g_pika_server->bgslots_cleanup_.db) <= 0) {
           LOG(WARNING) << "slots clean get key type for slot " << GetSlotID(g_pika_conf->default_slot_num(), *iter) << " key " << *iter << " error";
           continue;
         }
-        if (DeleteKey(*iter, key_type[0], g_pika_server->bgslots_cleanup_.db) <= 0){
+        if (DeleteKey(*iter, key_type[0], g_pika_server->bgslots_cleanup_.db) <= 0) {
           LOG(WARNING) << "slots clean del for slot " << GetSlotID(g_pika_conf->default_slot_num(), *iter) << " key "<< *iter << " error";
         }
       }
@@ -1728,7 +1728,7 @@ void DoBgslotscleanup(void* arg) {
     keys.clear();
   }
 
-  for (int cleanupSlot : cleanupSlots){
+  for (int cleanupSlot : cleanupSlots) {
     WriteDelKeyToBinlog(GetSlotKey(cleanupSlot), g_pika_server->bgslots_cleanup_.db);
     WriteDelKeyToBinlog(GetSlotsTagKey(cleanupSlot), g_pika_server->bgslots_cleanup_.db);
   }

--- a/src/pika_zset.cc
+++ b/src/pika_zset.cc
@@ -77,7 +77,7 @@ void ZCardCmd::Do() {
   }
 }
 
-void ZCardCmd::ReadCache(){
+void ZCardCmd::ReadCache() {
   res_.SetRes(CmdRes::kCacheMiss);
 }
 
@@ -590,7 +590,7 @@ void ZRevrangebyscoreCmd::Do() {
   }
 }
 
-void ZRevrangebyscoreCmd::ReadCache(){
+void ZRevrangebyscoreCmd::ReadCache() {
   if (min_score_ == storage::ZSET_SCORE_MAX || max_score_ == storage::ZSET_SCORE_MIN
       || max_score_ < min_score_) {
     res_.AppendContent("*0");
@@ -827,7 +827,7 @@ void ZUnionstoreCmd::DoBinlog() {
   del_cmd->SetResp(resp_.lock());
   del_cmd->DoBinlog();
 
-  if(value_to_dest_.empty()){
+  if (value_to_dest_.empty()) {
     // The union operation got an empty set, only use del to simulate overwrite the dest_key with empty set
     return;
   }
@@ -975,7 +975,7 @@ void ZRankCmd::ReadCache() {
   auto s = db_->cache()->ZRank(key_, member_, &rank, db_);
   if (s.ok()) {
     res_.AppendInteger(rank);
-  } else if (s.IsNotFound()){
+  } else if (s.IsNotFound()) {
     res_.SetRes(CmdRes::kCacheMiss);
   }  else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
@@ -1020,7 +1020,7 @@ void ZRevrankCmd::ReadCache() {
   auto s = db_->cache()->ZRevrank(key_, member_, &revrank, db_);
   if (s.ok()) {
     res_.AppendInteger(revrank);
-  } else if (s.IsNotFound()){
+  } else if (s.IsNotFound()) {
     res_.SetRes(CmdRes::kCacheMiss);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());

--- a/src/pstd/include/env.h
+++ b/src/pstd/include/env.h
@@ -17,6 +17,8 @@ class SequentialFile;
 class RWFile;
 class RandomRWFile;
 
+using TimeType = uint64_t;
+
 /*
  *  Set the resource limits of a process
  */
@@ -61,7 +63,10 @@ class FileLock : public pstd::noncopyable {
 int GetChildren(const std::string& dir, std::vector<std::string>& result);
 void GetDescendant(const std::string& dir, std::vector<std::string>& result);
 
-uint64_t NowMicros();
+TimeType NowMicros();
+
+TimeType NowMillis();
+
 void SleepForMicroseconds(int micros);
 
 Status NewSequentialFile(const std::string& fname, std::unique_ptr<SequentialFile>& result);

--- a/src/pstd/src/env.cc
+++ b/src/pstd/src/env.cc
@@ -217,9 +217,14 @@ uint64_t Du(const std::string& path) {
   return sum;
 }
 
-uint64_t NowMicros() {
+TimeType NowMicros() {
   auto now = std::chrono::system_clock::now();
   return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+}
+
+TimeType NowMillis() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 }
 
 void SleepForMicroseconds(int micros) { std::this_thread::sleep_for(std::chrono::microseconds(micros)); }

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -105,8 +105,8 @@ struct KeyInfo {
 struct ValueStatus {
   std::string value;
   Status status;
-  int64_t  ttl;
-  bool operator==(const ValueStatus& vs) const { return (vs.value == value && vs.status == status && vs.ttl == ttl); }
+  int64_t ttl_millsec;
+  bool operator==(const ValueStatus& vs) const { return (vs.value == value && vs.status == status && vs.ttl_millsec == ttl_millsec); }
 };
 
 struct FieldValue {
@@ -190,7 +190,7 @@ class Storage {
   Status Set(const Slice& key, const Slice& value);
 
   // Set key to hold the string value. if key exist
-  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
+  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
 
   // Get the value of key. If the key does not exist
   // the special value nil is returned
@@ -198,7 +198,7 @@ class Storage {
 
   // Get the value and ttl of key. If the key does not exist
   // the special value nil is returned. If the key has no ttl, ttl is -1
-  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
+  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
 
   // Atomically sets key to value and returns the old value stored at key
   // Returns an error when key exists but does not hold a string value.
@@ -227,7 +227,7 @@ class Storage {
   // Set key to hold string value if key does not exist
   // return 1 if the key was set
   // return 0 if the key was not set
-  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
+  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
 
   // Sets the given keys to their respective values.
   // MSETNX will not perform any operation at all even
@@ -238,7 +238,7 @@ class Storage {
   // return 1 if the key currently hold the give value And override success
   // return 0 if the key doesn't exist And override fail
   // return -1 if the key currently does not hold the given value And override fail
-  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl = 0);
+  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl_millsec = 0);
 
   // delete the key that holds a given value
   // return 1 if the key currently hold the give value And delete success
@@ -255,7 +255,7 @@ class Storage {
   Status Getrange(const Slice& key, int64_t start_offset, int64_t end_offset, std::string* ret);
 
   Status GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
-                           std::string* ret, std::string* value, int64_t* ttl);
+                           std::string* ret, std::string* value, int64_t* ttl_millsec);
 
   // If key already exists and is a string, this command appends the value at
   // the end of the string
@@ -293,7 +293,7 @@ class Storage {
 
   // Set key to hold the string value and set key to timeout after a given
   // number of seconds
-  Status Setex(const Slice& key, const Slice& value, int64_t ttl);
+  Status Setex(const Slice& key, const Slice& value, int64_t ttl_millsec);
 
   // Returns the length of the string value stored at key. An error
   // is returned when key holds a non-string value.
@@ -303,7 +303,7 @@ class Storage {
   // specifying the number of seconds representing the TTL (time to live), it
   // takes an absolute Unix timestamp (seconds since January 1, 1970). A
   // timestamp in the past will delete the key immediately.
-  Status PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp);
+  Status PKSetexAt(const Slice& key, const Slice& value, int64_t time_stamp_millsec_);
 
   // Hashes Commands
 
@@ -334,7 +334,7 @@ class Storage {
   // reply is twice the size of the hash.
   Status HGetall(const Slice& key, std::vector<FieldValue>* fvs);
 
-  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl);
+  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl_millsec);
 
   // Returns all field names in the hash stored at key.
   Status HKeys(const Slice& key, std::vector<std::string>* fields);
@@ -467,7 +467,7 @@ class Storage {
   // This has the same effect as running SINTER with one argument key.
   Status SMembers(const Slice& key, std::vector<std::string>* members);
 
-  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t *ttl);
+  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t * ttl_millsec);
 
   // Remove the specified members from the set stored at key. Specified members
   // that are not a member of this set are ignored. If key does not exist, it is
@@ -540,7 +540,7 @@ class Storage {
   // (the head of the list), 1 being the next element and so on.
   Status LRange(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret);
 
-  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t *ttl);
+  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t * ttl_millsec);
 
   // Removes the first count occurrences of elements equal to value from the
   // list stored at key. The count argument influences the operation in the
@@ -703,7 +703,7 @@ class Storage {
   Status ZRange(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members);
 
   Status ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members,
-                                int64_t *ttl);
+                                int64_t * ttl_millsec);
 
   // Returns all the elements in the sorted set at key with a score between min
   // and max (including elements with score equal to min or max). The elements
@@ -957,10 +957,10 @@ class Storage {
   // While any error happens, you need to check type_status for
   // the error message
 
-  // Set a timeout on key
+  // Set a timeout on key, milliseconds unit
   // return -1 operation exception errors happen in database
   // return >=0 success
-  int32_t Expire(const Slice& key, int64_t ttl);
+  int32_t Expire(const Slice& key, int64_t ttl_millsec);
 
   // Removes the specified keys
   // return -1 operation exception errors happen in database
@@ -1005,12 +1005,12 @@ class Storage {
 
   // EXPIREAT has the same effect and semantic as EXPIRE, but instead of
   // specifying the number of seconds representing the TTL (time to live), it
-  // takes an absolute Unix timestamp (seconds since January 1, 1970). A
+  // takes an absolute Unix timestamp (milliseconds since January 1, 1970). A
   // timestamp in the past will delete the key immediately.
   // return -1 operation exception errors happen in database
   // return 0 if key does not exist
   // return >=1 if the timueout was set
-  int32_t Expireat(const Slice& key, int64_t timestamp);
+  int32_t Expireat(const Slice& key, int64_t timestamp_millsec);
 
   // Remove the existing timeout on key, turning the key from volatile (a key
   // with an expire set) to persistent (a key that will never expire as no
@@ -1026,6 +1026,13 @@ class Storage {
   // return -1 if the key exists but has not associated expire
   // return > 0 TTL in seconds
   int64_t TTL(const Slice& key);
+
+  // Returns the remaining time to live of a key that has a timeout.
+  // return -3 operation exception errors happen in database
+  // return -2 if the key does not exist
+  // return -1 if the key exists but has not associated expire
+  // return > 0 TTL in milliseconds
+  int64_t PTTL(const Slice& key);
 
   // Reutrns the data all type of the key
   // if single is true, the query will return the first one
@@ -1115,7 +1122,7 @@ class Storage {
 
   // For scan keys in data base
   std::atomic<bool> scan_keynum_exit_ = {false};
-  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
+  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
 };
 
 }  //  namespace storage

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -260,7 +260,7 @@ class Storage {
   // If key already exists and is a string, this command appends the value at
   // the end of the string
   // return the length of the string after the append operation
-  Status Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_sec, std::string& out_new_value);
+  Status Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_millsec, std::string& out_new_value);
 
   // Count the number of set bits (population counting) in a string.
   // return the number of bits set to 1
@@ -285,7 +285,7 @@ class Storage {
 
   // Increments the number stored at key by increment.
   // If the key does not exist, it is set to 0 before performing the operation
-  Status Incrby(const Slice& key, int64_t value, int64_t* ret, int64_t* expired_timestamp_sec);
+  Status Incrby(const Slice& key, int64_t value, int64_t* ret, int64_t* expired_timestamp_millsec);
 
   // Increment the string representing a floating point number
   // stored at key by the specified increment.

--- a/src/storage/src/base_data_value_format.h
+++ b/src/storage/src/base_data_value_format.h
@@ -40,7 +40,8 @@ public:
     dst += user_value_.size();
     memcpy(dst, reserve_, kSuffixReserveLength);
     dst += kSuffixReserveLength;
-    EncodeFixed64(dst, ctime_);
+    uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
+    EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
     return rocksdb::Slice(start_pos, needed);
   }
@@ -58,7 +59,8 @@ public:
     if (value_->size() >= kBaseDataValueSuffixLength) {
       user_value_ = rocksdb::Slice(value_->data(), value_->size() - kBaseDataValueSuffixLength);
       memcpy(reserve_, value_->data() + user_value_.size(), kSuffixReserveLength);
-      ctime_ = DecodeFixed64(value_->data() + user_value_.size() + kSuffixReserveLength);
+      uint64_t ctime = DecodeFixed64(value_->data() + user_value_.size() + kSuffixReserveLength);
+      ctime_ = (ctime & ~(1ULL << 63));
     }
   }
 
@@ -70,7 +72,8 @@ public:
     if (value.size() >= kBaseDataValueSuffixLength) {
       user_value_ = rocksdb::Slice(value.data(), value.size() - kBaseDataValueSuffixLength);
       memcpy(reserve_, value.data() + user_value_.size(), kSuffixReserveLength);
-      ctime_ = DecodeFixed64(value.data() + user_value_.size() + kSuffixReserveLength);
+      uint64_t ctime = DecodeFixed64(value.data() + user_value_.size() + kSuffixReserveLength);
+      ctime_ = (ctime & ~(1ULL << 63));
     }
   }
 
@@ -81,7 +84,8 @@ public:
   void SetCtimeToValue() override {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() - kTimestampLength;
-      EncodeFixed64(dst, ctime_);
+      uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
+      EncodeFixed64(dst, ctime);
     }
   }
 

--- a/src/storage/src/base_filter.h
+++ b/src/storage/src/base_filter.h
@@ -28,9 +28,7 @@ class BaseMetaFilter : public rocksdb::CompactionFilter {
   BaseMetaFilter() = default;
   bool Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value, std::string* new_value,
               bool* value_changed) const override {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
-    auto cur_time = static_cast<uint64_t>(unix_time);
+    auto cur_time = pstd::NowMillis();
     /*
      * For the filtering of meta information, because the field designs of string
      * and list are different, their filtering policies are written separately.
@@ -181,9 +179,8 @@ class BaseDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
-    if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
+    pstd::TimeType unix_time = pstd::NowMillis();
+    if (cur_meta_etime_ != 0 && cur_meta_etime_ < unix_time) {
       TRACE("Drop[Timeout]");
       return true;
     }

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -51,7 +51,7 @@ public:
   }
   void SetEtime(uint64_t etime = 0) { etime_ = etime; }
   void setCtime(uint64_t ctime) { ctime_ = ctime; }
-  rocksdb::Status SetRelativeTimeByMillsec(int64_t ttl_millsec) {
+  rocksdb::Status SetRelativeTimeInMillsec(int64_t ttl_millsec) {
     pstd::TimeType unix_time = pstd::NowMillis();
     etime_ = unix_time + ttl_millsec;
     return rocksdb::Status::OK();

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -41,7 +41,7 @@ constexpr char DataTypeToTag(DataType type) {
 class InternalValue {
 public:
  explicit InternalValue(DataType type, const rocksdb::Slice& user_value) : type_(type), user_value_(user_value) {
-   ctime_ = pstd::NowMicros() / 1e6;
+   ctime_ = pstd::NowMillis();
  }
 
  virtual ~InternalValue() {
@@ -51,10 +51,9 @@ public:
   }
   void SetEtime(uint64_t etime = 0) { etime_ = etime; }
   void setCtime(uint64_t ctime) { ctime_ = ctime; }
-  rocksdb::Status SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
-    etime_ = uint64_t(unix_time + ttl);
+  rocksdb::Status SetRelativeTimeByMillsec(int64_t ttl_millsec) {
+    pstd::TimeType unix_time = pstd::NowMillis();
+    etime_ = unix_time + ttl_millsec;
     return rocksdb::Status::OK();
   }
   void SetVersion(uint64_t version = 0) { version_ = version; }
@@ -122,10 +121,9 @@ public:
     SetCtimeToValue();
   }
 
-  void SetRelativeTimestamp(int64_t ttl) {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
-    etime_ = unix_time + ttl;
+  void SetRelativeTimestamp(int64_t ttl_millsec) {
+    pstd::TimeType unix_time = pstd::NowMillis();
+    etime_ = unix_time + ttl_millsec;
     SetEtimeToValue();
   }
 
@@ -135,8 +133,7 @@ public:
     if (etime_ == 0) {
       return false;
     }
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    pstd::TimeType unix_time = pstd::NowMillis();
     return etime_ < unix_time;
   }
 

--- a/src/storage/src/lists_filter.h
+++ b/src/storage/src/lists_filter.h
@@ -88,8 +88,7 @@ class ListsDataFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    pstd::TimeType unix_time = pstd::NowMillis();
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -117,11 +117,11 @@ class Redis {
   Status ScanStreamsKeyNum(KeyInfo* key_info);
 
   // Keys Commands
-  virtual Status StringsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status HashesExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status ZsetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
-  virtual Status SetsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta = {});
+  virtual Status StringsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status HashesExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ListsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ZsetsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status SetsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta = {});
 
   virtual Status StringsDel(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status HashesDel(const Slice& key, std::string&& prefetch_meta = {});
@@ -130,11 +130,11 @@ class Redis {
   virtual Status SetsDel(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status StreamsDel(const Slice& key, std::string&& prefetch_meta = {});
 
-  virtual Status StringsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status HashesExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status ListsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status SetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
-  virtual Status ZsetsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta = {});
+  virtual Status StringsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status HashesExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status ListsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status SetsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
+  virtual Status ZsetsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta = {});
 
   virtual Status StringsPersist(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status HashesPersist(const Slice& key, std::string&& prefetch_meta = {});
@@ -142,11 +142,11 @@ class Redis {
   virtual Status ZsetsPersist(const Slice& key, std::string&& prefetch_meta = {});
   virtual Status SetsPersist(const Slice& key, std::string&& prefetch_meta = {});
 
-  virtual Status StringsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status HashesTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status ZsetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
-  virtual Status SetsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta = {});
+  virtual Status StringsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status HashesTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ListsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status ZsetsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
+  virtual Status SetsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
 
   // Strings Commands
   Status Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_sec, std::string& out_new_value);
@@ -156,12 +156,12 @@ class Redis {
   Status Get(const Slice& key, std::string* value);
   Status HyperloglogGet(const Slice& key, std::string* value);
   Status MGet(const Slice& key, std::string* value);
-  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
-  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl);
+  Status GetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
+  Status MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec);
   Status GetBit(const Slice& key, int64_t offset, int32_t* ret);
   Status Getrange(const Slice& key, int64_t start_offset, int64_t end_offset, std::string* ret);
   Status GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
-                           std::string* ret, std::string* value, int64_t* ttl);
+                           std::string* ret, std::string* value, int64_t* ttl_millsec);
   Status GetSet(const Slice& key, const Slice& value, std::string* old_value);
   Status Incrby(const Slice& key, int64_t value, int64_t* ret, int64_t* expired_timestamp_sec);
   Status Incrbyfloat(const Slice& key, const Slice& value, std::string* ret, int64_t* expired_timestamp_sec);
@@ -169,11 +169,11 @@ class Redis {
   Status MSetnx(const std::vector<KeyValue>& kvs, int32_t* ret);
   Status Set(const Slice& key, const Slice& value);
   Status HyperloglogSet(const Slice& key, const Slice& value);
-  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
+  Status Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
   Status SetBit(const Slice& key, int64_t offset, int32_t value, int32_t* ret);
-  Status Setex(const Slice& key, const Slice& value, int64_t ttl);
-  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl = 0);
-  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl = 0);
+  Status Setex(const Slice& key, const Slice& value, int64_t ttl_millsec);
+  Status Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec = 0);
+  Status Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl_millsec = 0);
   Status Delvx(const Slice& key, const Slice& value, int32_t* ret);
   Status Setrange(const Slice& key, int64_t start_offset, const Slice& value, int32_t* ret);
   Status Strlen(const Slice& key, int32_t* len);
@@ -181,14 +181,14 @@ class Redis {
   Status BitPos(const Slice& key, int32_t bit, int64_t* ret);
   Status BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_t* ret);
   Status BitPos(const Slice& key, int32_t bit, int64_t start_offset, int64_t end_offset, int64_t* ret);
-  Status PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp);
+  Status PKSetexAt(const Slice& key, const Slice& value, int64_t time_stamp_millsec_);
 
   Status Exists(const Slice& key);
   Status Del(const Slice& key);
-  Status Expire(const Slice& key, int64_t timestamp);
-  Status Expireat(const Slice& key, int64_t timestamp);
+  Status Expire(const Slice& key, int64_t ttl_millsec);
+  Status Expireat(const Slice& key, int64_t timestamp_millsec);
   Status Persist(const Slice& key);
-  Status TTL(const Slice& key, int64_t* timestamp);
+  Status TTL(const Slice& key, int64_t* ttl_millsec);
   Status PKPatternMatchDelWithRemoveKeys(const std::string& pattern, int64_t* ret, std::vector<std::string>* remove_keys, const int64_t& max_count);
 
   Status GetType(const Slice& key, enum DataType& type);
@@ -198,7 +198,7 @@ class Redis {
   Status HExists(const Slice& key, const Slice& field);
   Status HGet(const Slice& key, const Slice& field, std::string* value);
   Status HGetall(const Slice& key, std::vector<FieldValue>* fvs);
-  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl);
+  Status HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl_millsec);
   Status HIncrby(const Slice& key, const Slice& field, int64_t value, int64_t* ret);
   Status HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by, std::string* new_value);
   Status HKeys(const Slice& key, std::vector<std::string>* fields);
@@ -255,7 +255,7 @@ class Redis {
   Status SInterstore(const Slice& destination, const std::vector<std::string>& keys, std::vector<std::string>& value_to_dest, int32_t* ret);
   Status SIsmember(const Slice& key, const Slice& member, int32_t* ret);
   Status SMembers(const Slice& key, std::vector<std::string>* members);
-  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t* ttl);
+  Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t* ttl_millsec);
   Status SMove(const Slice& source, const Slice& destination, const Slice& member, int32_t* ret);
   Status SPop(const Slice& key, std::vector<std::string>* members, int64_t cnt);
   Status SRandmember(const Slice& key, int32_t count, std::vector<std::string>* members);
@@ -276,7 +276,7 @@ class Redis {
   Status LPush(const Slice& key, const std::vector<std::string>& values, uint64_t* ret);
   Status LPushx(const Slice& key, const std::vector<std::string>& values, uint64_t* len);
   Status LRange(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret);
-  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t* ttl);
+  Status LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t* ttl_millsec);
   Status LRem(const Slice& key, int64_t count, const Slice& value, uint64_t* ret);
   Status LSet(const Slice& key, int64_t index, const Slice& value);
   Status LTrim(const Slice& key, int64_t start, int64_t stop);
@@ -291,7 +291,7 @@ class Redis {
   Status ZCount(const Slice& key, double min, double max, bool left_close, bool right_close, int32_t* ret);
   Status ZIncrby(const Slice& key, const Slice& member, double increment, double* ret);
   Status ZRange(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members);
-  Status ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members, int64_t* ttl);
+  Status ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members, int64_t* ttl_millsec);
   Status ZRangebyscore(const Slice& key, double min, double max, bool left_close, bool right_close, int64_t count,
                        int64_t offset, std::vector<ScoreMember>* score_members);
   Status ZRank(const Slice& key, const Slice& member, int32_t* rank);

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -149,7 +149,7 @@ class Redis {
   virtual Status SetsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta = {});
 
   // Strings Commands
-  Status Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_sec, std::string& out_new_value);
+  Status Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_millsec, std::string& out_new_value);
   Status BitCount(const Slice& key, int64_t start_offset, int64_t end_offset, int32_t* ret, bool have_range);
   Status BitOp(BitOpType op, const std::string& dest_key, const std::vector<std::string>& src_keys, std::string &value_to_dest, int64_t* ret);
   Status Decrby(const Slice& key, int64_t value, int64_t* ret);
@@ -163,7 +163,7 @@ class Redis {
   Status GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
                            std::string* ret, std::string* value, int64_t* ttl_millsec);
   Status GetSet(const Slice& key, const Slice& value, std::string* old_value);
-  Status Incrby(const Slice& key, int64_t value, int64_t* ret, int64_t* expired_timestamp_sec);
+  Status Incrby(const Slice& key, int64_t value, int64_t* ret, int64_t* expired_timestamp_millsec);
   Status Incrbyfloat(const Slice& key, const Slice& value, std::string* ret, int64_t* expired_timestamp_sec);
   Status MSet(const std::vector<KeyValue>& kvs);
   Status MSetnx(const std::vector<KeyValue>& kvs, int32_t* ret);

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -30,8 +30,7 @@ Status Redis::ScanListsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
+  pstd::TimeType curtime = pstd::NowMillis();
 
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
@@ -471,7 +470,7 @@ Status Redis::LRange(const Slice& key, int64_t start, int64_t stop, std::vector<
   }
 }
 
-Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t* ttl) {
+Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t* ttl_millsec) {
   rocksdb::ReadOptions read_options;
   const rocksdb::Snapshot* snapshot;
 
@@ -499,13 +498,12 @@ Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::
       return Status::NotFound("Stale");
     } else {
       // ttl
-      *ttl = parsed_lists_meta_value.Etime();
-      if (*ttl == 0) {
-        *ttl = -1;
+      *ttl_millsec = parsed_lists_meta_value.Etime();
+      if (*ttl_millsec == 0) {
+        *ttl_millsec = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
-        *ttl = *ttl - curtime >= 0 ? *ttl - curtime : -2;
+        pstd::TimeType curtime = pstd::NowMillis();
+        *ttl_millsec = *ttl_millsec - curtime >= 0 ? *ttl_millsec - curtime : -2;
       }
 
       uint64_t version = parsed_lists_meta_value.Version();
@@ -1097,7 +1095,7 @@ Status Redis::RPushx(const Slice& key, const std::vector<std::string>& values, u
   return s;
 }
 
-Status Redis::ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_meta) {
+Status Redis::ListsExpire(const Slice& key, int64_t ttl_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1126,8 +1124,8 @@ Status Redis::ListsExpire(const Slice& key, int64_t ttl, std::string&& prefetch_
       return Status::NotFound();
     }
 
-    if (ttl > 0) {
-      parsed_lists_meta_value.SetRelativeTimestamp(ttl);
+    if (ttl_millsec > 0) {
+      parsed_lists_meta_value.SetRelativeTimestamp(ttl_millsec);
       s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     } else {
       parsed_lists_meta_value.InitialMetaValue();
@@ -1174,7 +1172,7 @@ Status Redis::ListsDel(const Slice& key, std::string&& prefetch_meta) {
   return s;
 }
 
-Status Redis::ListsExpireat(const Slice& key, int64_t timestamp, std::string&& prefetch_meta) {
+Status Redis::ListsExpireat(const Slice& key, int64_t timestamp_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
@@ -1202,8 +1200,8 @@ Status Redis::ListsExpireat(const Slice& key, int64_t timestamp, std::string&& p
     } else if (parsed_lists_meta_value.Count() == 0) {
       return Status::NotFound();
     } else {
-      if (timestamp > 0) {
-        parsed_lists_meta_value.SetEtime(static_cast<uint64_t>(timestamp));
+      if (timestamp_millsec > 0) {
+        parsed_lists_meta_value.SetEtime(static_cast<uint64_t>(timestamp_millsec));
       } else {
         parsed_lists_meta_value.InitialMetaValue();
       }
@@ -1253,7 +1251,7 @@ Status Redis::ListsPersist(const Slice& key, std::string&& prefetch_meta) {
   return s;
 }
 
-Status Redis::ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefetch_meta) {
+Status Redis::ListsTTL(const Slice& key, int64_t* ttl_millsec, std::string&& prefetch_meta) {
   std::string meta_value(std::move(prefetch_meta));
   BaseMetaKey base_meta_key(key);
   Status s;
@@ -1276,24 +1274,23 @@ Status Redis::ListsTTL(const Slice& key, int64_t* timestamp, std::string&& prefe
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
-      *timestamp = -2;
+      *ttl_millsec = -2;
       return Status::NotFound("Stale");
     } else if (parsed_lists_meta_value.Count() == 0) {
-      *timestamp = -2;
+      *ttl_millsec = -2;
       return Status::NotFound();
     } else {
       // Return -1 for lists with no set expiration, and calculate remaining time for others
-      *timestamp = parsed_lists_meta_value.Etime();
-      if (*timestamp == 0) {
-        *timestamp = -1;
+      *ttl_millsec = parsed_lists_meta_value.Etime();
+      if (*ttl_millsec == 0) {
+        *ttl_millsec = -1;
       } else {
-        int64_t curtime;
-        rocksdb::Env::Default()->GetCurrentTime(&curtime);
-        *timestamp = *timestamp - curtime >= 0 ? *timestamp - curtime : -2;
+        pstd::TimeType curtime = pstd::NowMillis();
+        *ttl_millsec = *ttl_millsec - curtime >= 0 ? *ttl_millsec - curtime : -2;
       }
     }
   } else if (s.IsNotFound()) {
-    *timestamp = -2;
+    *ttl_millsec = -2;
   }
   return s;
 }

--- a/src/storage/src/redis_streams.cc
+++ b/src/storage/src/redis_streams.cc
@@ -338,9 +338,6 @@ Status Redis::ScanStreamsKeyNum(KeyInfo* key_info) {
   iterator_options.snapshot = snapshot;
   iterator_options.fill_cache = false;
 
-  int64_t curtime;
-  rocksdb::Env::Default()->GetCurrentTime(&curtime);
-
   rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     if (!ExpectedMetaValue(DataType::kStreams, iter->value().ToString())) {

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -811,7 +811,7 @@ Status Redis::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t 
   } else {
     *ret = 1;
     if (ttl_millsec > 0) {
-      strings_value.SetRelativeTimeByMillsec(ttl_millsec);
+      strings_value.SetRelativeTimeInMillsec(ttl_millsec);
     }
     return db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
   }
@@ -881,7 +881,7 @@ Status Redis::Setex(const Slice& key, const Slice& value, int64_t ttl_millsec) {
     return Status::InvalidArgument("invalid expire time");
   }
   StringsValue strings_value(value);
-  auto s = strings_value.SetRelativeTimeByMillsec(ttl_millsec);
+  auto s = strings_value.SetRelativeTimeInMillsec(ttl_millsec);
   if (s != Status::OK()) {
     return s;
   }
@@ -909,7 +909,7 @@ Status Redis::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t 
 
   StringsValue strings_value(value);
   if (ttl_millsec > 0) {
-    strings_value.SetRelativeTimeByMillsec(ttl_millsec);
+    strings_value.SetRelativeTimeInMillsec(ttl_millsec);
   }
   s = db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
   if (s.ok()) {
@@ -944,7 +944,7 @@ Status Redis::Setvx(const Slice& key, const Slice& value, const Slice& new_value
       if (value.compare(parsed_strings_value.UserValue()) == 0) {
         StringsValue strings_value(new_value);
         if (ttl_millsec > 0) {
-          strings_value.SetRelativeTimeByMillsec(ttl_millsec);
+          strings_value.SetRelativeTimeInMillsec(ttl_millsec);
         }
         s = db_->Put(default_write_options_, base_key.Encode(), strings_value.Encode());
         if (!s.ok()) {

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -125,9 +125,7 @@ Status Storage::StoreCursorStartKey(const DataType& dtype, int64_t cursor, char 
   return cursors_store_->Insert(index_key, index_value);
 }
 
-std::unique_ptr<Redis>& Storage::GetDBInstance(const Slice& key) {
-  return GetDBInstance(key.ToString());
-}
+std::unique_ptr<Redis>& Storage::GetDBInstance(const Slice& key) { return GetDBInstance(key.ToString()); }
 
 std::unique_ptr<Redis>& Storage::GetDBInstance(const std::string& key) {
   auto inst_index = slot_indexer_->GetInstanceID(GetSlotID(slot_num_, key));
@@ -140,9 +138,9 @@ Status Storage::Set(const Slice& key, const Slice& value) {
   return inst->Set(key, value);
 }
 
-Status Storage::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl) {
+Status Storage::Setxx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setxx(key, value, ret, ttl);
+  return inst->Setxx(key, value, ret, ttl_millsec);
 }
 
 Status Storage::Get(const Slice& key, std::string* value) {
@@ -150,14 +148,14 @@ Status Storage::Get(const Slice& key, std::string* value) {
   return inst->Get(key, value);
 }
 
-Status Storage::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
+Status Storage::GetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->GetWithTTL(key, value, ttl);
+  return inst->GetWithTTL(key, value, ttl_millsec);
 }
 
-Status Storage::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl) {
+Status Storage::MGetWithTTL(const Slice& key, std::string* value, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->MGetWithTTL(key, value, ttl);
+  return inst->MGetWithTTL(key, value, ttl_millsec);
 }
 
 Status Storage::GetSet(const Slice& key, const Slice& value, std::string* old_value) {
@@ -196,7 +194,7 @@ Status Storage::MGet(const std::vector<std::string>& keys, std::vector<ValueStat
     s = inst->MGet(key, &value);
     if (s.ok()) {
       vss->push_back({value, Status::OK()});
-    } else if(s.IsNotFound()) {
+    } else if (s.IsNotFound()) {
       vss->push_back({std::string(), Status::NotFound()});
     } else {
       vss->clear();
@@ -212,12 +210,12 @@ Status Storage::MGetWithTTL(const std::vector<std::string>& keys, std::vector<Va
   for(const auto& key : keys) {
     auto& inst = GetDBInstance(key);
     std::string value;
-    int64_t ttl;
-    s = inst->MGetWithTTL(key, &value, &ttl);
+    int64_t ttl_millsec;
+    s = inst->MGetWithTTL(key, &value, &ttl_millsec);
     if (s.ok()) {
-      vss->push_back({value, Status::OK(), ttl});
+      vss->push_back({value, Status::OK(), ttl_millsec});
     } else if (s.IsNotFound()) {
-      vss->push_back({std::string(), Status::NotFound(), ttl});
+      vss->push_back({std::string(), Status::NotFound(), ttl_millsec});
     } else {
       vss->clear();
       return s;
@@ -226,9 +224,9 @@ Status Storage::MGetWithTTL(const std::vector<std::string>& keys, std::vector<Va
   return Status::OK();
 }
 
-Status Storage::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl) {
+Status Storage::Setnx(const Slice& key, const Slice& value, int32_t* ret, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setnx(key, value, ret, ttl);
+  return inst->Setnx(key, value, ret, ttl_millsec);
 }
 
 // disallowed in codis, only runs in pika classic mode
@@ -257,9 +255,9 @@ Status Storage::MSetnx(const std::vector<KeyValue>& kvs, int32_t* ret) {
   return s;
 }
 
-Status Storage::Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl) {
+Status Storage::Setvx(const Slice& key, const Slice& value, const Slice& new_value, int32_t* ret, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setvx(key, value, new_value, ret, ttl);
+  return inst->Setvx(key, value, new_value, ret, ttl_millsec);
 }
 
 Status Storage::Delvx(const Slice& key, const Slice& value, int32_t* ret) {
@@ -278,9 +276,9 @@ Status Storage::Getrange(const Slice& key, int64_t start_offset, int64_t end_off
 }
 
 Status Storage::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_t end_offset,
-                                     std::string* ret, std::string* value, int64_t* ttl) {
+                                     std::string* ret, std::string* value, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->GetrangeWithValue(key, start_offset, end_offset, ret, value, ttl);
+  return inst->GetrangeWithValue(key, start_offset, end_offset, ret, value, ttl_millsec);
 }
 
 Status Storage::Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_sec, std::string& out_new_value) {
@@ -357,9 +355,9 @@ Status Storage::Incrbyfloat(const Slice& key, const Slice& value, std::string* r
   return inst->Incrbyfloat(key, value, ret, expired_timestamp_sec);
 }
 
-Status Storage::Setex(const Slice& key, const Slice& value, int64_t ttl) {
+Status Storage::Setex(const Slice& key, const Slice& value, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Setex(key, value, ttl);
+  return inst->Setex(key, value, ttl_millsec);
 }
 
 Status Storage::Strlen(const Slice& key, int32_t* len) {
@@ -367,9 +365,12 @@ Status Storage::Strlen(const Slice& key, int32_t* len) {
   return inst->Strlen(key, len);
 }
 
-Status Storage::PKSetexAt(const Slice& key, const Slice& value, int64_t timestamp) {
+Status Storage::PKSetexAt(const Slice& key, const Slice& value, int64_t time_stamp_millsec_) {
   auto& inst = GetDBInstance(key);
-  return inst->PKSetexAt(key, value, timestamp);
+  if (time_stamp_millsec_ < 0) {
+    time_stamp_millsec_ = pstd::NowMillis() - 1;
+  }
+  return inst->PKSetexAt(key, value, time_stamp_millsec_);
 }
 
 // Hashes Commands
@@ -398,9 +399,9 @@ Status Storage::HGetall(const Slice& key, std::vector<FieldValue>* fvs) {
   return inst->HGetall(key, fvs);
 }
 
-Status Storage::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl) {
+Status Storage::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, int64_t* ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->HGetallWithTTL(key, fvs, ttl);
+  return inst->HGetallWithTTL(key, fvs, ttl_millsec);
 }
 
 Status Storage::HKeys(const Slice& key, std::vector<std::string>* fields) {
@@ -626,9 +627,9 @@ Status Storage::SMembers(const Slice& key, std::vector<std::string>* members) {
   return inst->SMembers(key, members);
 }
 
-Status Storage::SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t *ttl) {
+Status Storage::SMembersWithTTL(const Slice& key, std::vector<std::string>* members, int64_t * ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->SMembersWithTTL(key, members, ttl);
+  return inst->SMembersWithTTL(key, members, ttl_millsec);
 }
 
 Status Storage::SMove(const Slice& source, const Slice& destination, const Slice& member, int32_t* ret) {
@@ -753,9 +754,9 @@ Status Storage::LRange(const Slice& key, int64_t start, int64_t stop, std::vecto
   return inst->LRange(key, start, stop, ret);
 }
 
-Status Storage::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t *ttl) {
+Status Storage::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::vector<std::string>* ret, int64_t * ttl_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->LRangeWithTTL(key, start, stop, ret, ttl);
+  return inst->LRangeWithTTL(key, start, stop, ret, ttl_millsec);
 }
 
 Status Storage::LTrim(const Slice& key, int64_t start, int64_t stop) {
@@ -885,10 +886,10 @@ Status Storage::ZRange(const Slice& key, int32_t start, int32_t stop, std::vecto
   return inst->ZRange(key, start, stop, score_members);
 }
 Status Storage::ZRangeWithTTL(const Slice& key, int32_t start, int32_t stop, std::vector<ScoreMember>* score_members,
-                                 int64_t *ttl) {
+                                 int64_t * ttl_millsec) {
   score_members->clear();
   auto& inst = GetDBInstance(key);
-  return inst->ZRangeWithTTL(key, start, stop, score_members, ttl);
+  return inst->ZRangeWithTTL(key, start, stop, score_members, ttl_millsec);
 }
 
 Status Storage::ZRangebyscore(const Slice& key, double min, double max, bool left_close, bool right_close,
@@ -1170,10 +1171,10 @@ Status Storage::XInfo(const Slice& key, StreamInfoResult &result) {
 }
 
 // Keys Commands
-int32_t Storage::Expire(const Slice& key, int64_t ttl) {
+int32_t Storage::Expire(const Slice& key, int64_t ttl_millsec) {
   auto& inst = GetDBInstance(key);
   int32_t ret = 0;
-  Status s = inst->Expire(key, ttl);
+  Status s = inst->Expire(key, ttl_millsec);
   if (s.ok()) {
     ret++;
   } else if (!s.IsNotFound()) {
@@ -1449,11 +1450,11 @@ Status Storage::Scanx(const DataType& data_type, const std::string& start_key, c
   return Status::OK();
 }
 
-int32_t Storage::Expireat(const Slice& key, int64_t timestamp) {
+int32_t Storage::Expireat(const Slice& key, int64_t timestamp_millsec) {
   Status s;
   int32_t count = 0;
   auto& inst = GetDBInstance(key);
-  s = inst->Expireat(key, timestamp);
+  s = inst->Expireat(key, timestamp_millsec);
   if (s.ok()) {
     count++;
   } else if (!s.IsNotFound()) {
@@ -1474,16 +1475,28 @@ int32_t Storage::Persist(const Slice& key) {
   return count;
 }
 
-int64_t Storage::TTL(const Slice& key) {
-  int64_t timestamp = 0;
+int64_t Storage::PTTL(const Slice& key) {
+  int64_t ttl_millsec = 0;
   auto& inst = GetDBInstance(key);
-  Status s = inst->TTL(key, &timestamp);
+  Status s = inst->TTL(key, &ttl_millsec);
   if (s.ok() || s.IsNotFound()) {
-    return timestamp;
+    return ttl_millsec;
   } else if (!s.IsNotFound()) {
     return -3;
   }
-  return timestamp;
+  return ttl_millsec;
+}
+
+int64_t Storage::TTL(const Slice& key) {
+  int64_t ttl_millsec = 0;
+  auto& inst = GetDBInstance(key);
+  Status s = inst->TTL(key, &ttl_millsec);
+  if (s.ok() || s.IsNotFound()) {
+    return ttl_millsec > 0 ? ttl_millsec / 1000 : ttl_millsec;
+  } else if (!s.IsNotFound()) {
+    return -3;
+  }
+  return ttl_millsec > 0 ? ttl_millsec / 1000 : ttl_millsec;
 }
 
 Status Storage::GetType(const std::string& key, enum DataType& type) {
@@ -1779,7 +1792,7 @@ Status Storage::SetMaxCacheStatisticKeys(uint32_t max_cache_statistic_keys) {
 }
 
 Status Storage::SetSmallCompactionThreshold(uint32_t small_compaction_threshold) {
-  for (const auto& inst: insts_) {
+  for (const auto& inst : insts_) {
     inst->SetSmallCompactionThreshold(small_compaction_threshold);
   }
   return Status::OK();

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -281,9 +281,9 @@ Status Storage::GetrangeWithValue(const Slice& key, int64_t start_offset, int64_
   return inst->GetrangeWithValue(key, start_offset, end_offset, ret, value, ttl_millsec);
 }
 
-Status Storage::Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_sec, std::string& out_new_value) {
+Status Storage::Append(const Slice& key, const Slice& value, int32_t* ret, int64_t* expired_timestamp_millsec, std::string& out_new_value) {
   auto& inst = GetDBInstance(key);
-  return inst->Append(key, value, ret, expired_timestamp_sec, out_new_value);
+  return inst->Append(key, value, ret, expired_timestamp_millsec, out_new_value);
 }
 
 Status Storage::BitCount(const Slice& key, int64_t start_offset, int64_t end_offset, int32_t* ret, bool have_range) {
@@ -345,9 +345,9 @@ Status Storage::Decrby(const Slice& key, int64_t value, int64_t* ret) {
   return inst->Decrby(key, value, ret);
 }
 
-Status Storage::Incrby(const Slice& key, int64_t value, int64_t* ret, int64_t* expired_timestamp_sec) {
+Status Storage::Incrby(const Slice& key, int64_t value, int64_t* ret, int64_t* expired_timestamp_millsec) {
   auto& inst = GetDBInstance(key);
-  return inst->Incrby(key, value, ret, expired_timestamp_sec);
+  return inst->Incrby(key, value, ret, expired_timestamp_millsec);
 }
 
 Status Storage::Incrbyfloat(const Slice& key, const Slice& value, std::string* ret, int64_t* expired_timestamp_sec) {

--- a/src/storage/src/strings_filter.h
+++ b/src/storage/src/strings_filter.h
@@ -20,8 +20,7 @@ class StringsFilter : public rocksdb::CompactionFilter {
   StringsFilter() = default;
   bool Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value, std::string* new_value,
               bool* value_changed) const override {
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    pstd::TimeType unix_time = pstd::NowMillis();
     auto cur_time = static_cast<uint64_t>(unix_time);
     ParsedStringsValue parsed_strings_value(value);
     TRACE("==========================START==========================");

--- a/src/storage/src/strings_value_format.h
+++ b/src/storage/src/strings_value_format.h
@@ -35,9 +35,13 @@ class StringsValue : public InternalValue {
     dst += usize;
     memcpy(dst, reserve_, kSuffixReserveLength);
     dst += kSuffixReserveLength;
-    EncodeFixed64(dst, ctime_);
+    // The most significant bit is 1 for milliseconds and 0 for seconds.
+    // The previous data was stored in seconds, but the subsequent data was stored in milliseconds
+    uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
+    EncodeFixed64(dst, ctime);
     dst += kTimestampLength;
-    EncodeFixed64(dst, etime_);
+    uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
+    EncodeFixed64(dst, etime);
     return {start_, needed};
   }
 };
@@ -78,9 +82,20 @@ class ParsedStringsValue : public ParsedInternalValue {
       offset += user_value_.size();
       memcpy(reserve_, internal_value_str->data() + offset, kSuffixReserveLength);
       offset += kSuffixReserveLength;
-      ctime_ = DecodeFixed64(internal_value_str->data() + offset);
+      uint64_t ctime = DecodeFixed64(internal_value_str->data() + offset);
       offset += sizeof(ctime_);
-      etime_ = DecodeFixed64(internal_value_str->data() + offset);
+      uint64_t etime = DecodeFixed64(internal_value_str->data() + offset);
+
+      ctime_ = (ctime & ~(1ULL << 63));
+      // if ctime_==ctime, means ctime_ storaged in seconds
+      if (ctime_ == ctime) {
+        ctime_ *= 1000;
+      }
+      etime_ = (etime & ~(1ULL << 63));
+      // if etime_==etime, means etime_ storaged in seconds
+      if (etime == etime_) {
+        etime_ *= 1000;
+      }
     }
   }
 
@@ -94,9 +109,20 @@ class ParsedStringsValue : public ParsedInternalValue {
       offset += user_value_.size();
       memcpy(reserve_, internal_value_slice.data() + offset, kSuffixReserveLength);
       offset += kSuffixReserveLength;
-      ctime_ = DecodeFixed64(internal_value_slice.data() + offset);
+      uint64_t ctime = DecodeFixed64(internal_value_slice.data() + offset);
       offset += kTimestampLength;
-      etime_ = DecodeFixed64(internal_value_slice.data() + offset);
+      uint64_t etime = DecodeFixed64(internal_value_slice.data() + offset);
+
+      ctime_ = (ctime & ~(1ULL << 63));
+      // if ctime_==ctime, means ctime_ storaged in seconds
+      if (ctime_ == ctime) {
+        ctime_ *= 1000;
+      }
+      etime_ = (etime & ~(1ULL << 63));
+      // if etime_==etime, means etime_ storaged in seconds
+      if (etime == etime_) {
+        etime_ *= 1000;
+      }
     }
   }
 
@@ -114,7 +140,8 @@ class ParsedStringsValue : public ParsedInternalValue {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() -
                   kStringsValueSuffixLength + kSuffixReserveLength;
-      EncodeFixed64(dst, ctime_);
+      uint64_t ctime = ctime_ > 0 ? (ctime_ | (1ULL << 63)) : 0;
+      EncodeFixed64(dst, ctime);
     }
   }
 
@@ -122,7 +149,8 @@ class ParsedStringsValue : public ParsedInternalValue {
     if (value_) {
       char* dst = const_cast<char*>(value_->data()) + value_->size() -
                   kStringsValueSuffixLength + kSuffixReserveLength + kTimestampLength;
-      EncodeFixed64(dst, etime_);
+      uint64_t etime = etime_ > 0 ? (etime_ | (1ULL << 63)) : 0;
+      EncodeFixed64(dst, etime);
     }
   }
 

--- a/src/storage/src/zsets_filter.h
+++ b/src/storage/src/zsets_filter.h
@@ -80,8 +80,7 @@ class ZSetsScoreFilter : public rocksdb::CompactionFilter {
       return true;
     }
 
-    int64_t unix_time;
-    rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+    pstd::TimeType unix_time = pstd::NowMillis();
     if (cur_meta_etime_ != 0 && cur_meta_etime_ < static_cast<uint64_t>(unix_time)) {
       TRACE("Drop[Timeout]");
       return true;

--- a/src/storage/tests/keys_test.cc
+++ b/src/storage/tests/keys_test.cc
@@ -5179,8 +5179,7 @@ TEST_F(KeysTest, ExpireatTest) {
   s = db.Set("EXPIREAT_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
 
-  int64_t unix_time;
-  rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+  pstd::TimeType unix_time = pstd::NowMillis();
   int64_t timestamp = unix_time + 1;
   ret = db.Expireat("EXPIREAT_KEY", timestamp);
   ASSERT_EQ(ret, 1);

--- a/src/storage/tests/lists_filter_test.cc
+++ b/src/storage/tests/lists_filter_test.cc
@@ -102,7 +102,7 @@ TEST_F(ListsFilterTest, DataFilterTest) {
   EncodeFixed64(str, 1);
   ListsMetaValue lists_meta_value2(Slice(str, sizeof(uint64_t)));
   version = lists_meta_value2.UpdateVersion();
-  lists_meta_value2.SetRelativeTimestamp(1);
+  lists_meta_value2.SetRelativeTimeByMillsec(1);
   s = meta_db->Put(rocksdb::WriteOptions(), handles[0], bmk.Encode(), lists_meta_value2.Encode());
   ASSERT_TRUE(s.ok());
   ListsDataKey lists_data_key2("FILTER_TEST_KEY", version, 1);
@@ -119,7 +119,7 @@ TEST_F(ListsFilterTest, DataFilterTest) {
   EncodeFixed64(str, 1);
   ListsMetaValue lists_meta_value3(Slice(str, sizeof(uint64_t)));
   version = lists_meta_value3.UpdateVersion();
-  lists_meta_value3.SetRelativeTimestamp(1);
+  lists_meta_value3.SetRelativeTimeByMillsec(1);
   s = meta_db->Put(rocksdb::WriteOptions(), handles[0], bmk.Encode(), lists_meta_value3.Encode());
   ASSERT_TRUE(s.ok());
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/src/storage/tests/lists_filter_test.cc
+++ b/src/storage/tests/lists_filter_test.cc
@@ -102,7 +102,7 @@ TEST_F(ListsFilterTest, DataFilterTest) {
   EncodeFixed64(str, 1);
   ListsMetaValue lists_meta_value2(Slice(str, sizeof(uint64_t)));
   version = lists_meta_value2.UpdateVersion();
-  lists_meta_value2.SetRelativeTimeByMillsec(1);
+  lists_meta_value2.SetRelativeTimeInMillsec(1);
   s = meta_db->Put(rocksdb::WriteOptions(), handles[0], bmk.Encode(), lists_meta_value2.Encode());
   ASSERT_TRUE(s.ok());
   ListsDataKey lists_data_key2("FILTER_TEST_KEY", version, 1);
@@ -119,7 +119,7 @@ TEST_F(ListsFilterTest, DataFilterTest) {
   EncodeFixed64(str, 1);
   ListsMetaValue lists_meta_value3(Slice(str, sizeof(uint64_t)));
   version = lists_meta_value3.UpdateVersion();
-  lists_meta_value3.SetRelativeTimeByMillsec(1);
+  lists_meta_value3.SetRelativeTimeInMillsec(1);
   s = meta_db->Put(rocksdb::WriteOptions(), handles[0], bmk.Encode(), lists_meta_value3.Encode());
   ASSERT_TRUE(s.ok());
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/src/storage/tests/strings_filter_test.cc
+++ b/src/storage/tests/strings_filter_test.cc
@@ -21,7 +21,7 @@ TEST(StringsFilterTest, FilterTest) {
 
   int64_t ttl = 1;
   StringsValue strings_value("FILTER_VALUE");
-  strings_value.SetRelativeTimeByMillsec(ttl);
+  strings_value.SetRelativeTimeInMillsec(ttl);
   is_stale = filter->Filter(0, "FILTER_KEY", strings_value.Encode(), &new_value, &value_changed);
   ASSERT_FALSE(is_stale);
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/src/storage/tests/strings_filter_test.cc
+++ b/src/storage/tests/strings_filter_test.cc
@@ -21,7 +21,7 @@ TEST(StringsFilterTest, FilterTest) {
 
   int64_t ttl = 1;
   StringsValue strings_value("FILTER_VALUE");
-  strings_value.SetRelativeTimestamp(ttl);
+  strings_value.SetRelativeTimeByMillsec(ttl);
   is_stale = filter->Filter(0, "FILTER_KEY", strings_value.Encode(), &new_value, &value_changed);
   ASSERT_FALSE(is_stale);
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/src/storage/tests/strings_test.cc
+++ b/src/storage/tests/strings_test.cc
@@ -44,7 +44,7 @@ class StringsTest : public ::testing::Test {
 
 static bool make_expired(storage::Storage* const db, const Slice& key) {
   std::map<storage::DataType, rocksdb::Status> type_status;
-  int ret = db->Expire(key, 1);
+  int ret = db->Expire(key, 1 * 100);
   if ((ret == 0) || !type_status[storage::DataType::kStrings].ok()) {
     return false;
   }
@@ -87,7 +87,7 @@ TEST_F(StringsTest, AppendTest) {
   // ***************** Group 2 Test *****************
   s = db.Set("GP2_APPEND_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
-  ret = db.Expire("GP2_APPEND_KEY", 100);
+  ret = db.Expire("GP2_APPEND_KEY", 100 * 1000);
   ASSERT_EQ(ret, 1);
   type_status.clear();
   type_ttl = db.TTL("GP2_APPEND_KEY");
@@ -764,7 +764,7 @@ TEST_F(StringsTest, SetvxTest) {
   ASSERT_TRUE(s.ok());
 
   std::map<storage::DataType, Status> type_status;
-  ret = db.Expire("GP6_SETVX_KEY", 10);
+  ret = db.Expire("GP6_SETVX_KEY", 10 * 1000);
   ASSERT_EQ(ret, 1);
 
   sleep(1);
@@ -772,7 +772,7 @@ TEST_F(StringsTest, SetvxTest) {
   ASSERT_LT(0, ttl);
   ASSERT_GT(10, ttl);
 
-  s = db.Setvx("GP6_SETVX_KEY", "GP6_SETVX_VALUE", "GP6_SETVX_NEW_VALUE", &ret, 20);
+  s = db.Setvx("GP6_SETVX_KEY", "GP6_SETVX_VALUE", "GP6_SETVX_NEW_VALUE", &ret, 20 * 1000);
   ASSERT_TRUE(s.ok());
   ASSERT_EQ(ret, 1);
 
@@ -941,16 +941,13 @@ TEST_F(StringsTest, BitPosTest) {
 
 // PKSetexAt
 TEST_F(StringsTest, PKSetexAtTest) {
-#ifdef OS_MACOSX
-  return ;
-#endif
-  int64_t unix_time;
-  rocksdb::Env::Default()->GetCurrentTime(&unix_time);
+  pstd::TimeType unix_time;
   int64_t ttl_ret;
   std::map<storage::DataType, Status> type_status;
 
   // ***************** Group 1 Test *****************
-  s = db.PKSetexAt("GP1_PKSETEX_KEY", "VALUE", unix_time + 100);
+  unix_time = pstd::NowMillis();
+  s = db.PKSetexAt("GP1_PKSETEX_KEY", "VALUE", unix_time + 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -960,9 +957,10 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_GE(ttl_ret, 90);
 
   // ***************** Group 2 Test *****************
+  unix_time = pstd::NowMillis();
   s = db.Set("GP2_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
-  s = db.PKSetexAt("GP2_PKSETEX_KEY", "VALUE", unix_time + 100);
+  s = db.PKSetexAt("GP2_PKSETEX_KEY", "VALUE", unix_time + 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -972,7 +970,8 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_GE(ttl_ret, 90);
 
   // ***************** Group 3 Test *****************
-  s = db.PKSetexAt("GP3_PKSETEX_KEY", "VALUE", unix_time - 100);
+  unix_time = pstd::NowMillis();
+  s = db.PKSetexAt("GP3_PKSETEX_KEY", "VALUE", unix_time - 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -980,9 +979,10 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 4 Test *****************
+  unix_time = pstd::NowMillis();
   s = db.Set("GP4_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
-  s = db.PKSetexAt("GP4_PKSETEX_KEY", "VALUE", unix_time - 100);
+  s = db.PKSetexAt("GP4_PKSETEX_KEY", "VALUE", unix_time - 100*1000);
   ASSERT_TRUE(s.ok());
 
   type_status.clear();
@@ -990,6 +990,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 5 Test *****************
+  unix_time = pstd::NowMillis();
   s = db.PKSetexAt("GP5_PKSETEX_KEY", "VALUE", -unix_time);
   ASSERT_TRUE(s.ok());
 
@@ -998,6 +999,7 @@ TEST_F(StringsTest, PKSetexAtTest) {
   ASSERT_EQ(ttl_ret, -2);
 
   // ***************** Group 6 Test *****************
+  unix_time = pstd::NowMillis();
   s = db.Set("GP6_PKSETEX_KEY", "VALUE");
   ASSERT_TRUE(s.ok());
   s = db.PKSetexAt("GP6_PKSETEX_KEY", "VALUE", -unix_time);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced time-to-live (TTL) handling with a consistent shift from seconds to milliseconds across multiple commands and classes.
	- Introduced new utility methods for retrieving current time in milliseconds.
	- Added a new method to fetch remaining TTL in milliseconds, improving precision.

- **Bug Fixes**
	- Improved clarity and consistency in time-related operations, reducing potential confusion and errors related to time units.

- **Documentation**
	- Updated method signatures and parameter names for clarity regarding time units, ensuring developers understand the expected input values.

- **Style**
	- Standardized formatting and spacing across multiple files for improved readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->