### PR TITLE
fix: kill connections correctly in Net WorkThread

### DIFF
--- a/src/net/src/worker_thread.cc
+++ b/src/net/src/worker_thread.cc
@@ -284,7 +284,8 @@ void WorkerThread::DoCronTask() {
    */
 
   for (auto& conn : ready_to_close_conns_) {
-    CloseFd(conn);
+    close(conn->fd());
+    server_thread_->handle_->FdClosedHandle(conn->fd(), conn->ip_port());
   }
   ready_to_close_conns_.clear();
 

--- a/src/net/src/worker_thread.cc
+++ b/src/net/src/worker_thread.cc
@@ -284,7 +284,7 @@ void WorkerThread::DoCronTask() {
    */
 
   for (auto& conn : ready_to_close_conns_) {
-    close(conn->fd());
+    CloseFd(conn);
   }
   ready_to_close_conns_.clear();
 

--- a/src/net/src/worker_thread.cc
+++ b/src/net/src/worker_thread.cc
@@ -270,14 +270,51 @@ void WorkerThread::DoCronTask() {
       ++iter;
     }
   }
+  /*
+   * How Do we kill a conn correct:
+   * stage 1: stop accept new request(also give up the write back of shooting request's response)
+   *  1.1 remove the fd from epoll and erase it from conns_ to ensure no more request will submit to threadpool
+   *  1.2 add to-close-conn to wait_to_close_conns_
+   * stage 2: ensure there's no other shared_ptr of this conn in pika
+   *  2.1 in async task that exec by TheadPool, a shared_ptr of conn will hold and my case a pipe event to tell the epoll
+   *  to back the response, we must ensure this notification is done before we really close fd(linux will reuse the fd to accept new conn)
+   *  2.2 we must clear all other shared_ptr of this to-close-conn, like the map of blpop/brpop and the map of watchkeys
+   *  2.3 for those to-close-conns that ref count drop to 1, we add them to ready-to-close-conns_
+   * stage 3: after an epoll cycle(let it handle the already-invalid-writeback-notification ), we can safely close the fds of ready_to_close_conns_
+   */
+
+  for (auto& conn : ready_to_close_conns_) {
+    close(conn->fd());
+  }
+  ready_to_close_conns_.clear();
+
+  for (auto conn = wait_to_close_conns_.begin(); conn != wait_to_close_conns_.end();) {
+    if (conn->use_count() == 1) {
+      ready_to_close_conns_.push_back(*conn);
+      conn = wait_to_close_conns_.erase(conn);
+    } else {
+      ++conn;
+    }
+  }
+
   for (const auto& conn : to_close) {
     net_multiplexer_->NetDelEvent(conn->fd(), 0);
-    CloseFd(conn);
+    ClearConnsRefAndOtherInfo(conn);
+    wait_to_close_conns_.push_back(conn);
   }
   for (const auto& conn : to_timeout) {
     net_multiplexer_->NetDelEvent(conn->fd(), 0);
-    CloseFd(conn);
+    ClearConnsRefAndOtherInfo(conn);
+    wait_to_close_conns_.push_back(conn);
     server_thread_->handle_->FdTimeoutHandle(conn->fd(), conn->ip_port());
+  }
+}
+
+void WorkerThread::ClearConnsRefAndOtherInfo(const std::shared_ptr<NetConn>& conn) {
+  if (auto dispatcher = dynamic_cast<DispatchThread *>(server_thread_); dispatcher != nullptr ) {
+    //check if this conn disconnected from being blocked by blpop/brpop
+    dispatcher->ClosingConnCheckForBlrPop(std::dynamic_pointer_cast<net::RedisConn>(conn));
+    dispatcher->RemoveWatchKeys(conn);
   }
 }
 
@@ -301,12 +338,8 @@ bool WorkerThread::TryKillConn(const std::string& ip_port) {
 }
 
 void WorkerThread::CloseFd(const std::shared_ptr<NetConn>& conn) {
+  ClearConnsRefAndOtherInfo(conn);
   close(conn->fd());
-  if (auto dispatcher = dynamic_cast<DispatchThread *>(server_thread_); dispatcher != nullptr ) {
-    //check if this conn disconnected from being blocked by blpop/brpop
-    dispatcher->ClosingConnCheckForBlrPop(std::dynamic_pointer_cast<net::RedisConn>(conn));
-    dispatcher->RemoveWatchKeys(conn);
-  }
   server_thread_->handle_->FdClosedHandle(conn->fd(), conn->ip_port());
 }
 

