### PR TITLE
fix: blpop/brpop don't update cache

### DIFF
--- a/include/pika_list.h
+++ b/include/pika_list.h
@@ -105,7 +105,7 @@ class BlockingBaseCmd : public Cmd {
   void BlockThisClientToWaitLRPush(BlockKeyType block_pop_type, std::vector<std::string>& keys, int64_t expire_time);
   void TryToServeBLrPopWithThisKey(const std::string& key, std::shared_ptr<DB> db);
   static void ServeAndUnblockConns(void* args);
-  static void WriteBinlogOfPop(std::vector<WriteBinlogOfPopArgs>& pop_args);
+  static void WriteBinlogOfPopAndUpdateCache(std::vector<WriteBinlogOfPopArgs>& pop_args);
   void removeDuplicates(std::vector<std::string>& keys_);
   // blpop/brpop used functions end
 };

--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -184,7 +184,6 @@ void BlockingBaseCmd::ServeAndUnblockConns(void* args) {
   net::BlockKey blrPop_key{db->GetDBName(), key};
 
   pstd::lock::ScopeRecordLock record_lock(db->LockMgr(), key);//It's a RAII Lock
-  db->DBLockShared();
   std::unique_lock map_lock(dispatchThread->GetBlockMtx());// do not change the sequence of these 3 locks, or deadlock will happen
   auto it = key_to_conns_.find(blrPop_key);
   if (it == key_to_conns_.end()) {
@@ -225,7 +224,6 @@ void BlockingBaseCmd::ServeAndUnblockConns(void* args) {
   dispatchThread->CleanKeysAfterWaitNodeCleaned();
   map_lock.unlock();
   WriteBinlogOfPopAndUpdateCache(pop_binlog_args);
-  db->DBUnlockShared();
 }
 
 void BlockingBaseCmd::WriteBinlogOfPopAndUpdateCache(std::vector<WriteBinlogOfPopArgs>& pop_args) {


### PR DESCRIPTION
1 去年支持blpop/brpop时Pika还没有Cache, 所以Blpop/Brpop执行链路上没有更新Cache的逻辑。
本PR将其补上，以确保Cache一致性。 


Last year, when BLPOP/BRPOP was supported, Pika did not have a cache, so there was no logic to update the cache in the BLPOP execution path. This PR adds that logic to ensure cache consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced command initialization process with new parameters to support flexible database contexts.
	- Improved binlog writing functionality now includes cache updates for better data consistency and performance.
	- Adjustments to connection management for enhanced robustness and handling of network events.

- **Bug Fixes**
	- Increased logging severity for critical connection blocking information, enhancing monitoring capabilities.

- **Chores**
	- Updated unit test workflow to run in a clean environment, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->