### PR TITLE
fix: fix user ERR NOAUTH Authentication required

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -103,7 +103,7 @@ timeout : 60
 # the value of userpass will be ignored and all users are considered as administrators,
 # in this scenario, users are not subject to the restrictions imposed by the userblacklist.
 # PS: "user password" refers to value of the parameter below: userpass.
-requirepass : 123
+requirepass :
 
 # Password for replication verify, used for authentication when a slave
 # connects to a master to request replication.
@@ -115,14 +115,14 @@ masterauth :
 # the value of this parameter will be ignored and all users are considered as administrators,
 # in this scenario, users are not subject to the restrictions imposed by the userblacklist.
 # PS: "admin password" refers to value of the parameter above: requirepass.
-userpass :12345
+# userpass :
 
 # The blacklist of commands for users that logged in by userpass,
 # the commands that added to this list will not be available for users except for administrator.
 # [Advice] It's recommended to add high-risk commands to this list.
 # [Format] Commands should be separated by ",". For example: FLUSHALL, SHUTDOWN, KEYS, CONFIG
 # By default, this list is empty.
-userblacklist :FLUSHALL
+# userblacklist :
 
 # Running Mode of Pika, The current version only supports running in "classic mode".
 # If set to 'classic', Pika will create multiple DBs whose number is the value of configure item "databases".

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -103,7 +103,7 @@ timeout : 60
 # the value of userpass will be ignored and all users are considered as administrators,
 # in this scenario, users are not subject to the restrictions imposed by the userblacklist.
 # PS: "user password" refers to value of the parameter below: userpass.
-requirepass :
+requirepass : 123
 
 # Password for replication verify, used for authentication when a slave
 # connects to a master to request replication.
@@ -115,14 +115,14 @@ masterauth :
 # the value of this parameter will be ignored and all users are considered as administrators,
 # in this scenario, users are not subject to the restrictions imposed by the userblacklist.
 # PS: "admin password" refers to value of the parameter above: requirepass.
-# userpass :
+userpass :12345
 
 # The blacklist of commands for users that logged in by userpass,
 # the commands that added to this list will not be available for users except for administrator.
 # [Advice] It's recommended to add high-risk commands to this list.
 # [Format] Commands should be separated by ",". For example: FLUSHALL, SHUTDOWN, KEYS, CONFIG
 # By default, this list is empty.
-# userblacklist :
+userblacklist :FLUSHALL
 
 # Running Mode of Pika, The current version only supports running in "classic mode".
 # If set to 'classic', Pika will create multiple DBs whose number is the value of configure item "databases".