--- a/src/net/src/worker_thread.h
+++ b/src/net/src/worker_thread.h
@@ -48,10 +48,15 @@ class WorkerThread : public Thread {
   NetMultiplexer* net_multiplexer() { return net_multiplexer_.get(); }
   bool TryKillConn(const std::string& ip_port);
 
+  void ClearConnsRefAndOtherInfo(const std::shared_ptr<NetConn>& conn);
+
   ServerThread* GetServerThread() { return server_thread_; }
 
   mutable pstd::RWMutex rwlock_; /* For external statistics */
   std::map<int, std::shared_ptr<NetConn>> conns_;
+  std::vector<std::shared_ptr<NetConn>> wait_to_close_conns_;
+  std::vector<std::shared_ptr<NetConn>> ready_to_close_conns_;
+
 
   void* private_data_ = nullptr;
 

--- a/tests/integration/replication_test.go
+++ b/tests/integration/replication_test.go
@@ -634,14 +634,25 @@ var _ = Describe("should replication ", func() {
 
 			for i := 1; i <= 5; i++ {
 				go func() {
-					clientMaster.BLPop(ctx, 0, lists...)
+							client := redis.NewClient(PikaOption(MASTERADDR))
+                    		defer client.Close()
+
+                    		client.BLPop(ctx, 0, lists...)
 				}()
 				go func() {
-					clientMaster.BRPop(ctx, 0, lists...)
+							client := redis.NewClient(PikaOption(MASTERADDR))
+                    		defer client.Close()
+
+                    		client.BRPop(ctx, 0, lists...)
 				}()
 			}
 			execute(&ctx, clientMaster, 5, issuePushPopFrequency)
 
+
+            time.Sleep(3 * time.Second);
+            //reconnect to avoid timeout-kill
+            clientSlave := redis.NewClient(PikaOption(SLAVEADDR))
+            // Fail("Stopping the test due to some condition");
 			for i := int64(0); i < clientMaster.LLen(ctx, "blist0").Val(); i++ {
 				Expect(clientMaster.LIndex(ctx, "blist0", i)).To(Equal(clientSlave.LIndex(ctx, "blist0", i)))
 			}

--- a/tests/integration/rsync_dynamic_reconfig.go
+++ b/tests/integration/rsync_dynamic_reconfig.go
@@ -35,10 +35,10 @@ func RefillMaster(masterAddr string, dataVolumeMB int64, ctx context.Context) {
 			cli.Set(ctx, rKey, rValue, 0)
 		}
 	}
-	keySize := 1024
-	valueSize := 1024
+	keySize := 64
+	valueSize := 64
 	dataVolumeBytes := dataVolumeMB << 20
-	threadNum := 10
+	threadNum := 5
 	reqNumForEachThead := dataVolumeBytes / int64((keySize + valueSize)) / int64(threadNum)
 	//fmt.Printf("reqNumForEach:%d\n", reqNumForEachThead)
 	startTime := time.Now()
@@ -136,7 +136,7 @@ var _ = Describe("Rsync Reconfig Test", func() {
 		slave1.FlushDB(ctx)
 		master1.FlushDB(ctx)
 		time.Sleep(3 * time.Second)
-		RefillMaster(MASTERADDR, 64, ctx)
+		RefillMaster(MASTERADDR, 2, ctx)
 		key1 := "45vs45f4s5d6"
 		value1 := "afd54g5s4f545"
 		//set key before sync happened, slave is supposed to fetch it when sync done

--- a/tests/integration/start_master_and_slave.sh
+++ b/tests/integration/start_master_and_slave.sh
@@ -14,7 +14,8 @@ mkdir slave_data
 # Example Change the location for storing data on primary and secondary nodes in the configuration file
 sed -i.bak  \
   -e 's|databases : 1|databases : 2|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_single.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_single.conf
 
 sed -i.bak   \
   -e 's|databases : 1|databases : 2|'  \
@@ -24,7 +25,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./master_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./master_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./master_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_master.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_master.conf
 
 sed -i.bak   \
   -e 's|databases : 1|databases : 2|'  \
@@ -34,7 +36,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./slave_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./slave_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./slave_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_slave.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_slave.conf
 
 sed -i.bak   \
   -e 's|# rename-command : FLUSHALL 360flushall|rename-command : FLUSHALL 360flushall|'  \
@@ -46,7 +49,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./rename_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./rename_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./rename_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_rename.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_rename.conf
 
 sed -i.bak   \
   -e 's|requirepass :|requirepass : requirepass|' \
@@ -59,7 +63,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./acl1_data/dump/|' \
   -e 's|pidfile : ./pika.pid|pidfile : ./acl1_data/pika.pid|' \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./acl1_data/dbsync/|' \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_acl_both_password.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_acl_both_password.conf
 
 sed -i.bak   \
   -e 's|requirepass :|requirepass : requirepass|'  \
@@ -71,7 +76,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./acl2_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./acl2_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./acl2_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_acl_only_admin_password.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_acl_only_admin_password.conf
 sed -i.bak   \
   -e 's|requirepass :|requirepass : requirepass|'  \
   -e 's|masterauth :|masterauth : requirepass|'  \
@@ -83,7 +89,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./acl3_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./acl3_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./acl3_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_has_other_acl_user.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_has_other_acl_user.conf
 echo -e '\nuser : limit on >limitpass ~* +@all &*' >> ./pika_has_other_acl_user.conf
 
 # Start three nodes


### PR DESCRIPTION
## 本 PR 修复了

执行 `client kill ip:port`，`client kill all`，`client kill normal` 等杀连接的命令流程不正确的问题。

## 背景

之前的代码中这部分逻辑存在很大问题，会造成 fd 泄露。本人在 PR #2858 中对该问题做了一点修复，fd 不会再泄露了，但那版修复不够完善，**没考虑到 Linux 对 fd 复用来接受新连接的逻辑**。

## 代码细节

1. Pika 每同客户端创建一个新连接，都会新建一个 `NetConn` 对象，期内包含 fd 等信息, fd也会注册到WorkThread的Epoll上，而WorkThread本身也是epoll线程，不断循环epoll_wait。
2. Pika 的网络线程（`WorkerThread`）收到包，解析出任务以后，会将该任务提交给线程池异步执行，同时带上一枚当前 `NetConn` 的 `shared_ptr`，并且关闭该连接（fd）在 epoll 上的读写事件监听。等到线程池异步地执行完命令，会将 response 先写入 `NetConn` 的 `response_`，**再使用管道通知 epoll 将该连接（fd）的可写事件监听打开**。由于发送缓冲区是空的，所以下次 `epoll_wait` 该 fd 会立刻触发可写事件，于是 `NetConn` 的 `response_` 内容会被写入 socket。也就是说，Pika 中是通过管道通知 epoll 打开对应 fd 的可写监听来触发 response 的写回，或者说使用这样一种机制来标志/通知异步的任务执行结束以通知回写。

## 问题

当 Pika 要关闭某些连接时，如果直接关闭 fd（并从epoll上移除），可能会出现这样一种情况：该 fd 是从 epoll 上移除并且关闭了，但异步线程池还在执行该连接最后提交的那个任务（异步线程池还持有了一枚 `shared_ptr<Netconn>`关联这这枚已经关闭的fd）。等异步线程池执行完任务，**依旧会用管道通知 epoll 将该 fd 的可写事件打开监听（实际上这枚 fd 已经关闭，且已经不在 epoll 上了），这个通知其实已经是无效的了**。

但**如果恰好 Linux 立刻复用了该 fd 接受了一个新连接，并且注册到了这个 `WorkThread` 的 epoll 上，前面提到的无效通知就是一个非法通知了**。因为此时该 fd 对应了一个新的 client，而这个非法的，来自旧连接请求的通知会使得 epoll 直接使用新 client 的 `NetConn` 的 `response_` 的内容去回写 fd。问题在于此时线程池可能已经执行完一个该 `NetConn` 的请求，正在向 `response_` 进行写入，这实际上就是 data race 了，可能引起各种期望之外的后果。

## 本 PR 提供了一个相对完善，分阶段的关闭连接的流程,  步骤如下：

新增：`WorkThread::wait_to_close_conns_`, `WorkThread::ready_to_close_conns_`

1. 把 fd 从 epoll 上移掉，这样可以不再接受新的请求（当然，正在执行的请求结束了也不回写了，当前正在 kill conn，这个也是符合预期的），并且将其从 `conns_` 中移除，放在 `wait_to_close_conns_` 中，并且清除非常规路径上对该 conn 的 `shared_ptr` 引用（`blpop` 等阻塞命令，以及 `watchKeys` 功能都会持有 `NetConn` 的 `shared_ptr`）。
2. 在下一次 `cronTask` 中（即经过了一轮 `epoll_wait` 循环）检查 `wait_to_close_conns_`，如果引用计数降为了 1，将其移动到 `ready_to_close_conns_`。
3. 在下一次 `cronTask` 中（即又经过了一轮 `epoll_wait` 循环），关闭掉所有在 `ready_to_close_conns_` 中的连接。**为什么引用计数降为 1 了，还要放入 `ready_to_close_conns_` 等待一轮 epoll 循环以后再关闭 fd** ？主要就是前面提到的异步回写通知的问题，假如要关闭的 conn 对象引用计数已经降为 1，也可能异步线程池已经发出过了回写的通知（通过管道和队列通知 epoll打开该fd的可写时间监听，后面进行response回写），**需要等 epoll_wait 再走一轮，消化掉这些已经无效的回写通知**，才能去关闭 fd，以预防前面提到的 fd 复用和无效回写通知叠加可能导致的问题。


 ## This PR fixes

Incorrect process when executing `client kill XX`, `client kill all`, `client kill normal`, and similar commands to terminate connections.

## Background

The previous code had significant issues in this logic, which could lead to fd leaks. In PR #2858, some fixes were made to address this issue, ensuring that fds would no longer leak. However, that fix was not comprehensive enough as it didn't account for Linux's fd reuse logic for accepting new connections.

## Code details

Every time Pika creates a new connection with a client, a new `NetConn` object is created, containing fd and other information. Pika's network thread (`WorkerThread`) receives packets, parses the task, and submits it to a thread pool for asynchronous execution, passing along a `shared_ptr` to the current `NetConn`. It then closes the connection's (fd) read/write event listening on epoll. Once the thread pool completes executing the command asynchronously, it writes the response into `NetConn`'s `response_` and **notifies epoll via a pipe to enable write event listening for that connection (fd)**. Since the send buffer is empty, the next `epoll_wait` will immediately trigger a write event on that fd, causing `NetConn`'s `response_` content to be written to the socket. In other words, Pika uses the pipe notification to epoll to open the write event listening for the corresponding fd to trigger the response write-back, or in other words, to signal the completion of the asynchronous task.

## Issue

When Pika needs to close certain connections, directly closing the fd can lead to a situation where the fd is removed from epoll and closed, but the asynchronous thread pool is still executing the last submitted task for that connection (the thread pool still holds a `shared_ptr<Netconn>`). After completing the task, **it will still notify epoll via the pipe to enable the write event for that fd (which has already been closed and is no longer on epoll), making this notification ineffective**.

However, **if Linux happens to immediately reuse that fd for a new connection and registers it on the epoll of this `WorkThread`, the previously mentioned invalid notification becomes an illegal notification**. This is because the fd now corresponds to a new client, and this illegal notification from the old connection will cause epoll to directly use the new client's `NetConn`'s `response_` content to write back to the fd. The issue here is that the thread pool may have already executed a request for this `NetConn` and is writing to `response_`, leading to a data race, which could cause various unexpected outcomes.

## This PR provides a more complete, phased process for closing connections

New additions: `WorkThread::wait_to_close_conns_`, `WorkThread::ready_to_close_conns_`

1. Remove the fd from epoll, so it no longer accepts new requests (and ongoing requests will not be written back, which is expected when killing a connection). The fd is also removed from `conns_`, placed in `wait_to_close_conns_`, and clears any `shared_ptr` references to the conn on non-standard paths (such as `blpop` and `watchKeys`, which hold a `shared_ptr<NetConn>`).
2. In the next `cronTask` (i.e., after one `epoll_wait` loop), check `wait_to_close_conns_`. If the reference count drops to 1, move it to `ready_to_close_conns_`.
3. In the next `cronTask` (i.e., after another `epoll_wait` loop), close all connections in `ready_to_close_conns_`. Why wait for another `epoll` loop after the reference count drops to 1 before closing the fd? The reason is the asynchronous write-back notification mentioned earlier. If the conn's reference count has dropped to 1, the thread pool may have already issued a wr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced connection management with a multi-stage approach for safely closing connections, improving resource handling.
	- Introduction of methods for tracking and managing connections pending closure.
	- Timeout setting increased from 60 to 500 seconds in configuration files to improve operational stability.
	- Lightweight adjustments to the `RefillMaster` function and tests, reducing key/value sizes and thread count.

- **Bug Fixes**
	- Improved stability and robustness of connection lifecycles, preventing issues related to premature closure.

- **Refactor**
	- Code organization and separation of concerns improved through the addition of new helper functions.

- **Tests**
	- Improved reliability of replication tests by ensuring each operation uses a dedicated Redis client instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->