### PR TITLE
feat:zpopmax && zpopmin to do cache

### DIFF
--- a/include/pika_cache.h
+++ b/include/pika_cache.h
@@ -172,6 +172,8 @@ class PikaCache : public pstd::noncopyable, public std::enable_shared_from_this<
   rocksdb::Status ZLexcount(std::string& key, std::string& min, std::string& max, uint64_t* len,
                             const std::shared_ptr<DB>& db);
   rocksdb::Status ZRemrangebylex(std::string& key, std::string& min, std::string& max, const std::shared_ptr<DB>& db);
+  rocksdb::Status ZPopMin(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db);
+  rocksdb::Status ZPopMax(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db);
 
   // Bit Commands
   rocksdb::Status SetBit(std::string& key, size_t offset, int64_t value);

--- a/include/pika_cache.h
+++ b/include/pika_cache.h
@@ -149,9 +149,10 @@ class PikaCache : public pstd::noncopyable, public std::enable_shared_from_this<
   rocksdb::Status ZCard(std::string& key, uint32_t* len, const std::shared_ptr<DB>& db);
   rocksdb::Status ZCount(std::string& key, std::string& min, std::string& max, uint64_t* len, ZCountCmd* cmd);
   rocksdb::Status ZIncrby(std::string& key, std::string& member, double increment);
-  rocksdb::Status ZIncrbyIfKeyExist(std::string& key, std::string& member, double increment, ZIncrbyCmd* cmd, const std::shared_ptr<DB>& db);
-  rocksdb::Status ZRange(std::string& key, int64_t start, int64_t stop, std::vector<storage::ScoreMember>* score_members,
-                         const std::shared_ptr<DB>& db);
+  rocksdb::Status ZIncrbyIfKeyExist(std::string& key, std::string& member, double increment, ZIncrbyCmd* cmd,
+                                    const std::shared_ptr<DB>& db);
+  rocksdb::Status ZRange(std::string& key, int64_t start, int64_t stop,
+                         std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db);
   rocksdb::Status ZRangebyscore(std::string& key, std::string& min, std::string& max,
                                 std::vector<storage::ScoreMember>* score_members, ZRangebyscoreCmd* cmd);
   rocksdb::Status ZRank(std::string& key, std::string& member, int64_t* rank, const std::shared_ptr<DB>& db);
@@ -159,21 +160,24 @@ class PikaCache : public pstd::noncopyable, public std::enable_shared_from_this<
   rocksdb::Status ZRemrangebyrank(std::string& key, std::string& min, std::string& max, int32_t ele_deleted = 0,
                                   const std::shared_ptr<DB>& db = nullptr);
   rocksdb::Status ZRemrangebyscore(std::string& key, std::string& min, std::string& max, const std::shared_ptr<DB>& db);
-  rocksdb::Status ZRevrange(std::string& key, int64_t start, int64_t stop, std::vector<storage::ScoreMember>* score_members,
-                            const std::shared_ptr<DB>& db);
+  rocksdb::Status ZRevrange(std::string& key, int64_t start, int64_t stop,
+                            std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db);
   rocksdb::Status ZRevrangebyscore(std::string& key, std::string& min, std::string& max,
                                    std::vector<storage::ScoreMember>* score_members, ZRevrangebyscoreCmd* cmd,
                                    const std::shared_ptr<DB>& db);
-  rocksdb::Status ZRevrangebylex(std::string& key, std::string& min, std::string& max, std::vector<std::string>* members,
-                                 const std::shared_ptr<DB>& db);
-  rocksdb::Status ZRevrank(std::string& key, std::string& member, int64_t *rank, const std::shared_ptr<DB>& db);
+  rocksdb::Status ZRevrangebylex(std::string& key, std::string& min, std::string& max,
+                                 std::vector<std::string>* members, const std::shared_ptr<DB>& db);
+  rocksdb::Status ZRevrank(std::string& key, std::string& member, int64_t* rank, const std::shared_ptr<DB>& db);
   rocksdb::Status ZScore(std::string& key, std::string& member, double* score, const std::shared_ptr<DB>& db);
-  rocksdb::Status ZRangebylex(std::string& key, std::string& min, std::string& max, std::vector<std::string>* members, const std::shared_ptr<DB>& db);
+  rocksdb::Status ZRangebylex(std::string& key, std::string& min, std::string& max, std::vector<std::string>* members,
+                              const std::shared_ptr<DB>& db);
   rocksdb::Status ZLexcount(std::string& key, std::string& min, std::string& max, uint64_t* len,
                             const std::shared_ptr<DB>& db);
   rocksdb::Status ZRemrangebylex(std::string& key, std::string& min, std::string& max, const std::shared_ptr<DB>& db);
