### PR TITLE
fix: rpushx cmd insert error

### DIFF
--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -507,8 +507,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<RPushCmd>(kCmdNameRPush, -3, kCmdFlagsWrite | kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameRPush, std::move(rpushptr)));
   std::unique_ptr<Cmd> rpushxptr =
-      std::make_unique<RPushxCmd>(kCmdNameRPushx, -3, kCmdFlagsWrite |  kCmdFlagsList);
-  std::make_unique<RPushxCmd>(kCmdNameRPushx, 3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<RPushxCmd>(kCmdNameRPushx, -3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameRPushx, std::move(rpushxptr)));
 
   // Zset


### PR DESCRIPTION
关联issue https://github.com/OpenAtomFoundation/pika/issues/2878 ，删除rpushx命令注册时的多余错误代码，使得rpushx执行时会更新cache，保持cache与db的数据一致
效果如下
![image](https://github.com/user-attachments/assets/08e8a141-5b85-473a-af13-cbc6e734deaf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Streamlined the command initialization process for `RPushCmd` and `RPushxCmd`, removing redundancy to improve clarity and efficiency in command table setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->