--- a/include/acl.h
+++ b/include/acl.h
@@ -129,7 +129,7 @@ class AclSelector {
   friend User;
 
  public:
-  explicit AclSelector() : AclSelector(0){};
+  explicit AclSelector() : AclSelector(0) {};
   explicit AclSelector(uint32_t flag);
   explicit AclSelector(const AclSelector& selector);
   ~AclSelector() = default;
@@ -138,7 +138,7 @@ class AclSelector {
   inline bool HasFlags(uint32_t flag) const { return flags_ & flag; };
   inline void AddFlags(uint32_t flag) { flags_ |= flag; };
   inline void DecFlags(uint32_t flag) { flags_ &= ~flag; };
-  bool EqualChannel(const std::vector<std::string> &allChannel);
+  bool EqualChannel(const std::vector<std::string>& allChannel);
 
  private:
   pstd::Status SetSelector(const std::string& op);
@@ -224,8 +224,7 @@ class User {
   ~User() = default;
 
   std::string Name() const;
-
-  //  inline uint32_t Flags() const { return flags_; };
+  // inline uint32_t Flags() const { return flags_; };
   inline bool HasFlags(uint32_t flag) const { return flags_ & flag; };
   inline void AddFlags(uint32_t flag) { flags_ |= flag; };
   inline void DecFlags(uint32_t flag) { flags_ &= ~flag; };

--- a/include/pika_client_conn.h
+++ b/include/pika_client_conn.h
@@ -22,25 +22,15 @@ struct TimeStat {
     before_queue_ts_ = 0;
   }
 
-  uint64_t start_ts() const {
-    return enqueue_ts_;
-  }
+  uint64_t start_ts() const { return enqueue_ts_; }
 
-  uint64_t total_time() const {
-    return process_done_ts_ > enqueue_ts_ ? process_done_ts_ - enqueue_ts_ : 0;
-  }
+  uint64_t total_time() const { return process_done_ts_ > enqueue_ts_ ? process_done_ts_ - enqueue_ts_ : 0; }
 
-  uint64_t queue_time() const {
-    return dequeue_ts_ > enqueue_ts_ ? dequeue_ts_ - enqueue_ts_ : 0;
-  }
+  uint64_t queue_time() const { return dequeue_ts_ > enqueue_ts_ ? dequeue_ts_ - enqueue_ts_ : 0; }
 
-  uint64_t process_time() const {
-    return process_done_ts_ > dequeue_ts_ ? process_done_ts_ - dequeue_ts_ : 0;
-  }
+  uint64_t process_time() const { return process_done_ts_ > dequeue_ts_ ? process_done_ts_ - dequeue_ts_ : 0; }
 
-  uint64_t before_queue_time() const {
-    return process_done_ts_ > dequeue_ts_ ? before_queue_ts_ - enqueue_ts_ : 0;
-  }
+  uint64_t before_queue_time() const { return process_done_ts_ > dequeue_ts_ ? before_queue_ts_ - enqueue_ts_ : 0; }
 
   uint64_t enqueue_ts_;
   uint64_t dequeue_ts_;
@@ -94,7 +84,7 @@ class PikaClientConn : public net::RedisConn {
   void UnAuth(const std::shared_ptr<User>& user);
 
   bool IsAuthed() const;
-
+  void InitUser();
   bool AuthRequired() const;
 
   std::string UserName() const;
@@ -123,6 +113,7 @@ class PikaClientConn : public net::RedisConn {
   std::vector<std::shared_ptr<std::string>> resp_array;
 
   std::shared_ptr<TimeStat> time_stat_;
+
  private:
   net::ServerThread* const server_thread_;
   std::string current_db_;

--- a/src/acl.cc
+++ b/src/acl.cc
@@ -477,7 +477,11 @@ void Acl::UpdateDefaultUserPassword(const std::string& pass) {
   if (pass.empty()) {
     u->SetUser("nopass");
   } else {
-    u->SetUser(">" + pass);
+    if (g_pika_conf->userpass().empty()) {
+      u->SetUser("nopass");
+    } else {
+      u->SetUser(">" + pass);
+    }
   }
 }
 

--- a/src/acl.cc
+++ b/src/acl.cc
@@ -495,7 +495,15 @@ void Acl::InitLimitUser(const std::string& bl, bool limit_exist) {
       }
       u->SetUser("on");
     }
+    if (!pass.empty()) {
+      u->SetUser(">" + pass);
+    }
   } else {
+    if (pass.empty()) {
+      u->SetUser("nopass");
+    } else {
+      u->SetUser(">" + pass);
+    }
     u->SetUser("on");
     u->SetUser("+@all");
     u->SetUser("~*");
@@ -505,11 +513,6 @@ void Acl::InitLimitUser(const std::string& bl, bool limit_exist) {
       cmd = pstd::StringTrim(cmd, " ");
       u->SetUser("-" + cmd);
     }
-  }
-  if (pass.empty()) {
-    u->SetUser("nopass");
-  } else {
-    u->SetUser(">" + pass);
   }
 }
 // bool Acl::CheckUserCanExec(const std::shared_ptr<Cmd>& cmd, const PikaCmdArgsType& argv) { cmd->name(); }

--- a/src/acl.cc
+++ b/src/acl.cc
@@ -489,30 +489,27 @@ void Acl::InitLimitUser(const std::string& bl, bool limit_exist) {
   auto u = GetUser(DefaultLimitUser);
   if (limit_exist) {
     if (!bl.empty()) {
-      for(auto& cmd : blacklist) {
+      for (auto& cmd : blacklist) {
         cmd = pstd::StringTrim(cmd, " ");
         u->SetUser("-" + cmd);
       }
       u->SetUser("on");
     }
-    if (!pass.empty()) {
-      u->SetUser(">"+pass);
-    }
   } else {
-    if (pass.empty()) {
-      u->SetUser("nopass");
-    } else {
-      u->SetUser(">"+pass);
-    }
     u->SetUser("on");
     u->SetUser("+@all");
     u->SetUser("~*");
     u->SetUser("&*");
 
-    for(auto& cmd : blacklist) {
+    for (auto& cmd : blacklist) {
       cmd = pstd::StringTrim(cmd, " ");
       u->SetUser("-" + cmd);
     }
+  }
+  if (pass.empty()) {
+    u->SetUser("nopass");
+  } else {
+    u->SetUser(">" + pass);
   }
 }
 // bool Acl::CheckUserCanExec(const std::shared_ptr<Cmd>& cmd, const PikaCmdArgsType& argv) { cmd->name(); }

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -30,8 +30,7 @@ PikaClientConn::PikaClientConn(int fd, const std::string& ip_port, net::Thread* 
     : RedisConn(fd, ip_port, thread, mpx, handle_type, max_conn_rbuf_size),
       server_thread_(reinterpret_cast<net::ServerThread*>(thread)),
       current_db_(g_pika_conf->default_db()) {
-  // client init, set client user is default, and authenticated = false
-  UnAuth(g_pika_server->Acl()->GetUserLock(Acl::DefaultUser));
+  InitUser();
   time_stat_.reset(new TimeStat());
 }
 
@@ -259,7 +258,7 @@ void PikaClientConn::ProcessMonitor(const PikaCmdArgsType& argv) {
 }
 
 bool PikaClientConn::IsInterceptedByRTC(std::string& opt) {
-  //currently we only Intercept: Get, HGet
+  // currently we only Intercept: Get, HGet
   if (opt == kCmdNameGet && g_pika_conf->GetCacheString()) {
     return true;
   }
@@ -289,11 +288,9 @@ void PikaClientConn::ProcessRedisCmds(const std::vector<net::RedisCmdArgsType>& 
     bool is_slow_cmd = g_pika_conf->is_slow_cmd(opt);
     bool is_admin_cmd = g_pika_conf->is_admin_cmd(opt);
 
-    //we don't intercept pipeline batch (argvs.size() > 1)
-    if (g_pika_conf->rtc_cache_read_enabled() &&
-        argvs.size() == 1 && IsInterceptedByRTC(opt) &&
-        PIKA_CACHE_NONE != g_pika_conf->cache_mode() &&
-        !IsInTxn()) {
+    // we don't intercept pipeline batch (argvs.size() > 1)
+    if (g_pika_conf->rtc_cache_read_enabled() && argvs.size() == 1 && IsInterceptedByRTC(opt) &&
+        PIKA_CACHE_NONE != g_pika_conf->cache_mode() && !IsInTxn()) {
       // read in cache
       if (ReadCmdInCache(argvs[0], opt)) {
         delete arg;
@@ -358,21 +355,17 @@ bool PikaClientConn::ReadCmdInCache(const net::RedisCmdArgsType& argv, const std
     resp_num--;
     return false;
   }
-  //acl check
+  // acl check
   int8_t subCmdIndex = -1;
   std::string errKey;
   auto checkRes = user_->CheckUserPermission(c_ptr, argv, subCmdIndex, &errKey);
   std::string object;
-  if (checkRes == AclDeniedCmd::CMD ||
-      checkRes == AclDeniedCmd::KEY ||
-      checkRes == AclDeniedCmd::CHANNEL ||
-      checkRes == AclDeniedCmd::NO_SUB_CMD ||
-      checkRes == AclDeniedCmd::NO_AUTH
-      ) {
-    //acl check failed
+  if (checkRes == AclDeniedCmd::CMD || checkRes == AclDeniedCmd::KEY || checkRes == AclDeniedCmd::CHANNEL ||
+      checkRes == AclDeniedCmd::NO_SUB_CMD || checkRes == AclDeniedCmd::NO_AUTH) {
+    // acl check failed
     return false;
   }
-  //only read command(Get, HGet) will reach here, no need of record lock
+  // only read command(Get, HGet) will reach here, no need of record lock
   bool read_status = c_ptr->DoReadCommandInCache();
   auto cmdstat_map = g_pika_cmd_table_manager->GetCommandStatMap();
   resp_num--;
@@ -547,13 +540,24 @@ void PikaClientConn::UnAuth(const std::shared_ptr<User>& user) {
 }
 
 bool PikaClientConn::IsAuthed() const { return authenticated_; }
-
+void PikaClientConn::InitUser() {
+  if (g_pika_conf->requirepass().empty()) {
+    user_ = g_pika_server->Acl()->GetUserLock(Acl::DefaultUser);
+  }
+  user_ = g_pika_server->Acl()->GetUserLock(Acl::DefaultLimitUser);
+  authenticated_ = user_->HasFlags(static_cast<uint32_t>(AclUserFlag::NO_PASS)) &&
+                   !user_->HasFlags(static_cast<uint32_t>(AclUserFlag::DISABLED));
+}
 bool PikaClientConn::AuthRequired() const {
   // If the user does not have a password, and the user is valid, then the user does not need authentication
   // Otherwise, you need to determine whether go has been authenticated
-  return (!user_->HasFlags(static_cast<uint32_t>(AclUserFlag::NO_PASS)) ||
-          user_->HasFlags(static_cast<uint32_t>(AclUserFlag::DISABLED))) &&
-         !IsAuthed();
+  if (user_->HasFlags(static_cast<uint32_t>(AclUserFlag::DISABLED))) {
+    return true;
+  }
+  if (user_->HasFlags(static_cast<uint32_t>(AclUserFlag::NO_PASS))) {
+    return false;
+  }
+  return !IsAuthed();
 }
 std::string PikaClientConn::UserName() const { return user_->Name(); }
 

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -543,8 +543,9 @@ bool PikaClientConn::IsAuthed() const { return authenticated_; }
 void PikaClientConn::InitUser() {
   if (g_pika_conf->requirepass().empty()) {
     user_ = g_pika_server->Acl()->GetUserLock(Acl::DefaultUser);
+  } else {
+    user_ = g_pika_server->Acl()->GetUserLock(Acl::DefaultLimitUser);
   }
-  user_ = g_pika_server->Acl()->GetUserLock(Acl::DefaultLimitUser);
   authenticated_ = user_->HasFlags(static_cast<uint32_t>(AclUserFlag::NO_PASS)) &&
                    !user_->HasFlags(static_cast<uint32_t>(AclUserFlag::DISABLED));
 }


### PR DESCRIPTION
## Issue
(https://github.com/OpenAtomFoundation/pika/issues/2920)

### 描述
配置如下：

- `requirepass` : `xxx` (管理员密码)
- `userpass`: 
- `userblacklist` : `FLUSHALL`

设置了管理员密码，然后将 `userpass` 设置为空，这样普通用户无需密码即可使用。对于管理命令，如 `FLUSHALL` 等，需要管理员密码登录才可使用。在 3.5.2 版本中，工作正常，升级到 3.5.5 后，普通用户无法连接 Pika，提示：`ERR NOAUTH Authentication required`。

需要去除 `requirepass` 才可以正常连接使用，如下：

- `requirepass` : 
- `userpass`: 
- `userblacklist` : `FLUSHALL`

只有两项均为空，才可以无需密码连接，无法单独设置管理员密码。

### Issue 背景
在 3.5.5 后，添加了 ACL 认证，改变了传统的认证方式 `auth_stat_.IsAuthed(c_ptr)`。每一个 `PikaClientConn` 都拥有一个用户，里面存储了相关的 flag、password、limit 等信息。每来一个请求，`PikaClientConn` 都会做一次 Check authed，即检查当前 `PikaClientConn` 是否有密码、是否被禁用、是否需要认证。

## 问题
由于 `PikaClientConn` 在初始化时一直使用的是 `DefaultUser`，所以在配置文件中无论是否配置密码或 blacklist，均使用的是 `DefaultUser`。

## 解决方案
需要根据配置文件，去调整用户信息。在 `PikaClientConn` 初始化时，获取 `g_pika_conf` 的 `requirepass()` 是否为空；如果为空，则使用默认的用户；如果设置了密码，则使用 limit 的用户。

## 经过测试可以实现普通用户无密码登陆
![image](https://github.com/user-attachments/assets/fb89d244-9f47-4a32-93c2-b4f6e18803ae)

![image](https://github.com/user-attachments/assets/ab3fa7d4-1e7d-414c-819a-56860465cb7a)
## 有密码登陆也正常
![image](https://github.com/user-attachments/assets/081713eb-06c6-4afa-919e-29b9fd455c7c)
![image](https://github.com/user-attachments/assets/6b4aecd1-14b3-46b0-b897-b0666aa9ab40)
## limit也正常
![image](https://github.com/user-attachments/assets/6a90a3c9-d3ad-4c07-8e5b-e0c24f47501b)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter `best-delete-min-ratio` for improved compaction strategy.
	- Added a new method `InitUser()` to enhance user initialization in the Pika client connection.
	- Implemented version-specific handling for metrics collection in the exporter.

- **Bug Fixes**
	- Improved user password management by ensuring default users are set to "nopass" when no password is specified.

- **Style**
	- Minor formatting changes for improved code readability across various files.

- **Documentation**
	- Updated comments for clarity in the Pika client connection methods and enhanced logging context in the exporter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->