### PR TITLE
feat:add test for redis commands, including LPush, RPushX, BgSave, FlushDb and SetEx

### DIFF
--- a/tests/integration/list_test.go
+++ b/tests/integration/list_test.go
@@ -1291,5 +1291,28 @@ var _ = Describe("List Commands", func() {
 		//	Expect(lRange.Err()).NotTo(HaveOccurred())
 		//	Expect(lRange.Val()).To(Equal([]string{"san"}))
 		//})
+
+		It("should lpush and rpushx", func() {
+			lpush := client.LPush(ctx, "list1", 1, 2, 3, 4)
+			Expect(lpush.Err()).NotTo(HaveOccurred())
+			Expect(lpush.Val()).To(Equal(int64(4)))
+
+			getRes, err := client.Get(ctx, "list1").Result()
+			Expect(err).To(HaveOccurred())  // An error is expected since listkey is a list, not a string
+			Expect(getRes).To(Equal("")) 
+
+			lrang := client.LRange(ctx, "list1", 0, -1)
+			Expect(lrang.Err()).NotTo(HaveOccurred())
+			Expect(lrang.Val()).To(Equal([]string{"4", "3", "2", "1"}))
+
+			rpush := client.RPushX(ctx, "list1", 5)
+			Expect(rpush.Err()).NotTo(HaveOccurred())
+			Expect(rpush.Val()).To(Equal(int64(5)))
+
+			lrang = client.LRange(ctx, "list1", 0, -1)
+			Expect(lrang.Err()).NotTo(HaveOccurred())
+			Expect(lrang.Val()).To(Equal([]string{"4", "3", "2", "1", "5"}))
+
+		})
 	})
 })

--- a/tests/integration/server_test.go
+++ b/tests/integration/server_test.go
@@ -171,11 +171,14 @@ var _ = Describe("Server", func() {
 			Expect(err2).NotTo(HaveOccurred())
 			Expect(res.Err()).NotTo(HaveOccurred())
 			Expect(res2).To(ContainSubstring("Background saving started"))
-			dumpPath := "../dump/"
 
 			time.Sleep(5 * time.Second)
 			//wait for bgsave complete
 
+			dumpConfig := client.ConfigGet(ctx, "dump-path")
+			Expect(dumpConfig.Err()).NotTo(HaveOccurred())
+			dumpPath, ok := dumpConfig.Val()["dump-path"]
+			Expect(ok).To(BeTrue())
 			files, err := os.ReadDir(dumpPath)
 			Expect(err).NotTo(HaveOccurred())
 			//need to delete test bgsave file?

--- a/tests/integration/server_test.go
+++ b/tests/integration/server_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 	"os"
 	"fmt"
+	"path/filepath"
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
 	"github.com/redis/go-redis/v9"
@@ -198,21 +199,40 @@ var _ = Describe("Server", func() {
 			dumpPath, ok := dumpConfig.Val()["dump-path"]
 			Expect(ok).To(BeTrue())
 
-			currentDir, err := os.Getwd()
-			Expect(err).NotTo(HaveOccurred())
-			fmt.Printf("Current working directory: %s\n", currentDir)
+			// Convert dumpPath to absolute path
+			baseDir := "/home/runner/work/pika/"
+			absDumpPath := filepath.Join(baseDir, dumpPath)
 
-			fmt.Printf("Dump path: %s\n", dumpPath)
-			
 			// Check if dumpPath exists and is a directory
-			info, err := os.Stat(dumpPath)
+			info, err := os.Stat(absDumpPath)
 			if os.IsNotExist(err) {
-				Fail("Directory does not exist: " + dumpPath)
-			} else if err != nil {
-				Fail("Error accessing directory: " + err.Error())
-			}
-			Expect(info.IsDir()).To(BeTrue(), "dump path should be a directory")
+				// If dumpPath does not exist, search for 'dump' directories
+				fmt.Println("Dump path does not exist. Searching for 'dump' directories...")
 
+				err = filepath.WalkDir(baseDir, func(path string, info os.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+
+					if info.IsDir() && info.Name() == "dump" {
+						absPath, err := filepath.Abs(path)
+						if err != nil {
+							return err
+						}
+						fmt.Println("Found dump directory:", absPath)
+					}
+
+					return nil
+				})
+
+				if err != nil {
+					Fail("Error while searching for dump directories: " + err.Error())
+				}
+			} else if err != nil {
+				Fail("Error accessing dump path: " + err.Error())
+			} else {
+				Expect(info.IsDir()).To(BeTrue(), "dump path should be a directory")
+			}
 			files, err := os.ReadDir(dumpPath)
 			Expect(err).NotTo(HaveOccurred())
 			//need to delete test bgsave file?

--- a/tests/integration/server_test.go
+++ b/tests/integration/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 	"os"
+	"fmt"
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
 	"github.com/redis/go-redis/v9"
@@ -196,6 +197,22 @@ var _ = Describe("Server", func() {
 			Expect(dumpConfig.Err()).NotTo(HaveOccurred())
 			dumpPath, ok := dumpConfig.Val()["dump-path"]
 			Expect(ok).To(BeTrue())
+
+			currentDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("Current working directory: %s\n", currentDir)
+
+			fmt.Printf("Dump path: %s\n", dumpPath)
+			
+			// Check if dumpPath exists and is a directory
+			info, err := os.Stat(dumpPath)
+			if os.IsNotExist(err) {
+				Fail("Directory does not exist: " + dumpPath)
+			} else if err != nil {
+				Fail("Error accessing directory: " + err.Error())
+			}
+			Expect(info.IsDir()).To(BeTrue(), "dump path should be a directory")
+
 			files, err := os.ReadDir(dumpPath)
 			Expect(err).NotTo(HaveOccurred())
 			//need to delete test bgsave file?

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -797,6 +797,25 @@ var _ = Describe("String Commands", func() {
 			}, "2s", "100ms").Should(Equal(redis.Nil))
 		})
 
+		It("should SetEX ten seconds", func() {
+			err := client.SetEx(ctx, "x", "y", 10 * time.Second).Err()
+			Expect(err).NotTo(HaveOccurred())
+		
+			val, err := client.Get(ctx, "x").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("y"))
+		
+			time.Sleep(11 * time.Second)
+			//sleep 10 second x still exists
+		
+			err = client.Do(ctx, "compact").Err()
+			Expect(err).NotTo(HaveOccurred())
+		
+			keys, err := client.Keys(ctx, "x").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).To(BeEmpty())
+		})
+		
 		It("should SetNX", func() {
 			_, err := client.Del(ctx, "key").Result()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
add list test in list_test.go
add bgsave test ,flushdb test and info test in server_test.go
add setex test in string_test.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced test coverage for Redis list operations, including `LPush` and `RPushX` commands.
	- Added integration tests for server commands: `BgSave`, `FlushDb`, and `Info`.
	- Introduced a test case for the `SetEx` method to validate key expiration functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->