### PR TITLE
feat: support dynamically change max-subcompactions using config set command

### DIFF
--- a/src/storage/src/options_helper.h
+++ b/src/storage/src/options_helper.h
@@ -38,6 +38,7 @@ inline int offset_of(T1 T2::*member) {
 static std::unordered_map<std::string, MemberTypeInfo> mutable_db_options_member_type_info = {
     {"max_background_jobs", {offsetof(struct rocksdb::DBOptions, max_background_jobs), MemberType::kInt}},
     {"max_background_compactions", {offsetof(struct rocksdb::DBOptions, max_background_compactions), MemberType::kInt}},
+    {"max_subcompactions", {offsetof(struct rocksdb::DBOptions, max_subcompactions), MemberType::kInt}},
     // {"base_background_compactions", {offsetof(struct rocksdb::DBOptions, base_background_compactions),
     // MemberType::kInt}},
     {"max_open_files", {offsetof(struct rocksdb::DBOptions, max_open_files), MemberType::kInt}},


### PR DESCRIPTION
支持使用config set 动态修改max-subcompactions参数。

应用场景：
   当发现Rocksdb实例出现了由L0层文件达到上限而引起的write stall（L0层compaction速度跟不上flush速度）, 可以尝试将max-subcompactions改大，另外该值不占用max-background-jobs的份额，他会直接启动新的lwp来将一个大的L0层compaction分割为多个小compaction并发处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter, `max-subcompactions`, allowing users to manage subcompaction settings.
	- Enhanced configurability of RocksDB options with the addition of `max_subcompactions` in the database options.

- **Bug Fixes**
	- Improved error handling for invalid inputs related to the new configuration parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->