### PR TITLE
fix: add centos CI in github action

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -93,8 +93,8 @@ jobs:
     steps:
       - name: use SCL
         run: |
-          sudo yum install centos-release-scl
-          sudo yum install devtoolset-9  
+          yum install centos-release-scl
+          yum install devtoolset-9  
           scl enable devtoolset-9 bash
 
       - name: Checkout

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -98,7 +98,7 @@ jobs:
           scl enable devtoolset-9 bash
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -105,7 +105,7 @@ jobs:
           path: ${{ github.workspace }}/deps
           key: ${{ runner.os }}-centos-deps-${{ hashFiles('**/CMakeLists.txt') }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}/buildtrees
           key: ${{ runner.os }}-centos-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
           path: ${{ github.workspace }}/deps
           key: ${{ runner.os }}-centos-deps-${{ hashFiles('**/CMakeLists.txt') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/buildtrees
           key: ${{ runner.os }}-centos-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -100,15 +100,15 @@ jobs:
         run: |
           source /opt/rh/devtoolset-10/enable
           cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
-      - uses: actions/cache@v1
-        with:
-          path: ${{ github.workspace }}/deps
-          key: ${{ runner.os }}-centos-deps-${{ hashFiles('**/CMakeLists.txt') }}
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ github.workspace }}/buildtrees
-          key: ${{ runner.os }}-centos-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}
+#      - uses: actions/cache@v1
+#        with:
+#          path: ${{ github.workspace }}/deps
+#          key: ${{ runner.os }}-centos-deps-${{ hashFiles('**/CMakeLists.txt') }}
+#
+#      - uses: actions/cache@v1
+#        with:
+#          path: ${{ github.workspace }}/buildtrees
+#          key: ${{ runner.os }}-centos-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}
 
       - name: Build
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -91,11 +91,16 @@ jobs:
       image: cheniujh/pika-ci-centos7:v1
 
     steps:
+      - name: use SCL
+        run: |
+          sudo yum install centos-release-scl
+          sudo yum install devtoolset-9  
+          scl enable devtoolset-9 bash
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          node-version: '14'
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -114,13 +114,19 @@ jobs:
         run: |
           source /opt/rh/devtoolset-10/enable
           cmake --build build --config ${{ env.BUILD_TYPE }}
+
+      - name: Cleanup
+        run: |
+          rm -rf  ./deps
+          rm -rf ./buildtrees    
+
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: ctest -C ${{ env.BUILD_TYPE }}
 
       - name: Unit Test
         working-directory: ${{ github.workspace }}
-        run: ./pikatests.sh all
+        run: ./pikatests.sh all clean
 
       - name: Start codis, pika master and pika slave
         working-directory: ${{ github.workspace }}/build

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -88,7 +88,7 @@ jobs:
   build_on_centos:
     runs-on: ubuntu-latest
     container:
-      image: cheniujh/pika-ci-centos7:v1
+      image: cheniujh/pika-centos7-ci:v5
 
     steps:
       - name: Checkout

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           source /opt/rh/devtoolset-10/enable
           cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
-      - uses: actions/cache@v3
+      - uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}/deps
           key: ${{ runner.os }}-centos-deps-${{ hashFiles('**/CMakeLists.txt') }}

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -88,7 +88,7 @@ jobs:
   build_on_centos:
     runs-on: ubuntu-latest
     container:
-      image: cheniujh/pika-ci-centos7
+      image: cheniujh/pika-ci-centos7:v1
 
     steps:
       - name: Checkout

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -91,12 +91,6 @@ jobs:
       image: cheniujh/pika-ci-centos7:v1
 
     steps:
-      - name: use SCL
-        run: |
-          yum install centos-release-scl
-          yum install devtoolset-9  
-          scl enable devtoolset-9 bash
-
       - name: Checkout
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -84,59 +84,43 @@ jobs:
           chmod +x integrate_test.sh
           sh integrate_test.sh
 
-  build_on_rocky:
+
+  build_on_centos:
     runs-on: ubuntu-latest
     container:
