### PR TITLE
fix: change the network time out in github action's pika.conf to avoid fake failure

### DIFF
--- a/tests/integration/start_master_and_slave.sh
+++ b/tests/integration/start_master_and_slave.sh
@@ -16,7 +16,8 @@ mkdir slave_data
 # Example Change the location for storing data on primary and secondary nodes in the configuration file
 sed -i.bak  \
   -e 's|databases : 1|databases : 2|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_single.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_single.conf
 
 sed -i.bak   \
   -e 's|databases : 1|databases : 2|'  \
@@ -26,7 +27,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./master_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./master_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./master_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_master.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_master.conf
 
 sed -i.bak   \
   -e 's|databases : 1|databases : 2|'  \
@@ -36,7 +38,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./slave_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./slave_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./slave_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_slave.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_slave.conf
 
 sed -i.bak   \
   -e 's|# rename-command : FLUSHALL 360flushall|rename-command : FLUSHALL 360flushall|'  \
@@ -48,7 +51,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./rename_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./rename_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./rename_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_rename.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_rename.conf
 
 sed -i.bak   \
   -e 's|requirepass :|requirepass : requirepass|' \
@@ -61,7 +65,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./acl1_data/dump/|' \
   -e 's|pidfile : ./pika.pid|pidfile : ./acl1_data/pika.pid|' \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./acl1_data/dbsync/|' \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_acl_both_password.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_acl_both_password.conf
 
 sed -i.bak   \
   -e 's|requirepass :|requirepass : requirepass|'  \
@@ -73,7 +78,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./acl2_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./acl2_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./acl2_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_acl_only_admin_password.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_acl_only_admin_password.conf
 
 sed -i.bak   \
   -e 's|requirepass :|requirepass : requirepass|'  \
@@ -86,7 +92,8 @@ sed -i.bak   \
   -e 's|dump-path : ./dump/|dump-path : ./acl3_data/dump/|'  \
   -e 's|pidfile : ./pika.pid|pidfile : ./acl3_data/pika.pid|'  \
   -e 's|db-sync-path : ./dbsync/|db-sync-path : ./acl3_data/dbsync/|'  \
-  -e 's|#daemonize : yes|daemonize : yes|' ./pika_has_other_acl_user.conf
+  -e 's|#daemonize : yes|daemonize : yes|' \
+  -e 's|timeout : 60|timeout : 500|' ./pika_has_other_acl_user.conf
 echo -e '\nuser : limit on >limitpass ~* +@all &*' >> ./pika_has_other_acl_user.conf
 
 sed -i ''  \


### PR DESCRIPTION
github action中的E2E测试中，有部分连接可能会超过60s都没有任何活动，按照默认配置，pika会杀掉这些连接，导致测试的“假失败”，本PR将CI中的client timeout改成500秒以预防这种情况出现。