### PR TITLE
fix: disable rpoplpush when cache mode is enabled with list structure

### DIFF
--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -1102,7 +1102,7 @@ class PikaConf : public pstd::BaseConf {
   int64_t min_blob_size_ = 4096;                // 4K
   int64_t blob_cache_ = 0;
   int64_t blob_num_shard_bits_ = 0;
-  int64_t blob_file_size_ = 256 * 1024 * 1024;  // 256M
+  int64_t blob_file_size_ = 256 << 20;  // 256M
   std::string blob_compression_type_ = "none";
 
   std::shared_mutex rwlock_;

--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -7,14 +7,12 @@
 #include <utility>
 #include "include/pika_cache.h"
 #include "include/pika_data_distribution.h"
-#include "include/pika_rm.h"
 #include "include/pika_server.h"
 #include "include/pika_slot_command.h"
 #include "pstd/include/pstd_string.h"
 #include "scope_record_lock.h"
 
 extern PikaServer* g_pika_server;
-extern std::unique_ptr<PikaReplicaManager> g_pika_rm;
 
 void LIndexCmd::DoInitial() {
   if (!CheckArg(argv_.size())) {
@@ -786,6 +784,10 @@ void RPopCmd::DoUpdateCache() {
 }
 
 void RPopLPushCmd::DoInitial() {
+  if (PIKA_CACHE_NONE != g_pika_conf->cache_mode() && g_pika_conf->GetCacheList()) {
+    res_.SetRes(CmdRes::kErrOther, "the command is not supported when cache&list is enabled");
+    return;
+  }
   if (!CheckArg(argv_.size())) {
     res_.SetRes(CmdRes::kWrongNum, kCmdNameRPopLPush);
     return;


### PR DESCRIPTION
更新：暂时不合并本PR，尽量在cache模式下实现rpoplpush即可，并不是一定要禁用。

本PR修复 ISSUE #2953 , 在cache模式下禁用了rpoplpush命令。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command handling for list operations, including checks for caching compatibility.
  
- **Bug Fixes**
	- Improved error responses for unsupported commands in cache mode.

- **Refactor**
	- Removed unnecessary global variable to streamline the codebase.
  
- **Documentation**
	- Clarified variable initialization for better understanding of intended values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->