### PR TITLE
fix: target_file_size_base connot set large than 2G

### DIFF
--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -270,7 +270,7 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return compression_;
   }
-  int target_file_size_base() {
+  int64_t target_file_size_base() {
     std::shared_lock l(rwlock_);
     return target_file_size_base_;
   }
@@ -1027,7 +1027,7 @@ class PikaConf : public pstd::BaseConf {
   // Critical configure items
   //
   bool write_binlog_ = false;
-  int target_file_size_base_ = 0;
+  int64_t target_file_size_base_ = 0;
   int64_t max_compaction_bytes_ = 0;
   int binlog_file_size_ = 0;
 

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -421,7 +421,7 @@ int PikaConf::Load() {
   }
 
   // target_file_size_base
-  GetConfIntHuman("target-file-size-base", &target_file_size_base_);
+  GetConfInt64Human("target-file-size-base", &target_file_size_base_);
   if (target_file_size_base_ <= 0) {
     target_file_size_base_ = 1048576;  // 10Mb
   }


### PR DESCRIPTION
目前target_file_size_base类型是int, 设置超过2G会变成10M

https://github.com/OpenAtomFoundation/pika/blob/3a232f25a9c67f0d7f7e984d1d0b49aecb22817c/src/storage/src/options_helper.h#L54
按照这里的说明类型应该是int64的

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of larger file sizes by updating configuration parameters to support 64-bit integers for file size settings.

- **Bug Fixes**
	- Improved reliability of the configuration loading process by switching to a method that accommodates larger integer values for file size configurations.

- **Documentation**
	- Updated comments to reflect the changes in data types for better clarity on configuration limits and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->