### PR TITLE
feat: add worker thread queue

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -170,6 +170,7 @@ jobs:
 
       - name: Cleanup
         run: |
+
           cp deps/lib/libz.1.dylib .
           cp deps/lib/libz.1.dylib tests/integration/
           rm -rf ./deps 
@@ -197,9 +198,10 @@ jobs:
       - name: Run Go E2E Tests
         working-directory: ${{ github.workspace }}
         run: |
+
           cd tests/integration/
           chmod +x integrate_test.sh
-   #       sh integrate_test.sh
+  #       sh integrate_test.sh
 
   build_pika_image:
     name: Build Pika Docker image

--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -170,7 +170,6 @@ jobs:
 
       - name: Cleanup
         run: |
-
           cp deps/lib/libz.1.dylib .
           cp deps/lib/libz.1.dylib tests/integration/
           rm -rf ./deps 
@@ -198,10 +197,9 @@ jobs:
       - name: Run Go E2E Tests
         working-directory: ${{ github.workspace }}
         run: |
-
           cd tests/integration/
           chmod +x integrate_test.sh
-  #       sh integrate_test.sh
+   #       sh integrate_test.sh
 
   build_pika_image:
     name: Build Pika Docker image

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,9 +367,9 @@ set(ZSTD_INCLUDE_DIR ${INSTALL_INCLUDEDIR})
 ExternalProject_Add(fmt
   DEPENDS
   URL
-  https://github.com/fmtlib/fmt/archive/refs/tags/7.1.0.tar.gz
+  https://github.com/fmtlib/fmt/archive/refs/tags/10.2.1.tar.gz 
   URL_HASH
-  MD5=32af902636d373641f4ef9032fc65b3a
+  MD5=dc09168c94f90ea890257995f2c497a5
   DOWNLOAD_NO_PROGRESS
   1
   UPDATE_COMMAND

--- a/src/net/include/thread_pool.h
+++ b/src/net/include/thread_pool.h
@@ -37,51 +37,58 @@ class ThreadPool : public pstd::noncopyable {
  public:
   class Worker {
    public:
-    explicit Worker(ThreadPool* tp) : start_(false), thread_pool_(tp){};
+    explicit Worker(ThreadPool* tp, size_t size) : start_(false), thread_pool_(tp), should_stop_(false), max_queue_size_(size) {};
     static void* WorkerMain(void* arg);
 
     int start();
     int stop();
+    void Schedule(TaskFunc func, void* arg);
 
    private:
+    void runInThread();
+    size_t max_queue_size();
+    void cur_queue_size(size_t* qsize);
+    void cur_time_queue_size(size_t* qsize);
+    void DelaySchedule(uint64_t timeout, TaskFunc func, void* arg);
+    bool should_stop();
+    void set_should_stop();
+
     pthread_t thread_id_;
     std::atomic<bool> start_;
     ThreadPool* const thread_pool_;
     std::string worker_name_;
+    std::queue<Task> queue_;
+    std::priority_queue<TimeTask> time_queue_;
+    pstd::Mutex mu_;
+    pstd::CondVar rsignal_;
+    pstd::CondVar wsignal_;
+    std::atomic<bool> should_stop_;
+    size_t max_queue_size_; 
   };
 
   explicit ThreadPool(size_t worker_num, size_t max_queue_size, std::string  thread_pool_name = "ThreadPool");
   virtual ~ThreadPool();
-
+  void Schedule(TaskFunc func, void* arg);
   int start_thread_pool();
   int stop_thread_pool();
-  bool should_stop();
-  void set_should_stop();
-
-  void Schedule(TaskFunc func, void* arg);
-  void DelaySchedule(uint64_t timeout, TaskFunc func, void* arg);
   size_t max_queue_size();
   size_t worker_size();
+  std::string thread_pool_name();
   void cur_queue_size(size_t* qsize);
   void cur_time_queue_size(size_t* qsize);
-  std::string thread_pool_name();
 
  private:
-  void runInThread();
-
+  /*
+   * Here we used auto poll to find the next work thread,
+   * last_thread_ is the last work thread
+   */
+  int last_thread_;
   size_t worker_num_;
   size_t max_queue_size_;
+
   std::string thread_pool_name_;
-  std::queue<Task> queue_;
-  std::priority_queue<TimeTask> time_queue_;
   std::vector<Worker*> workers_;
   std::atomic<bool> running_;
-  std::atomic<bool> should_stop_;
-
-  pstd::Mutex mu_;
-  pstd::CondVar rsignal_;
-  pstd::CondVar wsignal_;
-
 };
 
 }  // namespace net

