### PR TITLE
feat: add repl_connect_status to pika_exporter

### DIFF
--- a/tools/pika_exporter/exporter/metrics/parser.go
+++ b/tools/pika_exporter/exporter/metrics/parser.go
@@ -16,6 +16,52 @@ const (
 	defaultValue = 0
 )
 
+type statusToGaugeParser struct {
+    statusMapping map[string]int
+}
+
+func (p *statusToGaugeParser) Parse(m MetricMeta, c Collector, opt ParseOption) {
+    m.Lookup(func(m MetaData) {
+        metric := Metric{
+            MetaData:    m,
+            LabelValues: make([]string, len(m.Labels)),
+            Value:       defaultValue,
+        }
+
+        for i, labelName := range m.Labels {
+            labelValue, ok := findInMap(labelName, opt.Extracts)
+            if !ok {
+                log.Debugf("statusToGaugeParser::Parse not found label value. metricName:%s labelName:%s",
+                    m.Name, labelName)
+            }
+
+            metric.LabelValues[i] = labelValue
+        }
+
+        if m.ValueName != "" {
+            if v, ok := findInMap(m.ValueName, opt.Extracts); !ok {
+                log.Warnf("statusToGaugeParser::Parse not found value. metricName:%s valueName:%s", m.Name, m.ValueName)
+                return
+            } else {
+                mappedValue, exists := p.statusMapping[v]
+                if !exists {
+                    log.Warnf("statusToGaugeParser::Parse unknown status value. metricName:%s valueName:%s rawValue:%s",
+                        m.Name, m.ValueName, v)
+                    mappedValue = defaultValue // 使用默认值
+                }
+                metric.Value = float64(mappedValue)
+            }
+        }
+
+        if err := c.Collect(metric); err != nil {
+            log.Errorf("statusToGaugeParser::Parse metric collect failed. metric:%#v err:%s",
+                m, m.ValueName)
+        }
+    })
+}
+
+
+
 type ParseOption struct {
 	Version        *semver.Version
 	Extracts       map[string]string

--- a/tools/pika_exporter/exporter/metrics/parser.go
+++ b/tools/pika_exporter/exporter/metrics/parser.go
@@ -47,7 +47,7 @@ func (p *statusToGaugeParser) Parse(m MetricMeta, c Collector, opt ParseOption) 
                 if !exists {
                     log.Warnf("statusToGaugeParser::Parse unknown status value. metricName:%s valueName:%s rawValue:%s",
                         m.Name, m.ValueName, v)
-                    mappedValue = defaultValue // 使用默认值
+                    mappedValue = defaultValue
                 }
                 metric.Value = float64(mappedValue)
             }

--- a/tools/pika_exporter/exporter/metrics/replication.go
+++ b/tools/pika_exporter/exporter/metrics/replication.go
@@ -175,6 +175,37 @@ var collectReplicationMetrics = map[string]MetricConfig{
 		},
 	},
 
