### PR TITLE
fix: add a function for washing data after upgrading version from 4.0.0 to 4.0.1

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -653,3 +653,8 @@ cache-lfu-decay-time: 1
 # which serves for the scenario of codis-pika cluster reelection
 # You'd better [DO NOT MODIFY IT UNLESS YOU KNOW WHAT YOU ARE DOING]
 internal-used-unfinished-full-sync :
+
+# for wash data from 4.0.0 to 4.0.1
+# https://github.com/OpenAtomFoundation/pika/issues/2886
+# default value: false
+wash-data: true

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -656,5 +656,5 @@ internal-used-unfinished-full-sync :
 
 # for wash data from 4.0.0 to 4.0.1
 # https://github.com/OpenAtomFoundation/pika/issues/2886
-# default value: false
+# default value: true
 wash-data: true

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -332,6 +332,10 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return share_block_cache_;
   }
+  bool wash_data() {
+    std::shared_lock l(rwlock_);
+    return wash_data_;
+  }
   bool enable_partitioned_index_filters() {
     std::shared_lock l(rwlock_);
     return enable_partitioned_index_filters_;
@@ -1069,6 +1073,9 @@ class PikaConf : public pstd::BaseConf {
 
   //Internal used metrics Persisted by pika.conf
   std::unordered_set<std::string> internal_used_unfinished_full_sync_;
+
+  // for wash data from 4.0.0 to 4.0.1
+  bool wash_data_;
 };
 
 #endif

--- a/include/pika_db.h
+++ b/include/pika_db.h
@@ -93,6 +93,7 @@ class DB : public std::enable_shared_from_this<DB>, public pstd::noncopyable {
   /**
    * When it is the first time for upgrading version from 4.0.0 to 4.0.1, you should call
    * this function to wash data.  false if successful, false otherwise.
+   * @see https://github.com/OpenAtomFoundation/pika/issues/2886
   */
   bool WashData();
 

--- a/include/pika_db.h
+++ b/include/pika_db.h
@@ -92,7 +92,7 @@ class DB : public std::enable_shared_from_this<DB>, public pstd::noncopyable {
 
   /**
    * When it is the first time for upgrading version from 4.0.0 to 4.0.1, you should call
-   * this function to wash data.  false if successful, false otherwise.
+   * this function to wash data.  true if successful, false otherwise.
    * @see https://github.com/OpenAtomFoundation/pika/issues/2886
   */
   bool WashData();

--- a/include/pika_db.h
+++ b/include/pika_db.h
@@ -90,6 +90,12 @@ class DB : public std::enable_shared_from_this<DB>, public pstd::noncopyable {
   friend class PkClusterInfoCmd;
   friend class PikaServer;
 
+  /**
+   * When it is the first time for upgrading version from 4.0.0 to 4.0.1, you should call
+   * this function to wash data.  false if successful, false otherwise.
+  */
+  bool WashData();
+
   std::string GetDBName();
   std::shared_ptr<storage::Storage> storage() const;
   void GetBgSaveMetaData(std::vector<std::string>* fileNames, std::string* snapshot_uuid);

--- a/src/pika.cc
+++ b/src/pika.cc
@@ -237,6 +237,7 @@ int main(int argc, char* argv[]) {
     auto dbs = g_pika_server->GetDB();
     for (auto& kv : dbs) {
       if (!kv.second->WashData()) {
+        LOG(FATAL) << "write batch error in WashData";
         return 1;
       }
     }

--- a/src/pika.cc
+++ b/src/pika.cc
@@ -232,6 +232,16 @@ int main(int argc, char* argv[]) {
     g_pika_conf.reset();
   };
 
+  // wash data if necessary
+  if (g_pika_conf->wash_data()) {
+    auto dbs = g_pika_server->GetDB();
+    for (auto& kv : dbs) {
+      if (!kv.second->WashData()) {
+        return 1;
+      }
+    }
+  }
+
   g_pika_rm->Start();
   g_pika_server->Start();
 

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -730,6 +730,8 @@ int PikaConf::Load() {
     rsync_timeout_ms_.store(tmp_rsync_timeout_ms);
   }
 
+  GetConfBool("wash-data", &wash_data_);
+
   return ret;
 }
 

--- a/src/pika_db.cc
+++ b/src/pika_db.cc
@@ -72,6 +72,7 @@ bool DB::WashData() {
         batch.Put(handle, key, internal_value.Encode());
       }
     }
+    delete it;
     s = db->Write(storage_->GetDefaultWriteOptions(i), &batch);
     if (!s.ok()) {
       return false;

--- a/src/pika_db.cc
+++ b/src/pika_db.cc
@@ -57,28 +57,23 @@ DB::~DB() {
 bool DB::WashData() {
   rocksdb::ReadOptions read_options;
   rocksdb::Status s;
+  auto suffix_len = storage::ParsedBaseDataValue::GetkBaseDataValueSuffixLength();
   for (int i = 0; i < g_pika_conf->db_instance_num(); i++) {
     rocksdb::WriteBatch batch;
     auto handle = storage_->GetHashCFHandles(i)[1];
     auto db = storage_->GetDBByIndex(i);
-    std::unique_ptr<rocksdb::Iterator> it(db->NewIterator(read_options, handle));
+    auto it(db->NewIterator(read_options, handle));
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
       std::string key = it->key().ToString();
       std::string value = it->value().ToString();
-      auto suffix_len = storage::ParsedBaseDataValue::GetkBaseDataValueSuffixLength();
-      if (value.size() >= suffix_len &&
-          std::all_of(value.end() - static_cast<int>(suffix_len), value.end() - storage::kTimestampLength,
-                      [](char c) { return c == 0; })) {
-        // right data, no wash
-      } else {
+      if (value.size() < suffix_len) {
+        // need to wash
         storage::BaseDataValue internal_value(value);
-        batch.Delete(handle, key);
         batch.Put(handle, key, internal_value.Encode());
       }
     }
     s = db->Write(storage_->GetDefaultWriteOptions(i), &batch);
     if (!s.ok()) {
-      LOG(ERROR) << "write batch error in WashData";
       return false;
     }
   }

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -1096,6 +1096,11 @@ class Storage {
                     const std::string& db_type, const std::unordered_map<std::string, std::string>& options);
   void GetRocksDBInfo(std::string& info);
 
+  // get hash cf handle in insts_[idx]
+  std::vector<rocksdb::ColumnFamilyHandle*> GetHashCFHandles(const int idx);
+  // get DefaultWriteOptions in insts_[idx]
+  rocksdb::WriteOptions GetDefaultWriteOptions(const int idx) const;
+
  private:
   std::vector<std::unique_ptr<Redis>> insts_;
   std::unique_ptr<SlotIndexer> slot_indexer_;

--- a/src/storage/src/base_data_value_format.h
+++ b/src/storage/src/base_data_value_format.h
@@ -98,11 +98,13 @@ public:
     }
   }
 
+  static size_t GetkBaseDataValueSuffixLength() { return kBaseDataValueSuffixLength; }
+
 protected:
   virtual void SetVersionToValue() override {};
 
 private:
-  const size_t kBaseDataValueSuffixLength = kSuffixReserveLength + kTimestampLength;
+  static const size_t kBaseDataValueSuffixLength = kSuffixReserveLength + kTimestampLength;
 };
 
 }  //  namespace storage

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -464,6 +464,8 @@ private:
   inline Status SetFirstOrLastID(const rocksdb::Slice& key, StreamMetaValue& stream_meta, bool is_set_first,
                                  rocksdb::ReadOptions& read_options);
 
+public:
+ inline rocksdb::WriteOptions GetDefaultWriteOptions() const { return default_write_options_; }
 
 private:
   int32_t index_ = 0;

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -89,6 +89,14 @@ static std::string AppendSubDirectory(const std::string& db_path, int index) {
   }
 }
 
+std::vector<rocksdb::ColumnFamilyHandle*> Storage::GetHashCFHandles(const int idx) {
+  return insts_[idx]->GetHashCFHandles();
+}
+
+rocksdb::WriteOptions Storage::GetDefaultWriteOptions(const int idx) const {
+  return insts_[idx]->GetDefaultWriteOptions();
+}
+
 Status Storage::Open(const StorageOptions& storage_options, const std::string& db_path) {
   mkpath(db_path.c_str(), 0755);
 


### PR DESCRIPTION
fix #2886 

因为 4.0.0 中错误格式的数据一定是在 hincrby 中产生的，那么 value 肯定为 '0' - '9' 的字符，所以一定可以与 4.0.0 中 reverse 中字符相区分。

当第一次从 4.0.0 升级到 4.0.1 时，建议开启 pika.conf 中 wash-data，清洗一遍数据。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new configuration option `wash-data` to enhance data migration handling.
	- Added methods for data washing in the `DB` class to ensure data integrity during version upgrades.
	- Implemented data integrity checks during server startup to ensure clean data.

- **Bug Fixes**
	- Improved data handling processes to ensure successful data migration between versions.

- **Documentation**
	- Updated comments in configuration files for better clarity on data handling metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->