-  rocksdb::Status ZPopMin(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db);
-  rocksdb::Status ZPopMax(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db);
+  rocksdb::Status ZPopMin(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members,
+                          const std::shared_ptr<DB>& db);
+  rocksdb::Status ZPopMax(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members,
+                          const std::shared_ptr<DB>& db);
 
   // Bit Commands
   rocksdb::Status SetBit(std::string& key, size_t offset, int64_t value);

--- a/include/pika_zset.h
+++ b/include/pika_zset.h
@@ -603,6 +603,8 @@ class ZPopmaxCmd : public Cmd {
   void Do() override;
   void Split(const HintKeys& hint_keys) override {};
   void Merge() override {};
+  void DoThroughDB() override;
+  void DoUpdateCache() override;
   Cmd* Clone() override { return new ZPopmaxCmd(*this); }
 
  private:
@@ -623,6 +625,8 @@ class ZPopminCmd : public Cmd {
   void Do() override;
   void Split(const HintKeys& hint_keys) override {};
   void Merge() override {};
+  void DoThroughDB() override;
+  void DoUpdateCache() override;
   Cmd* Clone() override { return new ZPopminCmd(*this); }
 
  private:

--- a/src/cache/include/cache.h
+++ b/src/cache/include/cache.h
@@ -147,6 +147,8 @@ public:
                      std::vector<std::string> *members);
   Status ZLexcount(std::string& key, std::string &min, std::string &max, uint64_t *len);
   Status ZRemrangebylex(std::string& key, std::string &min, std::string &max);
+  Status ZPopMin(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members);
+  Status ZPopMax(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members);
 
   // Bit Commands
   Status SetBit(std::string& key, size_t offset, int64_t value);

--- a/src/cache/src/zset.cc
+++ b/src/cache/src/zset.cc
@@ -405,13 +405,11 @@ Status RedisCache::ZRemrangebylex(std::string& key, std::string &min, std::strin
   return Status::OK();
 }
 
-Status RedisCache::ZPopMin(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members) {
-  zitem* items = nullptr;
+Status RedisCache::ZPopMin(std::string &key, int64_t count, std::vector<storage::ScoreMember> *score_members) {
+  zitem *items = nullptr;
   unsigned long items_size = 0;
-  robj* kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
-  DEFER {
-    DecrObjectsRefCount(kobj);
-  };
+  robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
+  DEFER { DecrObjectsRefCount(kobj); };
 
   int ret = RcZrange(cache_, kobj, 0, -1, &items, &items_size);
   if (C_OK != ret) {
@@ -429,13 +427,11 @@ Status RedisCache::ZPopMin(std::string& key, int64_t count, std::vector<storage:
     score_members->push_back(sm);
   }
 
-  robj** members_obj = (robj**)zcallocate(sizeof(robj*) * items_size);
+  robj **members_obj = (robj **)zcallocate(sizeof(robj *) * items_size);
   for (unsigned long i = 0; i < items_size; ++i) {
     members_obj[i] = createObject(OBJ_STRING, sdsnewlen(items[i].member, sdslen(items[i].member)));
   }
-  DEFER {
-    FreeObjectList(members_obj, items_size);
-  };
+  DEFER { FreeObjectList(members_obj, items_size); };
 
   RcZRem(cache_, kobj, members_obj, to_return);
 
@@ -443,13 +439,11 @@ Status RedisCache::ZPopMin(std::string& key, int64_t count, std::vector<storage:
   return Status::OK();
 }
 
-Status RedisCache::ZPopMax(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members) {
-  zitem* items = nullptr;
+Status RedisCache::ZPopMax(std::string &key, int64_t count, std::vector<storage::ScoreMember> *score_members) {
+  zitem *items = nullptr;
   unsigned long items_size = 0;
-  robj* kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
-  DEFER {
-    DecrObjectsRefCount(kobj);
-  };
+  robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
+  DEFER { DecrObjectsRefCount(kobj); };
 
   int ret = RcZrange(cache_, kobj, 0, -1, &items, &items_size);
   if (C_OK != ret) {
@@ -467,21 +461,18 @@ Status RedisCache::ZPopMax(std::string& key, int64_t count, std::vector<storage:
     score_members->push_back(sm);
   }
 
-  robj** members_obj = (robj**)zcallocate(sizeof(robj*) * items_size);
+  robj **members_obj = (robj **)zcallocate(sizeof(robj *) * items_size);
   for (unsigned long i = items_size - 1; i >= 0; --i) {
     members_obj[items_size - 1 - i] = createObject(OBJ_STRING, sdsnewlen(items[i].member, sdslen(items[i].member)));
   }
 
-  DEFER {
-    FreeObjectList(members_obj, items_size);
-  };
+  DEFER { FreeObjectList(members_obj, items_size); };
 
   RcZRem(cache_, kobj, members_obj, to_return);
 
   FreeZitemList(items, items_size);
   return Status::OK();
 }
-
 
 }  // namespace cache
 /* EOF */

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -1465,7 +1465,8 @@ Status PikaCache::ZRemrangebylex(std::string& key, std::string &min, std::string
   }
 }
 
-Status PikaCache::ZPopMin(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db) {
+Status PikaCache::ZPopMin(std::string &key, int64_t count, std::vector<storage::ScoreMember> *score_members,
+                          const std::shared_ptr<DB> &db) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
 
@@ -1479,7 +1480,8 @@ Status PikaCache::ZPopMin(std::string& key, int64_t count, std::vector<storage::
   }
 }
 
-Status PikaCache::ZPopMax(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db) {
+Status PikaCache::ZPopMax(std::string &key, int64_t count, std::vector<storage::ScoreMember> *score_members,
+                          const std::shared_ptr<DB> &db) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
 

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -1465,6 +1465,34 @@ Status PikaCache::ZRemrangebylex(std::string& key, std::string &min, std::string
   }
 }
 
+Status PikaCache::ZPopMin(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db) {
+  int cache_index = CacheIndex(key);
+  std::lock_guard lm(*cache_mutexs_[cache_index]);
+
+  auto cache_obj = caches_[cache_index];
+  Status s;
+
+  if (cache_obj->Exists(key)) {
+    return cache_obj->ZPopMin(key, count, score_members);
+  } else {
+    return Status::NotFound("key not in cache");
+  }
+}
+
+Status PikaCache::ZPopMax(std::string& key, int64_t count, std::vector<storage::ScoreMember>* score_members, const std::shared_ptr<DB>& db) {
+  int cache_index = CacheIndex(key);
+  std::lock_guard lm(*cache_mutexs_[cache_index]);
+
+  auto cache_obj = caches_[cache_index];
+  Status s;
+
+  if (cache_obj->Exists(key)) {
+    return cache_obj->ZPopMax(key, count, score_members);
+  } else {
+    return Status::NotFound("key not in cache");
+  }
+}
+
 /*-----------------------------------------------------------------------------
  * Bit Commands
  *----------------------------------------------------------------------------*/

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -600,11 +600,11 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRemrangebylex, std::move(zremrangebylexptr)));
   ////ZPopmax
   std::unique_ptr<Cmd> zpopmaxptr = std::make_unique<ZPopmaxCmd>(
-      kCmdNameZPopmax, -2, kCmdFlagsWrite |  kCmdFlagsZset | kCmdFlagsFast);
+      kCmdNameZPopmax, -2, kCmdFlagsWrite |  kCmdFlagsZset | kCmdFlagsFast | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZPopmax, std::move(zpopmaxptr)));
   ////ZPopmin
   std::unique_ptr<Cmd> zpopminptr = std::make_unique<ZPopminCmd>(
-      kCmdNameZPopmin, -2, kCmdFlagsWrite |  kCmdFlagsZset | kCmdFlagsFast);
+      kCmdNameZPopmin, -2, kCmdFlagsWrite |  kCmdFlagsZset | kCmdFlagsFast | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZPopmin, std::move(zpopminptr)));
 
   // Set