+    "slave_info>=3.5.5_or_4.0.0": {
+        Parser: &keyMatchParser{
+            matchers: map[string]Matcher{
+                "role": &equalMatcher{v: "slave"},
+            },
+            Parser: &regexParser{
+                name: "repl_connect_status",
+                reg:  regexp.MustCompile(`(?m)^\s*(?P<db_name>db\d+)\s*:\s*(?P<status>\w+)\s*$`),
+                Parser: &statusToGaugeParser{
+                    statusMapping: map[string]int{
+                        "no_connect":          0,
+                        "try_to_incr_sync":    1,
+                        "try_to_full_sync":    2,
+                        "syncing_full":        3,
+                        "connecting":          4,
+                        "connected":           5,
+                        "error":               -1,
+                    },
+                },
+            },
+        },
+        MetricMeta: &MetaData{
+            Name:      "repl_connect_status",
+            Help:      "Replication connection status for each database on the slave node",
+            Type:      metricTypeGauge,
+            Labels:    []string{LabelNameAddr, LabelNameAlias, "db_name"},
+            ValueName: "status",
+        },
+    },
+
+
 	"slave_info<3.2.0": {
 		Parser: &keyMatchParser{
 			matchers: map[string]Matcher{

--- a/tools/pika_exporter/version.go
+++ b/tools/pika_exporter/version.go
@@ -1,8 +1,8 @@
 package main
 
 const (
-	BuildVersion   = "Filled in by build"
-	BuildCommitSha = "Filled in by build"
-	BuildDate      = "Filled in by build"
-	GoVersion      = "Filled in by build"
+	BuildVersion   = "  240624_use_fwrite_binlog   240625_fix_S2_Issue2436   2_slavetestbranch   3.5   355/change_timeout_conf   AckEnd_smaller_than_AckStart   RTC   RTC_v2 add_centos7_release add_centos7_release   add_execute_back   binlog_fwrite   binlog_use_fwrite   blpop_update_cache   blpop_update_cache_back   bugfix/bgsave_inconsistent   bugfix/compatible_redis_sentinel   bugfix/fix_centos_compile   bugfix/flushdb_inconsistent   bugfix/flushdb_inconsistent_bak   bugfix/kill_conn_correct   bugfix/remove_extra_conn_ref   bugfix/set_status_before_dump   bugfix/slaveofnoone_fullsync   bugfix/slaveofnoone_log   change_timeout_conf   d   db_stat_multi_thread   dynamic_rsync_speed_and_timeout   feature/add_centos_7_ci   fix_ci_centos   fix_data_race_spop_binlog   fix_full_sync_interrupt   fix_full_sync_interrupt_backup240627   fix_full_sync_interupt_exit   fix_lock_issue_rsync   fix_macos_ci   fix_s2_old_methodflag   fix_successive_flushdb_exec   flushall_binlog   kv_para_align   modify_full_sync_state_transition   multi_dbsync_handle   multi_sync_debug   new2_all_in_one_sync_fix   new_all_in_one_fix   new_detach   new_full_sync_state   new_slave_tracing   new_unstable   newest_use_fwrite_binlog   ospp/refactor_binlog_   ospp/refactor_binlog_2   ospp/refactor_binlog_3   ospp/refactor_binlog_v4   part_multisync_fix   reading_replication   refactor_binlog   reivsed_timer_timeout   remove_unnecessary_binlog_lock   revise_slave_worker   revise_slave_worker_model   revised_rocksdb_default_options   revised_timer_task_manager   rsync_reconfig_0501   rtc_improve   slavetestbranch   testing_slave_qps   unstable"
+	BuildCommitSha = "20b9d2d8"
+	BuildDate      = "2024-11-15 19:04:14 CST"
+	GoVersion      = "go1.19 linux/amd64"
 )

--- a/tools/pika_exporter/version.go
+++ b/tools/pika_exporter/version.go
@@ -1,8 +1,8 @@
 package main
 
 const (
-	BuildVersion   = "  240624_use_fwrite_binlog   240625_fix_S2_Issue2436   2_slavetestbranch   3.5   355/change_timeout_conf   AckEnd_smaller_than_AckStart   RTC   RTC_v2 add_centos7_release add_centos7_release   add_execute_back   binlog_fwrite   binlog_use_fwrite   blpop_update_cache   blpop_update_cache_back   bugfix/bgsave_inconsistent   bugfix/compatible_redis_sentinel   bugfix/fix_centos_compile   bugfix/flushdb_inconsistent   bugfix/flushdb_inconsistent_bak   bugfix/kill_conn_correct   bugfix/remove_extra_conn_ref   bugfix/set_status_before_dump   bugfix/slaveofnoone_fullsync   bugfix/slaveofnoone_log   change_timeout_conf   d   db_stat_multi_thread   dynamic_rsync_speed_and_timeout   feature/add_centos_7_ci   fix_ci_centos   fix_data_race_spop_binlog   fix_full_sync_interrupt   fix_full_sync_interrupt_backup240627   fix_full_sync_interupt_exit   fix_lock_issue_rsync   fix_macos_ci   fix_s2_old_methodflag   fix_successive_flushdb_exec   flushall_binlog   kv_para_align   modify_full_sync_state_transition   multi_dbsync_handle   multi_sync_debug   new2_all_in_one_sync_fix   new_all_in_one_fix   new_detach   new_full_sync_state   new_slave_tracing   new_unstable   newest_use_fwrite_binlog   ospp/refactor_binlog_   ospp/refactor_binlog_2   ospp/refactor_binlog_3   ospp/refactor_binlog_v4   part_multisync_fix   reading_replication   refactor_binlog   reivsed_timer_timeout   remove_unnecessary_binlog_lock   revise_slave_worker   revise_slave_worker_model   revised_rocksdb_default_options   revised_timer_task_manager   rsync_reconfig_0501   rtc_improve   slavetestbranch   testing_slave_qps   unstable"
-	BuildCommitSha = "20b9d2d8"
-	BuildDate      = "2024-11-15 19:04:14 CST"
-	GoVersion      = "go1.19 linux/amd64"
+	BuildVersion   = "Filled in by build"
+	BuildCommitSha = "Filled in by build"
+	BuildDate      = "Filled in by build"
+	GoVersion      = "Filled in by build"
 )


### PR DESCRIPTION
本PR将pika info指标中提供的**repl_connect_status加入到了pika_exporter**, 该指标的值域以及映射如下：

no_connect:          0,
try_to_incr_sync:    1,
try_to_full_sync:    2,
syncing_full:        3,
connecting:          4,
connected:           5,
error:               -1,


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new parser for converting status metrics into gauge values, enhancing metric collection accuracy.
  - Added a metric for monitoring replication connection status specifically for slave nodes in Pika server environments.

- **Bug Fixes**
  - Improved error handling and logging during metric parsing to ensure better reporting of issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->