### PR TITLE
fix: pika may compile fail in some centos platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ ExternalProject_Add(gtest
   make -j${CPU_CORE}
 )
 
-if(${OS_VERSION} MATCHES "Rocky")
+if(${OS_VERSION} MATCHES "Rocky" OR ${OS_VERSION} MATCHES "CentOS")
   set(GTEST_LIBRARY ${INSTALL_LIBDIR_64}/libgtest.a)
   set(GTEST_MAIN_LIBRARY ${INSTALL_LIBDIR_64}/libgtest_main.a)
   set(GMOCK_LIBRARY ${INSTALL_LIBDIR_64}/libgmock.a)
@@ -283,7 +283,7 @@ else()
   set(LIB_GLOG libglog.a)
 endif()
 
-if(${OS_VERSION} MATCHES "Rocky")
+if(${OS_VERSION} MATCHES "Rocky" OR ${OS_VERSION} MATCHES "CentOS")
   set(GLOG_LIBRARY ${INSTALL_LIBDIR_64}/${LIB_GLOG})
 else()
   set(GLOG_LIBRARY ${INSTALL_LIBDIR}/${LIB_GLOG})
@@ -318,7 +318,7 @@ ExternalProject_Add(snappy
   make -j${CPU_CORE}
 )
 
-if(${OS_VERSION} MATCHES "Rocky")
+if(${OS_VERSION} MATCHES "Rocky" OR ${OS_VERSION} MATCHES "CentOS")
   set(SNAPPY_LIBRARY ${INSTALL_LIBDIR_64}/libsnappy.a)
 else()
   set(SNAPPY_LIBRARY ${INSTALL_LIBDIR}/libsnappy.a)
@@ -356,7 +356,7 @@ ExternalProject_Add(zstd
   make -j${CPU_CORE}
 )
 
-if(${OS_VERSION} MATCHES "Rocky")
+if(${OS_VERSION} MATCHES "Rocky" OR ${OS_VERSION} MATCHES "CentOS")
   set(ZSTD_LIBRARY ${INSTALL_LIBDIR_64}/libzstd.a)
 else()
   set(ZSTD_LIBRARY ${INSTALL_LIBDIR}/libzstd.a)
@@ -395,7 +395,7 @@ else()
   set(LIB_FMT libfmt.a)
 endif()
 
-if(${OS_VERSION} MATCHES "Rocky")
+if(${OS_VERSION} MATCHES "Rocky" OR ${OS_VERSION} MATCHES "CentOS")
   set(FMT_LIBRARY ${INSTALL_LIBDIR_64}/${LIB_FMT})
 else()
   set(FMT_LIBRARY ${INSTALL_LIBDIR}/${LIB_FMT})
@@ -433,7 +433,7 @@ ExternalProject_Add(lz4
   make -j${CPU_CORE}
 )
 
-if(${OS_VERSION} MATCHES "Rocky")
+if(${OS_VERSION} MATCHES "Rocky" OR ${OS_VERSION} MATCHES "CentOS")
   set(LZ4_LIBRARY ${INSTALL_LIBDIR_64}/liblz4.a)
 else()
   set(LZ4_LIBRARY ${INSTALL_LIBDIR}/liblz4.a)
@@ -719,7 +719,7 @@ if (USE_PIKA_TOOLS)
   set(BZ2_LIBRARY ${INSTALL_LIBDIR}/libbz2.a)
 endif()
 
-if(${OS_VERSION} MATCHES "Rocky")
+if(${OS_VERSION} MATCHES "Rocky" OR ${OS_VERSION} MATCHES "CentOS")
   set(ROCKSDB_LIBRARY ${INSTALL_LIBDIR_64}/librocksdb.a)
 else()
   set(ROCKSDB_LIBRARY ${INSTALL_LIBDIR}/librocksdb.a)


### PR DESCRIPTION
fix: pika may compile fail in some centos platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced compatibility with CentOS alongside Rocky for library path configurations, improving build flexibility across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->