--- a/src/pika_zset.cc
+++ b/src/pika_zset.cc
@@ -1507,6 +1507,17 @@ void ZPopmaxCmd::Do() {
   }
 }
 
+void ZPopmaxCmd::DoThroughDB(){
+  Do();
+}
+
+void ZPopmaxCmd::DoUpdateCache(){
+  std::vector<storage::ScoreMember> score_members;
+  if(s_.ok() || s_.IsNotFound()){
+    db_->cache()->ZPopMax(key_, count_, &score_members, db_);
+  }
+}
+
 void ZPopminCmd::DoInitial() {
   if (!CheckArg(argv_.size())) {
     res_.SetRes(CmdRes::kWrongNum, kCmdNameZPopmin);
@@ -1520,6 +1531,17 @@ void ZPopminCmd::DoInitial() {
     if (pstd::string2int(argv_[2].data(), argv_[2].size(), static_cast<int64_t *>(&count_)) == 0) {
       res_.SetRes(CmdRes::kInvalidInt);
     }
+  }
+}
+
+void ZPopminCmd::DoThroughDB(){
+  Do();
+}
+
+void ZPopminCmd::DoUpdateCache(){
+  std::vector<storage::ScoreMember> score_members;
+  if(s_.ok() || s_.IsNotFound()){
+    db_->cache()->ZPopMin(key_, count_, &score_members, db_);
   }
 }
 

--- a/src/pika_zset.cc
+++ b/src/pika_zset.cc
@@ -1507,13 +1507,13 @@ void ZPopmaxCmd::Do() {
   }
 }
 
