### PR TITLE
fix: pika exporter error output due to versions dismatch

### DIFF
--- a/tools/pika_exporter/exporter/metrics/parser.go
+++ b/tools/pika_exporter/exporter/metrics/parser.go
@@ -26,13 +26,14 @@ type ParseOption struct {
 type VersionChecker interface {
 	CheckContainsEmptyValueName(key string) bool
 	CheckContainsEmptyRegexName(key string) bool
+	InitVersionChecker()
 }
 type VersionChecker336 struct {
 	EmptyValueName []string
 	EmptyRegexName []string
 }
 
-func (v *VersionChecker336) CheckContainsEmptyValueName(key string) bool {
+func (v *VersionChecker336) InitVersionChecker() {
 	if v.EmptyValueName == nil {
 		v.EmptyValueName = []string{
 			"instantaneous_output_repl_kbps",
@@ -50,6 +51,13 @@ func (v *VersionChecker336) CheckContainsEmptyValueName(key string) bool {
 			"cache_memory",
 		}
 	}
+	if v.EmptyRegexName == nil {
+		v.EmptyRegexName = []string{
+			"hitratio_per_sec",
+		}
+	}
+}
+func (v *VersionChecker336) CheckContainsEmptyValueName(key string) bool {
 	for _, str := range v.EmptyValueName {
 		if str == key {
 			return true
@@ -58,11 +66,6 @@ func (v *VersionChecker336) CheckContainsEmptyValueName(key string) bool {
 	return false
 }
 func (v *VersionChecker336) CheckContainsEmptyRegexName(key string) bool {
-	if v.EmptyRegexName == nil {
-		v.EmptyRegexName = []string{
-			"hitratio_per_sec",
-		}
-	}
 	for _, str := range v.EmptyRegexName {
 		if str == key {
 			return true
@@ -76,7 +79,7 @@ type VersionChecker350 struct {
 	EmptyRegexName []string
 }
 
-func (v *VersionChecker350) CheckContainsEmptyValueName(key string) bool {
+func (v *VersionChecker350) InitVersionChecker() {
 	if v.EmptyValueName == nil {
 		v.EmptyValueName = []string{
 			"cache_db_num",
@@ -86,6 +89,13 @@ func (v *VersionChecker350) CheckContainsEmptyValueName(key string) bool {
 			"slow_logs_count",
 		}
 	}
+	if v.EmptyRegexName == nil {
+		v.EmptyRegexName = []string{
+			"hitratio_per_sec",
+		}
+	}
+}
+func (v *VersionChecker350) CheckContainsEmptyValueName(key string) bool {
 	for _, str := range v.EmptyValueName {
 		if str == key {
 			return true
@@ -94,11 +104,6 @@ func (v *VersionChecker350) CheckContainsEmptyValueName(key string) bool {
 	return false
 }
 func (v *VersionChecker350) CheckContainsEmptyRegexName(key string) bool {
-	if v.EmptyRegexName == nil {
-		v.EmptyRegexName = []string{
-			"hitratio_per_sec",
-		}
-	}
 	for _, str := range v.EmptyRegexName {
 		if str == key {
 			return true
@@ -112,7 +117,7 @@ type VersionChecker355 struct {
 	EmptyRegexName []string
 }
 
-func (v *VersionChecker355) CheckContainsEmptyValueName(key string) bool {
+func (v *VersionChecker355) InitVersionChecker() {
 	if v.EmptyValueName == nil {
 		v.EmptyValueName = []string{
 			"cache_db_num",
@@ -121,14 +126,6 @@ func (v *VersionChecker355) CheckContainsEmptyValueName(key string) bool {
 			"hits_per_sec",
 		}
 	}
-	for _, str := range v.EmptyValueName {
-		if str == key {
-			return true
-		}
-	}
-	return false
-}
-func (v *VersionChecker355) CheckContainsEmptyRegexName(key string) bool {
 	if v.EmptyRegexName == nil {
 		v.EmptyRegexName = []string{
 			"hitratio_per_sec",
@@ -139,6 +136,16 @@ func (v *VersionChecker355) CheckContainsEmptyRegexName(key string) bool {
 			"is_scaning_keyspace",
 		}
 	}
+}
+func (v *VersionChecker355) CheckContainsEmptyValueName(key string) bool {
+	for _, str := range v.EmptyValueName {
+		if str == key {
+			return true
+		}
+	}
+	return false
+}
+func (v *VersionChecker355) CheckContainsEmptyRegexName(key string) bool {
 	for _, str := range v.EmptyRegexName {
 		if str == key {
 			return true

--- a/tools/pika_exporter/exporter/metrics/parser.go
+++ b/tools/pika_exporter/exporter/metrics/parser.go
@@ -24,13 +24,15 @@ type ParseOption struct {
 	CurrentVersion VersionChecker
 }
 type VersionChecker interface {
-	CheckContainsEmptyValue(key string) bool
+	CheckContainsEmptyValueName(key string) bool
+	CheckContainsEmptyRegexName(key string) bool
 }
 type VersionChecker336 struct {
 	EmptyValueName []string
+	EmptyRegexName []string
 }
 
-func (v *VersionChecker336) CheckContainsEmptyValue(key string) bool {
+func (v *VersionChecker336) CheckContainsEmptyValueName(key string) bool {
 	if v.EmptyValueName == nil {
 		v.EmptyValueName = []string{
 			"instantaneous_output_repl_kbps",
@@ -55,12 +57,62 @@ func (v *VersionChecker336) CheckContainsEmptyValue(key string) bool {
 	}
 	return false
 }
+func (v *VersionChecker336) CheckContainsEmptyRegexName(key string) bool {
+	if v.EmptyRegexName == nil {
+		v.EmptyRegexName = []string{
+			"hitratio_per_sec",
+		}
+	}
+	for _, str := range v.EmptyRegexName {
+		if str == key {
+			return true
+		}
+	}
+	return false
+}
+
+type VersionChecker350 struct {
+	EmptyValueName []string
+	EmptyRegexName []string
+}
+
+func (v *VersionChecker350) CheckContainsEmptyValueName(key string) bool {
+	if v.EmptyValueName == nil {
+		v.EmptyValueName = []string{
+			"cache_db_num",
+			"cache_status",
+			"cache_memory",
+			"hits_per_sec",
+			"slow_logs_count",
+		}
+	}
+	for _, str := range v.EmptyValueName {
+		if str == key {
+			return true
+		}
+	}
+	return false
+}
+func (v *VersionChecker350) CheckContainsEmptyRegexName(key string) bool {
+	if v.EmptyRegexName == nil {
+		v.EmptyRegexName = []string{
+			"hitratio_per_sec",
+		}
+	}
+	for _, str := range v.EmptyRegexName {
+		if str == key {
+			return true
+		}
+	}
+	return false
+}
 
 type VersionChecker355 struct {
 	EmptyValueName []string
+	EmptyRegexName []string
 }
 
-func (v *VersionChecker355) CheckContainsEmptyValue(key string) bool {
+func (v *VersionChecker355) CheckContainsEmptyValueName(key string) bool {
 	if v.EmptyValueName == nil {
 		v.EmptyValueName = []string{
 			"cache_db_num",
@@ -76,22 +128,18 @@ func (v *VersionChecker355) CheckContainsEmptyValue(key string) bool {
 	}
 	return false
 }
-
-type VersionChecker350 struct {
-	EmptyValueName []string
-}
-
-func (v *VersionChecker350) CheckContainsEmptyValue(key string) bool {
-	if v.EmptyValueName == nil {
-		v.EmptyValueName = []string{
-			"cache_db_num",
-			"cache_status",
-			"cache_memory",
-			"hits_per_sec",
-			"slow_logs_count",
+func (v *VersionChecker355) CheckContainsEmptyRegexName(key string) bool {
+	if v.EmptyRegexName == nil {
+		v.EmptyRegexName = []string{
+			"hitratio_per_sec",
+			"keyspace_info_>=3.1.0",
+			"keyspace_info_all_>=3.3.3",
+			"binlog_>=3.2.0",
+			"keyspace_last_start_time",
+			"is_scaning_keyspace",
 		}
 	}
-	for _, str := range v.EmptyValueName {
+	for _, str := range v.EmptyRegexName {
 		if str == key {
 			return true
 		}
@@ -188,7 +236,7 @@ func (p *regexParser) Parse(m MetricMeta, c Collector, opt ParseOption) {
 
 	matchMaps := p.regMatchesToMap(s)
 	if len(matchMaps) == 0 {
-		if opt.CurrentVersion == nil || !opt.CurrentVersion.CheckContainsEmptyValue(p.name) {
+		if opt.CurrentVersion == nil || !opt.CurrentVersion.CheckContainsEmptyRegexName(p.name) {
 			log.Warnf("regexParser::Parse reg find sub match nil. name:%s", p.name)
 		}
 	}
@@ -213,7 +261,6 @@ func (p *regexParser) regMatchesToMap(s string) []map[string]string {
 
 	multiMatches := p.reg.FindAllStringSubmatch(s, -1)
 	if len(multiMatches) == 0 {
-		log.Errorf("regexParser::regMatchesToMap reg find sub match nil. name:%s", p.name)
 		return nil
 	}
 
@@ -249,7 +296,7 @@ func (p *normalParser) Parse(m MetricMeta, c Collector, opt ParseOption) {
 
 		if m.ValueName != "" {
 			if v, ok := findInMap(m.ValueName, opt.Extracts); !ok {
-				if opt.CurrentVersion == nil || !opt.CurrentVersion.CheckContainsEmptyValue(m.ValueName) {
+				if opt.CurrentVersion == nil || !opt.CurrentVersion.CheckContainsEmptyValueName(m.ValueName) {
 					log.Warnf("normalParser::Parse not found value. metricName:%s valueName:%s", m.Name, m.ValueName)
 				}
 				return

--- a/tools/pika_exporter/exporter/pika.go
+++ b/tools/pika_exporter/exporter/pika.go
@@ -264,22 +264,37 @@ func (e *exporter) collectInfo(c *client, ch chan<- prometheus.Metric) error {
 	return nil
 }
 
-func selectversion(version string) metrics.VersionChecker {
-	var v metrics.VersionChecker
+const (
+	VERSION_336 = "3.3.6"
+	VERSION_350 = "3.5.0"
+	VERSION_355 = "3.5.5"
+)
 
+func selectversion(version string) metrics.VersionChecker {
+	if !isValidVersion(version) {
+		log.Warnf("Invalid version format: %s", version)
+		return nil
+	}
+	var v metrics.VersionChecker
 	switch version {
-	case "3.3.6":
+	case VERSION_336:
 		v = &metrics.VersionChecker336{}
-	case "3.5.5":
+	case VERSION_355:
 		v = &metrics.VersionChecker355{}
-	case "3.5.0":
+	case VERSION_350:
 		v = &metrics.VersionChecker350{}
 	default:
 		return nil
 	}
+	v.InitVersionChecker()
 	return v
 }
 
+// isValidVersion validates the version string format (e.g., x.y.z)
+func isValidVersion(version string) bool {
+	matched, _ := regexp.MatchString(`^\d+\.\d+\.\d+$`, version)
+	return matched
+}
 func (e *exporter) collectKeys(c *client) error {
 	allKeys := append([]dbKeyPair{}, e.keys...)
 	keys, err := getKeysFromPatterns(c, e.keyPatterns, e.scanCount)

--- a/tools/pika_exporter/exporter/pika.go
+++ b/tools/pika_exporter/exporter/pika.go
@@ -252,15 +252,32 @@ func (e *exporter) collectInfo(c *client, ch chan<- prometheus.Metric) error {
 		return nil
 	})
 	parseOpt := metrics.ParseOption{
-		Version:  version,
-		Extracts: extracts,
-		Info:     info,
+		Version:        version,
+		Extracts:       extracts,
+		Info:           info,
+		CurrentVersion: selectversion(version.Original()),
 	}
 	for _, m := range metrics.MetricConfigs {
 		m.Parse(m, collector, parseOpt)
 	}
 
 	return nil
+}
+
+func selectversion(version string) metrics.VersionChecker {
+	var v metrics.VersionChecker
+
+	switch version {
+	case "3.3.6":
+		v = &metrics.VersionChecker336{}
+	case "3.5.5":
+		v = &metrics.VersionChecker355{}
+	case "3.5.0":
+		v = &metrics.VersionChecker350{}
+	default:
+		return nil
+	}
+	return v
 }
 
 func (e *exporter) collectKeys(c *client) error {


### PR DESCRIPTION
# 问题描述：

### 由于不同的版本字段不同，导致一直触发log

![image](https://github.com/user-attachments/assets/faea89c4-00bd-4305-8191-630b95be11bd)
![image](https://github.com/user-attachments/assets/df974746-78cc-47fa-a18e-8159bf3b6077)

# 解决方案：

### 根据不同的版本,增加对应的处理方式

提取info种的version，根据version选择不同的版本
```
	parseOpt := metrics.ParseOption{
		Version:        version,
		Extracts:       extracts,
		Info:           info,
		CurrentVersion: selectversion(version.Original()),
	}
func selectversion(version string) metrics.VersionChecker {
	var v metrics.VersionChecker

	switch version {
	case "3.3.6":
		v = &metrics.VersionChecker336{}
	case "3.5.5":
		v = &metrics.VersionChecker355{}
	case "3.5.0":
		v = &metrics.VersionChecker350{}
	default:
		return nil
	}
	return v
}
```
### 定义抽象接口,实现对多版本的控制。

```
type VersionChecker interface {
	CheckContainsEmptyValueName(key string) bool
	CheckContainsEmptyRegexName(key string) bool
}
type VersionChecker336 struct {
	EmptyValueName []string
	EmptyRegexName []string
}
type VersionChecker350 struct {
	EmptyValueName []string
	EmptyRegexName []string
}
type VersionChecker355 struct {
	EmptyValueName []string
	EmptyRegexName []string
}
```

### 接口的实现，定义了两个check方式，方便后续根据不同parse做补充

```
func (v *VersionChecker336) CheckContainsEmptyValueName(key string) bool {
	if v.EmptyValueName == nil {
		v.EmptyValueName = []string{
			"instantaneous_output_repl_kbps",
			"total_net_output_bytes",
			"cache_db_num",
			"hits_per_sec",
			"cache_status",
			"total_net_input_bytes",
			"instantaneous_output_kbps",
			"instantaneous_input_kbps",
			"total_net_repl_input_bytes",
			"instantaneous_input_repl_kbps",
			"slow_logs_count",
			"total_net_repl_output_bytes",
			"cache_memory",
		}
	}
	for _, str := range v.EmptyValueName {
		if str == key {
			return true
		}
	}
	return false
}
func (v *VersionChecker336) CheckContainsEmptyRegexName(key string) bool {
	if v.EmptyRegexName == nil {
		v.EmptyRegexName = []string{
			"hitratio_per_sec",
		}
	}
	for _, str := range v.EmptyRegexName {
		if str == key {
			return true
		}
	}
	return false
}
```


### 只有在opt.CurrentVersion ==nil and 当前字段不在当前版本的check列表才打印日志

```
		if opt.CurrentVersion == nil || !opt.CurrentVersion.CheckContainsEmptyRegexName(p.name) {
			log.Warnf("regexParser::Parse reg find sub match nil. name:%s", p.name)
		}

```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced version checking capabilities in the metrics parsing system.
	- Added a new function to select the appropriate version checker based on the provided version.

- **Enhancements**
	- Improved error handling and logging by integrating version-specific checks into the parsing logic.
	- Enhanced the `collectInfo` method to include version validation and tailored handling for different Pika versions.

- **Bug Fixes**
	- Enhanced robustness of the metrics collection process with tailored handling for different Pika versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->