--- a/src/net/include/thread_pool.h
+++ b/src/net/include/thread_pool.h
@@ -37,7 +37,7 @@ class ThreadPool : public pstd::noncopyable {
  public:
   class Worker {
    public:
-    explicit Worker(ThreadPool* tp, size_t size) : start_(false), thread_pool_(tp), should_stop_(false), max_queue_size_(size) {};
+    explicit Worker(size_t size) : start_(false), should_stop_(false), max_queue_size_(size) {};
     static void* WorkerMain(void* arg);
 
     int start();
@@ -56,7 +56,6 @@ class ThreadPool : public pstd::noncopyable {
 
     pthread_t thread_id_;
     std::atomic<bool> start_;
-    ThreadPool* const thread_pool_;
     std::string worker_name_;
     std::queue<Task> queue_;
     std::priority_queue<TimeTask> time_queue_;
@@ -83,10 +82,9 @@ class ThreadPool : public pstd::noncopyable {
    * Here we used auto poll to find the next work thread,
    * last_thread_ is the last work thread
    */
-  int last_thread_;
+
   size_t worker_num_;
   size_t max_queue_size_;
-
   std::string thread_pool_name_;
   std::vector<Worker*> workers_;
   std::atomic<bool> running_;

--- a/src/net/include/thread_pool.h
+++ b/src/net/include/thread_pool.h
@@ -43,12 +43,13 @@ class ThreadPool : public pstd::noncopyable {
     int start();
     int stop();
     void Schedule(TaskFunc func, void* arg);
+    size_t cur_queue_size();
+    size_t cur_time_queue_size();
+
 
    private:
     void runInThread();
     size_t max_queue_size();
-    void cur_queue_size(size_t* qsize);
-    void cur_time_queue_size(size_t* qsize);
     void DelaySchedule(uint64_t timeout, TaskFunc func, void* arg);
     bool should_stop();
     void set_should_stop();

--- a/src/net/src/thread_pool.cc
+++ b/src/net/src/thread_pool.cc
@@ -34,8 +34,8 @@ int ThreadPool::Worker::start() {
 
 int ThreadPool::Worker::stop() {
   should_stop_.store(true);
-  rsignal_.notify_all();
-  wsignal_.notify_all();
+  rsignal_.notify_one();
+  wsignal_.notify_one();
   if (start_.load()) {
     if (pthread_join(thread_id_, nullptr) != 0) {
       return -1;
@@ -121,7 +121,7 @@ void ThreadPool::Worker::DelaySchedule(uint64_t timeout, TaskFunc func, void* ar
   std::unique_lock lock(mu_);  
   if (!should_stop()) {
     time_queue_.emplace(exec_time, func, arg);
-    rsignal_.notify_all();
+    rsignal_.notify_one();
   }
 }
 


### PR DESCRIPTION
PR 对 Pika 的 Worker 命令线程池进行了修改，由原来的多个 WorkerThread 线程争抢一个 queue 改成了每个 WorkerThread 自己持有一个 queue，减少了读场景下的锁竞争，读 QPS 方面提升了 13% 左右

**修改之前的 QPS**
```bash
Summary:
  throughput summary: 433990.09 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        0.221     0.080     0.207     0.351     0.527     6.463
```
**修改之后的 QPS**
```bash
Summary:
  throughput summary: 492926.50 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        0.192     0.064     0.175     0.335     0.503    19.727
```
![flamegraph](https://github.com/user-attachments/assets/e12f442c-fd6b-4df7-ae43-30b8dce79d09)