-void ZPopmaxCmd::DoThroughDB(){
+void ZPopmaxCmd::DoThroughDB() {
   Do();
 }
 
-void ZPopmaxCmd::DoUpdateCache(){
+void ZPopmaxCmd::DoUpdateCache() {
   std::vector<storage::ScoreMember> score_members;
-  if(s_.ok() || s_.IsNotFound()){
+  if (s_.ok() || s_.IsNotFound()) {
     db_->cache()->ZPopMax(key_, count_, &score_members, db_);
   }
 }
@@ -1534,13 +1534,13 @@ void ZPopminCmd::DoInitial() {
   }
 }
 
-void ZPopminCmd::DoThroughDB(){
+void ZPopminCmd::DoThroughDB() {
   Do();
 }
 
-void ZPopminCmd::DoUpdateCache(){
+void ZPopminCmd::DoUpdateCache() {
   std::vector<storage::ScoreMember> score_members;
-  if(s_.ok() || s_.IsNotFound()){
+  if (s_.ok() || s_.IsNotFound()) {
     db_->cache()->ZPopMin(key_, count_, &score_members, db_);
   }
 }

--- a/tests/integration/zset_test.go
+++ b/tests/integration/zset_test.go
@@ -1092,6 +1092,38 @@ var _ = Describe("Zset Commands", func() {
 		Expect(err).To(MatchError(ContainSubstring("ERR wrong number of arguments for 'zpopmin' command")))
 	})
 
+	It("should Zpopmin test", func() {
+		err := client.ZAdd(ctx, "zpopzset1", redis.Z{
+			Score:  1,
+			Member: "m1",
+		}).Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = client.ZAdd(ctx, "zpopzset1", redis.Z{
+			Score:  3,
+			Member: "m3",
+		}).Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = client.ZAdd(ctx, "zpopzset1", redis.Z{
+			Score:  4,
+			Member: "m4",
+		}).Err()
+		Expect(err).NotTo(HaveOccurred())
+
+		max, err := client.ZPopMax(ctx, "zpopzset1", 1).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(max).To(Equal([]redis.Z{{Score: 4, Member: "m4"}}))
+
+		min, err := client.ZPopMin(ctx, "zpopzset1", 1).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(min).To(Equal([]redis.Z{{Score: 1, Member: "m1"}}))
+
+		rangeResult, err := client.ZRange(ctx, "zpopzset1", 0, -1).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rangeResult).To(Equal([]string{"m3"}))
+	})
+
 	It("should ZRange", func() {
 		err := client.ZAdd(ctx, "zset", redis.Z{Score: 1, Member: "one"}).Err()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
fix issue https://github.com/OpenAtomFoundation/pika/issues/2892 (执行zpopmin后还能查询到被删除数据)
1.zpopmin与zpopmax作为写操作不会更新到cache值，导致对cache进行读操作的指令能读到被zpopmin删除的值，因此为zpopmin与zpopmax添加了更新cache的功能。
2.新增对应的测试case
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced `ZPopMin` and `ZPopMax` methods to remove and retrieve elements from sorted sets based on scores.
	- Enhanced `ZPopmaxCmd` and `ZPopminCmd` with new methods for database interaction and cache updates.

- **Bug Fixes**
	- Improved error handling for cases where keys do not exist in the cache.

- **Refactor**
	- Updated method signatures across several classes to enhance functionality and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->