### PR TITLE
fix:Segmentation fault in zremrangebyrank

### DIFF
--- a/src/pika_zset.cc
+++ b/src/pika_zset.cc
@@ -1356,6 +1356,8 @@ void ZRemrangebyrankCmd::DoInitial() {
     return;
   }
   key_ = argv_[1];
+  min_ = argv_[2];
+  max_ = argv_[3];
   if (pstd::string2int(argv_[2].data(), argv_[2].size(), &start_rank_) == 0) {
     res_.SetRes(CmdRes::kInvalidInt);
     return;
@@ -1384,7 +1386,7 @@ void ZRemrangebyrankCmd::DoThroughDB() {
 
 void ZRemrangebyrankCmd::DoUpdateCache() {
   if (s_.ok()) {
-    db_->cache()->ZRemrangebyrank(key_, min_, max_, ele_deleted_);
+    db_->cache()->ZRemrangebyrank(key_, min_, max_, ele_deleted_, db_);
   }
 }
 


### PR DESCRIPTION
https://github.com/OpenAtomFoundation/pika/issues/2891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `ZRemRangeByRank` command to support a broader range of input parameters for improved functionality.
  
- **Bug Fixes**
	- Improved interaction between cache and database for better performance and reliability.

- **Tests**
	- Added new test cases for the `ZRemRangeByRank` command to ensure expected behavior across various scenarios, including edge cases with duplicate scores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->