-      image: rockylinux:9
+      image: cheniujh/pika-ci-centos7
 
     steps:
-      - name: Install deps
-        run: |
-          dnf update -y
-          dnf install -y bash cmake wget git autoconf gcc perl-Digest-SHA tcl which tar g++ tar epel-release gcc-c++ libstdc++-devel gcc-toolset-13
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.19
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Configure CMake
         run: |
-          source /opt/rh/gcc-toolset-13/enable
-          cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address .
-
+          source /opt/rh/devtoolset-10/enable
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
       - uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/deps
-          key: ${{ runner.os }}-rocky-deps-${{ hashFiles('**/CMakeLists.txt') }}
+          key: ${{ runner.os }}-centos-deps-${{ hashFiles('**/CMakeLists.txt') }}
 
       - uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/buildtrees
-          key: ${{ runner.os }}-rocky-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}
+          key: ${{ runner.os }}-centos-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}
 
       - name: Build
         run: |
-          source /opt/rh/gcc-toolset-13/enable
+          source /opt/rh/devtoolset-10/enable
           cmake --build build --config ${{ env.BUILD_TYPE }}
-
-      - name: Cleanup
-        run: |
-          rm -rf  ./deps
-          rm -rf ./buildtrees
-
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: ctest -C ${{ env.BUILD_TYPE }}
 
       - name: Unit Test
         working-directory: ${{ github.workspace }}
-        run: ./pikatests.sh all clean
+        run: ./pikatests.sh all
 
       - name: Start codis, pika master and pika slave
         working-directory: ${{ github.workspace }}/build
@@ -145,7 +129,6 @@ jobs:
           ../tests/integration/start_master_and_slave.sh
           chmod +x ../tests/integration/start_codis.sh
           ../tests/integration/start_codis.sh
-
       - name: Run Go E2E Tests
         working-directory: ${{ github.workspace }}/build
         run: |
@@ -154,6 +137,78 @@ jobs:
           cd ../../tests/integration/
           chmod +x integrate_test.sh
           sh integrate_test.sh
+
+
+#  build_on_rocky:
+#    runs-on: ubuntu-latest
+#    container:
+#      image: rockylinux:9
+#
+#    steps:
+#      - name: Install deps
+#        run: |
+#          dnf update -y
+#          dnf install -y bash cmake wget git autoconf gcc perl-Digest-SHA tcl which tar g++ tar epel-release gcc-c++ libstdc++-devel gcc-toolset-13
+#
+#      - name: Set up Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: 1.19
+#
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0
+#
+#      - name: Configure CMake
+#        run: |
+#          source /opt/rh/gcc-toolset-13/enable
+#          cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address .
+#
+#      - uses: actions/cache@v3
+#        with:
+#          path: ${{ github.workspace }}/deps
+#          key: ${{ runner.os }}-rocky-deps-${{ hashFiles('**/CMakeLists.txt') }}
+#
+#      - uses: actions/cache@v3
+#        with:
+#          path: ${{ github.workspace }}/buildtrees
+#          key: ${{ runner.os }}-rocky-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}
+#
+#      - name: Build
+#        run: |
+#          source /opt/rh/gcc-toolset-13/enable
+#          cmake --build build --config ${{ env.BUILD_TYPE }}
+#
+#      - name: Cleanup
+#        run: |
+#          rm -rf  ./deps
+#          rm -rf ./buildtrees
+#
+#      - name: Test
+#        working-directory: ${{ github.workspace }}/build
+#        run: ctest -C ${{ env.BUILD_TYPE }}
+#
+#      - name: Unit Test
+#        working-directory: ${{ github.workspace }}
+#        run: ./pikatests.sh all clean
+#
+#      - name: Start codis, pika master and pika slave
+#        working-directory: ${{ github.workspace }}/build
+#        run: |
+#          chmod +x ../tests/integration/start_master_and_slave.sh
+#          ../tests/integration/start_master_and_slave.sh
+#          chmod +x ../tests/integration/start_codis.sh
+#          ../tests/integration/start_codis.sh
+#
+#      - name: Run Go E2E Tests
+#        working-directory: ${{ github.workspace }}/build
+#        run: |
+#          cd ../tools/pika_keys_analysis/
+#          go test -v ./...
+#          cd ../../tests/integration/
+#          chmod +x integrate_test.sh
+#          sh integrate_test.sh
 
   build_on_macos:
 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -100,15 +100,6 @@ jobs:
         run: |
           source /opt/rh/devtoolset-10/enable
           cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address
