### PR TITLE
fix: change sloglog to INFO

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite autoconf protobuf llvm wget git
+          brew install --overwrite python@3.12 autoconf protobuf llvm wget git
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite python@3.12 autoconf protobuf llvm wget git
+          brew install --overwrite python@3.13 autoconf protobuf llvm wget git
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,8 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite python@3.13 autoconf protobuf llvm wget git
+          brew link --overwrite python@3.12
+          brew install --overwrite autoconf protobuf llvm wget git
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -156,7 +156,7 @@ jobs:
           sh integrate_test.sh
 
   build_on_macos:
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
         with:
-          key: macos-12
+          key: macos-latest
 
       - name: Install Deps
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -156,7 +156,7 @@ jobs:
           sh integrate_test.sh
 
   build_on_macos:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4
@@ -169,12 +169,12 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
         with:
-          key: macos-12
+          key: macos-13
 
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite autoconf protobuf llvm
+          brew install --overwrite protobuf llvm
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -156,7 +156,7 @@ jobs:
           sh integrate_test.sh
 
   build_on_macos:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
         with:
-          key: macos-12
+          key: macos-14
 
       - name: Install Deps
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -156,7 +156,7 @@ jobs:
           sh integrate_test.sh
 
   build_on_macos:
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
         with:
-          key: macos-11
+          key: macos-12
 
       - name: Install Deps
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite protobuf llvm
+          brew install --overwrite python@3.12 autoconf protobuf llvm wget git
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,8 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew link --overwrite python@3.13
-          brew install --overwrite protobuf llvm
+          brew install --overwrite python@3.13 protobuf llvm
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite python@3.12 autoconf protobuf llvm wget git
+          brew install --overwrite protobuf llvm
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite python@3.13 protobuf llvm
+          brew install --overwrite python@3.13 protobuf llvm zlib
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -156,7 +156,7 @@ jobs:
           sh integrate_test.sh
 
   build_on_macos:
-    runs-on: macos-14
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
         with:
-          key: macos-14
+          key: macos-13
 
       - name: Install Deps
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite python@3.13 protobuf llvm zlib
+          brew install --overwrite python@3.13 protobuf llvm
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -156,7 +156,7 @@ jobs:
           sh integrate_test.sh
 
   build_on_macos:
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v4
@@ -169,12 +169,12 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
         with:
-          key: macos-latest
+          key: macos-11
 
       - name: Install Deps
         run: |
           brew update
-          brew install --overwrite python@3.12 autoconf protobuf llvm wget git
+          brew install --overwrite autoconf protobuf llvm
           brew install gcc@10 automake cmake make binutils
 
       - name: Configure CMake

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -156,7 +156,7 @@ jobs:
           sh integrate_test.sh
 
   build_on_macos:
-    runs-on: macos-13
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.13
         with:
-          key: macos-13
+          key: macos-12
 
       - name: Install Deps
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,7 +174,6 @@ jobs:
       - name: Install Deps
         run: |
           brew update
-          brew link --overwrite python@3.12
           brew install --overwrite autoconf protobuf llvm wget git
           brew install gcc@10 automake cmake make binutils
 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Configure CMake
         run: |
           export CC=/usr/local/opt/gcc@10/bin/gcc-10 
-          cmake -B build -DCMAKE_C_COMPILER=/usr/local/opt/gcc@10/bin/gcc-10 -DUSE_PIKA_TOOLS=ON -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -B build -DCMAKE_C_COMPILER=/usr/local/opt/gcc@10/bin/gcc-10 -DCMAKE_PREFIX_PATH=$(brew --prefix zlib) -DUSE_PIKA_TOOLS=ON -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
         run: |
@@ -198,7 +198,6 @@ jobs:
       - name: Unit Test
         working-directory: ${{ github.workspace }}
         run: |
-          cmake -B build -DZLIB_ROOT=$(brew --prefix zlib) -DCMAKE_BUILD_TYPE=RelWithDebInfo
           ./pikatests.sh all clean
 
       - name: Start codis, pika master and pika slave

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -174,6 +174,7 @@ jobs:
       - name: Install Deps
         run: |
           brew update
+          brew link --overwrite python@3.13
           brew install --overwrite protobuf llvm
           brew install gcc@10 automake cmake make binutils
 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Configure CMake
         run: |
           export CC=/usr/local/opt/gcc@10/bin/gcc-10 
-          cmake -B build -DCMAKE_C_COMPILER=/usr/local/opt/gcc@10/bin/gcc-10 -DCMAKE_PREFIX_PATH=$(brew --prefix zlib) -DUSE_PIKA_TOOLS=ON -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -B build -DCMAKE_C_COMPILER=/usr/local/opt/gcc@10/bin/gcc-10 -DUSE_PIKA_TOOLS=ON -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -198,6 +198,7 @@ jobs:
       - name: Unit Test
         working-directory: ${{ github.workspace }}
         run: |
+          cmake -B build -DZLIB_ROOT=$(brew --prefix zlib) -DCMAKE_BUILD_TYPE=RelWithDebInfo
           ./pikatests.sh all clean
 
       - name: Start codis, pika master and pika slave

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -236,7 +236,7 @@ void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, uint64_t do_dur
           }
         }
       }
-      LOG(ERROR) << "ip_port: " << ip_port() << ", db: " << current_db_ << ", command:" << slow_log
+      LOG(INFO) << "ip_port: " << ip_port() << ", db: " << current_db_ << ", command:" << slow_log
                  << ", command_size: " << cmd_size - 1 << ", arguments: " << argv.size()
                  << ", total_time(ms): " << time_stat_->total_time() / 1000
                  << ", before_queue_time(ms): " << time_stat_->before_queue_time() / 1000


### PR DESCRIPTION
将慢日志的日志级别从 ERROR 日志调整为 INFO 日志

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the macOS build environment to use macOS 13 for improved compatibility.
	- Modified dependency installation commands to ensure the correct compiler configuration, replacing `python@3.12` with `python@3.13`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->