### PR TITLE
feat:add test for redis commands, including LPush, RPushX, BgSave, FlushDb and SetEx

### DIFF
--- a/tests/integration/list_test.go
+++ b/tests/integration/list_test.go
@@ -1291,5 +1291,28 @@ var _ = Describe("List Commands", func() {
 		//	Expect(lRange.Err()).NotTo(HaveOccurred())
 		//	Expect(lRange.Val()).To(Equal([]string{"san"}))
 		//})
+
+		It("should lpush and rpushx", func() {
+			lpush := client.LPush(ctx, "list1", 1, 2, 3, 4)
+			Expect(lpush.Err()).NotTo(HaveOccurred())
+			Expect(lpush.Val()).To(Equal(int64(4)))
+
+			getRes, err := client.Get(ctx, "list1").Result()
+			Expect(err).To(HaveOccurred())  // An error is expected since listkey is a list, not a string
+			Expect(getRes).To(Equal("")) 
+
+			lrang := client.LRange(ctx, "list1", 0, -1)
+			Expect(lrang.Err()).NotTo(HaveOccurred())
+			Expect(lrang.Val()).To(Equal([]string{"4", "3", "2", "1"}))
+
+			rpush := client.RPushX(ctx, "list1", 5)
+			Expect(rpush.Err()).NotTo(HaveOccurred())
+			Expect(rpush.Val()).To(Equal(int64(5)))
+
+			lrang = client.LRange(ctx, "list1", 0, -1)
+			Expect(lrang.Err()).NotTo(HaveOccurred())
+			Expect(lrang.Val()).To(Equal([]string{"4", "3", "2", "1", "5"}))
+
+		})
 	})
 })

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -797,6 +797,25 @@ var _ = Describe("String Commands", func() {
 			}, "2s", "100ms").Should(Equal(redis.Nil))
 		})
 
+		It("should SetEX ten seconds", func() {
+			err := client.SetEx(ctx, "x", "y", 10 * time.Second).Err()
+			Expect(err).NotTo(HaveOccurred())
+		
+			val, err := client.Get(ctx, "x").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("y"))
+		
+			time.Sleep(11 * time.Second)
+			//sleep 10 second x still exists
+		
+			err = client.Do(ctx, "compact").Err()
+			Expect(err).NotTo(HaveOccurred())
+		
+			keys, err := client.Keys(ctx, "x").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).To(BeEmpty())
+		})
+		
 		It("should SetNX", func() {
 			_, err := client.Del(ctx, "key").Result()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
add list test in list_test.go
add bgsave test ,flushdb test  and info test in server_test.go
add setex test in string_test.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced integration test coverage for Redis commands, including `LPush`, `RPushX`, `BgSave`, `FlushDb`, and `SetEx`.
	- Added validations for data persistence and expiration functionalities.

- **Tests**
	- Introduced new test cases to ensure proper functionality of list operations, background saving, database flushing, and key expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->