### PR TITLE
fix: rpoplpush cause inconsistency in cache mode 

### DIFF
--- a/include/pika_list.h
+++ b/include/pika_list.h
@@ -364,6 +364,8 @@ class RPopLPushCmd : public BlockingBaseCmd {
   void ReadCache() override;
   void Split(const HintKeys& hint_keys) override{};
   void Merge() override{};
+  void DoThroughDB() override;
+  void DoUpdateCache() override;
   Cmd* Clone() override { return new RPopLPushCmd(*this); }
   void DoBinlog() override;
 

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -501,7 +501,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<RPopCmd>(kCmdNameRPop, -2, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameRPop, std::move(rpopptr)));
   std::unique_ptr<Cmd> rpoplpushptr = std::make_unique<RPopLPushCmd>(
-      kCmdNameRPopLPush, 3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsSlow);
+      kCmdNameRPopLPush, 3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameRPopLPush, std::move(rpoplpushptr)));
   std::unique_ptr<Cmd> rpushptr =
       std::make_unique<RPushCmd>(kCmdNameRPush, -3, kCmdFlagsWrite | kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);

--- a/src/pika_list.cc
+++ b/src/pika_list.cc
@@ -847,6 +847,17 @@ void RPopLPushCmd::DoBinlog() {
   rpop_cmd_->DoBinlog();
   lpush_cmd_->DoBinlog();
 }
+void RPopLPushCmd::DoUpdateCache() {
+  if (s_.ok()) {
+    std::vector<std::string> value;
+    value.resize(1);
+    db_->cache()->RPop(source_, &value[0]);
+    db_->cache()->LPushx(receiver_, value);
+  }
+}
+void RPopLPushCmd::DoThroughDB() {
+  Do();
+}
 
 void RPushCmd::DoInitial() {
   if (!CheckArg(argv_.size())) {


### PR DESCRIPTION
这个PR实现了cache模式下rpoplpush的逻辑，修复了 Issue #2953 