-#      - uses: actions/cache@v1
-#        with:
-#          path: ${{ github.workspace }}/deps
-#          key: ${{ runner.os }}-centos-deps-${{ hashFiles('**/CMakeLists.txt') }}
-#
-#      - uses: actions/cache@v1
-#        with:
-#          path: ${{ github.workspace }}/buildtrees
-#          key: ${{ runner.os }}-centos-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}
 
       - name: Build
         run: |
@@ -144,77 +135,6 @@ jobs:
           chmod +x integrate_test.sh
           sh integrate_test.sh
 
-
-#  build_on_rocky:
-#    runs-on: ubuntu-latest
-#    container:
-#      image: rockylinux:9
-#
-#    steps:
-#      - name: Install deps
-#        run: |
-#          dnf update -y
-#          dnf install -y bash cmake wget git autoconf gcc perl-Digest-SHA tcl which tar g++ tar epel-release gcc-c++ libstdc++-devel gcc-toolset-13
-#
-#      - name: Set up Go
-#        uses: actions/setup-go@v5
-#        with:
-#          go-version: 1.19
-#
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#
-#      - name: Configure CMake
-#        run: |
-#          source /opt/rh/gcc-toolset-13/enable
-#          cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DUSE_PIKA_TOOLS=ON -DCMAKE_CXX_FLAGS_DEBUG=-fsanitize=address .
-#
-#      - uses: actions/cache@v3
-#        with:
-#          path: ${{ github.workspace }}/deps
-#          key: ${{ runner.os }}-rocky-deps-${{ hashFiles('**/CMakeLists.txt') }}
-#
-#      - uses: actions/cache@v3
-#        with:
-#          path: ${{ github.workspace }}/buildtrees
-#          key: ${{ runner.os }}-rocky-buildtrees-${{ hashFiles('**/CMakeLists.txt') }}
-#
-#      - name: Build
-#        run: |
-#          source /opt/rh/gcc-toolset-13/enable
-#          cmake --build build --config ${{ env.BUILD_TYPE }}
-#
-#      - name: Cleanup
-#        run: |
-#          rm -rf  ./deps
-#          rm -rf ./buildtrees
-#
-#      - name: Test
-#        working-directory: ${{ github.workspace }}/build
-#        run: ctest -C ${{ env.BUILD_TYPE }}
-#
-#      - name: Unit Test
-#        working-directory: ${{ github.workspace }}
-#        run: ./pikatests.sh all clean
-#
-#      - name: Start codis, pika master and pika slave
-#        working-directory: ${{ github.workspace }}/build
-#        run: |
-#          chmod +x ../tests/integration/start_master_and_slave.sh
-#          ../tests/integration/start_master_and_slave.sh
-#          chmod +x ../tests/integration/start_codis.sh
-#          ../tests/integration/start_codis.sh
-#
-#      - name: Run Go E2E Tests
-#        working-directory: ${{ github.workspace }}/build
-#        run: |
-#          cd ../tools/pika_keys_analysis/
-#          go test -v ./...
-#          cd ../../tests/integration/
-#          chmod +x integrate_test.sh
-#          sh integrate_test.sh
 
   build_on_macos:
 

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -95,6 +95,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          node-version: '14'
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
add back centos CI by using customized docker image to avoid pull dependency fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to replace the `build_on_rocky` job with a new `build_on_centos` job.
	- Adjusted Docker image and checkout action version for the CentOS environment.
	- Simplified unit test command for better efficiency.

These changes enhance the build process, ensuring a smoother integration and testing experience for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->