### PR TITLE
feat: migrate tools support pika v3.5.0

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -1,3 +1,16 @@
+###################
+## Migrate Settings
+###################
+
+target-redis-host : 127.0.0.1
+target-redis-port : 6379
+target-redis-user :
+target-redis-pwd  :
+
+sync-batch-num    : 100
+redis-sender-num  : 10
+
+
 ###########################
 # Pika configuration file #
 ###########################

--- a/include/migrator_thread.h
+++ b/include/migrator_thread.h
@@ -1,0 +1,65 @@
+#ifndef MIGRATOR_THREAD_H_
+#define MIGRATOR_THREAD_H_
+
+#include <iostream>
+#include <mutex>
+
+#include "storage/storage.h"
+#include "net/include/redis_cli.h"
+
+#include "include/redis_sender.h"
+
+class MigratorThread : public net::Thread {
+ public:
+  MigratorThread(std::shared_ptr<storage::Storage> storage_, std::vector<std::shared_ptr<RedisSender>>  *senders, int type, int thread_num) :
+      storage_(storage_),
+      should_exit_(false),
+      senders_(senders),
+      type_(type),
+      thread_num_(thread_num),
+      thread_index_(0),
+      num_(0) {
+  }
+
+  virtual ~ MigratorThread();
+
+  int64_t num() {
+    std::lock_guard<std::mutex> l(num_mutex_);
+    return num_;
+  }
+
+  void Stop() {
+	  should_exit_ = true;
+  }
+
+ private:
+  void PlusNum() {
+    std::lock_guard<std::mutex> l(num_mutex_);
+    ++num_;
+  }
+
+  void DispatchKey(const std::string &command, const std::string& key = "");
+
+  void MigrateDB();
+  void MigrateStringsDB();
+  void MigrateListsDB();
+  void MigrateHashesDB();
+  void MigrateSetsDB();
+  void MigrateZsetsDB();
+
+  virtual void *ThreadMain();
+
+ private:
+  std::shared_ptr<storage::Storage> storage_;
+  bool should_exit_;
+
+  std::vector<std::shared_ptr<RedisSender>> *senders_;
+  int type_;
+  int thread_num_;
+  int thread_index_;
+
+  int64_t num_;
+  std::mutex num_mutex_;
+};
+
+#endif

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -887,7 +887,12 @@ class PikaConf : public pstd::BaseConf {
   int ConfigRewrite();
   int ConfigRewriteSlaveOf();
   int ConfigRewriteReplicationID();
-
+  std::string target_redis_host() { return target_redis_host_; }
+  int target_redis_port() { return target_redis_port_; }
+  std::string target_redis_pwd() { return target_redis_pwd_; }
+  std::string target_redis_user() { return target_redis_user_; }
+  int sync_batch_num() { return sync_batch_num_; }
+  int redis_sender_num() { return redis_sender_num_; }
  private:
   int port_ = 0;
   int slave_priority_ = 100;
@@ -1065,6 +1070,14 @@ class PikaConf : public pstd::BaseConf {
 
   //Internal used metrics Persisted by pika.conf
   std::unordered_set<std::string> internal_used_unfinished_full_sync_;
+
+  // migrate configure items
+  std::string target_redis_host_;
+  int target_redis_port_;
+  std::string target_redis_pwd_;
+  std::string target_redis_user_;
+  int sync_batch_num_;
+  int redis_sender_num_;
 };
 
 #endif

--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -169,6 +169,7 @@ class ConsensusCoordinator {
 
   pstd::Status InternalAppendLog(const std::shared_ptr<Cmd>& cmd_ptr);
   pstd::Status InternalAppendBinlog(const std::shared_ptr<Cmd>& cmd_ptr);
+  pstd::Status AppendBinlogByContent(const std::shared_ptr<Cmd>& cmd_ptr, const std::string& content);
   void InternalApply(const MemLog::LogItem& log);
   void InternalApplyFollower(const std::shared_ptr<Cmd>& cmd_ptr);
 
@@ -181,7 +182,6 @@ class ConsensusCoordinator {
                                           LogOffset* found_offset);
   pstd::Status FindLogicOffset(const BinlogOffset& start_offset, uint64_t target_index, LogOffset* found_offset);
   pstd::Status GetLogsBefore(const BinlogOffset& start_offset, std::vector<LogOffset>* hints);
-
  private:
   // keep members in this class works in order
   pstd::Mutex order_mu_;

--- a/include/pika_repl_bgworker.h
+++ b/include/pika_repl_bgworker.h
@@ -47,6 +47,7 @@ class PikaReplBgWorker {
   net::BGThread bg_thread_;
   static int HandleWriteBinlog(net::RedisParser* parser, const net::RedisCmdArgsType& argv);
   static void ParseBinlogOffset(const InnerMessage::BinlogOffset& pb_offset, LogOffset* offset);
+  static void ParseAndSendPikaCommand(const std::shared_ptr<Cmd>& c_ptr);
 };
 
 #endif  // PIKA_REPL_BGWROKER_H_

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -46,6 +46,7 @@
 #include "include/pika_statistic.h"
 #include "include/pika_transaction.h"
 #include "include/rsync_server.h"
+#include "include/redis_sender.h"
 
 extern std::unique_ptr<PikaConf> g_pika_conf;
 
@@ -308,6 +309,12 @@ class PikaServer : public pstd::noncopyable {
   int ClientPubSubChannelPatternSize(const std::shared_ptr<net::NetConn>& conn);
 
   pstd::Status GetCmdRouting(std::vector<net::RedisCmdArgsType>& redis_cmds, std::vector<Node>* dst, bool* all_local);
+
+  /*
+   * migrate used
+   */
+  int SendRedisCommand(const std::string& command, const std::string& key);
+  void RetransmitData(const std::string& path);
 
   // info debug use
   void ServerStatus(std::string* info);
@@ -616,6 +623,11 @@ class PikaServer : public pstd::noncopyable {
    * Communication used
    */
   std::unique_ptr<PikaAuxiliaryThread> pika_auxiliary_thread_;
+
+  /*
+   * migrate to redis used
+   */
+  std::vector<std::unique_ptr<RedisSender>> redis_senders_;
 
   /*
    * Async slotsMgrt use

--- a/include/redis_sender.h
+++ b/include/redis_sender.h
@@ -1,0 +1,52 @@
+#ifndef REDIS_SENDER_H_
+#define REDIS_SENDER_H_
+
+#include <atomic>
+#include <thread>
+#include <chrono>
+#include <iostream>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+#include "net/include/net_thread.h"
+#include "net/include/net_cli.h"
+#include "net/include/redis_cli.h"
+
+class RedisSender : public net::Thread {
+ public:
+  RedisSender(int id, std::string ip, int64_t port, std::string user, std::string password);
+  virtual ~RedisSender();
+  void Stop(void);
+  int64_t elements() {
+    return elements_;
+  }
+
+  void SendRedisCommand(const std::string &command);
+
+ private:
+  int SendCommand(std::string &command);
+  void ConnectRedis();
+  size_t commandQueueSize() {
+    std::lock_guard l(command_queue_mutex_);
+    return commands_queue_.size();
+  }
+  virtual void *ThreadMain();
+ private:
+  int id_;
+  int port_;
+  std::shared_ptr<net::NetCli> cli_;
+  std::condition_variable rsignal_;
+  std::condition_variable wsignal_;
+  std::mutex signal_mutex_;
+  std::mutex command_queue_mutex_;
+  std::queue<std::string> commands_queue_;
+  std::string ip_;
+  std::string user_;
+  std::string password_;
+  bool should_exit_;
+  int64_t elements_;
+  std::atomic<time_t> last_write_time_;
+};
+
+#endif

--- a/src/migrator_thread.cc
+++ b/src/migrator_thread.cc
@@ -1,0 +1,465 @@
+// Copyright (c) 2015-present, Qihoo, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include "include/migrator_thread.h"
+
+#include <unistd.h>
+
+#include <vector>
+#include <functional>
+#define GLOG_USE_GLOG_EXPORT
+#include <glog/logging.h>
+
+#include "storage/storage.h"
+#include "src/redis_strings.h"
+#include "src/redis_lists.h"
+#include "src/redis_hashes.h"
+#include "src/redis_sets.h"
+#include "src/redis_zsets.h"
+#include "src/scope_snapshot.h"
+#include "src/strings_value_format.h"
+
+#include "include/pika_conf.h"
+
+const int64_t MAX_BATCH_NUM = 30000;
+
+extern PikaConf* g_pika_conf;
+
+MigratorThread::~MigratorThread() {
+}
+
+void MigratorThread::MigrateStringsDB() {
+  int64_t scan_batch_num = g_pika_conf->sync_batch_num() * 10;
+  if (MAX_BATCH_NUM < scan_batch_num) {
+    if (g_pika_conf->sync_batch_num() < MAX_BATCH_NUM) {
+      scan_batch_num = MAX_BATCH_NUM;
+    } else {
+      scan_batch_num = g_pika_conf->sync_batch_num() * 2;
+    }
+  }
+
+  int64_t ttl = -1;
+  int64_t cursor = 0;
+  storage::Status s;
+  std::string value;
+  std::vector<std::string> keys;
+  std::map<storage::DataType, int64_t> type_timestamp;
+  std::map<storage::DataType, rocksdb::Status> type_status;
+  while (true) {
+    cursor = storage_->Scan(storage::DataType::kStrings, cursor, "*", scan_batch_num, &keys);
+
+    for (const auto& key : keys) {
+      s = storage_->Get(key, &value);
+      if (!s.ok()) {
+        LOG(WARNING) << "get " << key << " error: " << s.ToString();
+        continue;
+      }
+
+      net::RedisCmdArgsType argv;
+      std::string cmd;
+
+      argv.push_back("SET");
+      argv.push_back(key);
+      argv.push_back(value);
+
+      ttl = -1;
+      type_status.clear();
+      type_timestamp = storage_->TTL(key, &type_status);
+      if (type_timestamp[storage::kStrings] != -2) {
+        ttl = type_timestamp[storage::kStrings];
+      }
+
+      if (ttl > 0) {
+        argv.push_back("EX");
+        argv.push_back(std::to_string(ttl));
+      }
+
+      net::SerializeRedisCommand(argv, &cmd);
+      PlusNum();
+      DispatchKey(cmd, key);
+    }
+
+    if (!cursor) {
+      break;
+    }
+  }
+}
+
+void MigratorThread::MigrateListsDB() {
+  int64_t scan_batch_num = g_pika_conf->sync_batch_num() * 10;
+  if (MAX_BATCH_NUM < scan_batch_num) {
+    if (g_pika_conf->sync_batch_num() < MAX_BATCH_NUM) {
+      scan_batch_num = MAX_BATCH_NUM;
+    } else {
+      scan_batch_num = g_pika_conf->sync_batch_num() * 2;
+    }
+  }
+
+  int64_t ttl = -1;
+  int64_t cursor = 0;
+  storage::Status s;
+  std::vector<std::string> keys;
+  std::map<storage::DataType, int64_t> type_timestamp;
+  std::map<storage::DataType, rocksdb::Status> type_status;
+
+  while (true) {
+    cursor = storage_->Scan(storage::DataType::kLists, cursor, "*", scan_batch_num, &keys);
+
+    for (const auto& key : keys) {
+      int64_t pos = 0;
+      std::vector<std::string> nodes;
+      storage::Status s = storage_->LRange(key, pos, pos + g_pika_conf->sync_batch_num() - 1, &nodes);
+      if (!s.ok()) {
+        LOG(WARNING) << "db->LRange(key:" << key << ", pos:" << pos
+          << ", batch size: " << g_pika_conf->sync_batch_num() << ") = " << s.ToString();
+        continue;
+      }
+
+      while (s.ok() && !should_exit_ && !nodes.empty()) {
+        net::RedisCmdArgsType argv;
+        std::string cmd;
+
+        argv.push_back("RPUSH");
+        argv.push_back(key);
+        for (const auto& node : nodes) {
+          argv.push_back(node);
+        }
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+
+        pos += g_pika_conf->sync_batch_num();
+        nodes.clear();
+        s = storage_->LRange(key, pos, pos + g_pika_conf->sync_batch_num() - 1, &nodes);
+        if (!s.ok()) {
+          LOG(WARNING) << "db->LRange(key:" << key << ", pos:" << pos
+            << ", batch size:" << g_pika_conf->sync_batch_num() << ") = " << s.ToString();
+        }
+      }
+
+      ttl = -1;
+      type_status.clear();
+      type_timestamp = storage_->TTL(key, &type_status);
+      if (type_timestamp[storage::kLists] != -2) {
+        ttl = type_timestamp[storage::kLists];
+      }
+
+      if (s.ok() && ttl > 0) {
+        net::RedisCmdArgsType argv;
+        std::string cmd;
+
+        argv.push_back("EXPIRE");
+        argv.push_back(key);
+        argv.push_back(std::to_string(ttl));
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+      }
+    }
+
+    if (!cursor) {
+      break;
+    }
+  }
+}
+
+void MigratorThread::MigrateHashesDB() {
+  int64_t scan_batch_num = g_pika_conf->sync_batch_num() * 10;
+  if (MAX_BATCH_NUM < scan_batch_num) {
+    if (g_pika_conf->sync_batch_num() < MAX_BATCH_NUM) {
+      scan_batch_num = MAX_BATCH_NUM;
+    } else {
+      scan_batch_num = g_pika_conf->sync_batch_num() * 2;
+    }
+  }
+
+  int64_t ttl = -1;
+  int64_t cursor = 0;
+  storage::Status s;
+  std::vector<std::string> keys;
+  std::map<storage::DataType, int64_t> type_timestamp;
+  std::map<storage::DataType, rocksdb::Status> type_status;
+
+  while (true) {
+    cursor = storage_->Scan(storage::DataType::kHashes, cursor, "*", scan_batch_num, &keys);
+
+    for (const auto& key : keys) {
+      std::vector<storage::FieldValue> fvs;
+      storage::Status s = storage_->HGetall(key, &fvs);
+      if (!s.ok()) {
+        LOG(WARNING) << "db->HGetall(key:" << key << ") = " << s.ToString();
+        continue;
+      }
+
+      auto it = fvs.begin();
+      while (!should_exit_ && it != fvs.end()) {
+        net::RedisCmdArgsType argv;
+        std::string cmd;
+
+        argv.push_back("HMSET");
+        argv.push_back(key);
+        for (int idx = 0;
+             idx < g_pika_conf->sync_batch_num() && !should_exit_ && it != fvs.end();
+             idx++, it++) {
+          argv.push_back(it->field);
+          argv.push_back(it->value);
+        }
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+      }
+
+      ttl = -1;
+      type_status.clear();
+      type_timestamp = storage_->TTL(key, &type_status);
+      if (type_timestamp[storage::kHashes] != -2) {
+        ttl = type_timestamp[storage::kHashes];
+      }
+
+      if (s.ok() && ttl > 0) {
+        net::RedisCmdArgsType argv;
+        std::string cmd;
+
+        argv.push_back("EXPIRE");
+        argv.push_back(key);
+        argv.push_back(std::to_string(ttl));
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+      }
+    }
+
+    if (!cursor) {
+      break;
+    }
+  }
+}
+
+void MigratorThread::MigrateSetsDB() {
+  int64_t scan_batch_num = g_pika_conf->sync_batch_num() * 10;
+  if (MAX_BATCH_NUM < scan_batch_num) {
+    if (g_pika_conf->sync_batch_num() < MAX_BATCH_NUM) {
+      scan_batch_num = MAX_BATCH_NUM;
+    } else {
+      scan_batch_num = g_pika_conf->sync_batch_num() * 2;
+    }
+  }
+
+  int64_t ttl = -1;
+  int64_t cursor = 0;
+  storage::Status s;
+  std::vector<std::string> keys;
+  std::map<storage::DataType, int64_t> type_timestamp;
+  std::map<storage::DataType, rocksdb::Status> type_status;
+
+  while (true) {
+    cursor = storage_->Scan(storage::DataType::kSets, cursor, "*", scan_batch_num, &keys);
+
+    for (const auto& key : keys) {
+      std::vector<std::string> members;
+      storage::Status s = storage_->SMembers(key, &members);
+      if (!s.ok()) {
+        LOG(WARNING) << "db->SMembers(key:" << key << ") = " << s.ToString();
+        continue;
+      }
+      auto it = members.begin();
+      while (!should_exit_ && it != members.end()) {
+        std::string cmd;
+        net::RedisCmdArgsType argv;
+
+        argv.push_back("SADD");
+        argv.push_back(key);
+        for (int idx = 0;
+             idx < g_pika_conf->sync_batch_num() && !should_exit_ && it != members.end();
+             idx++, it++) {
+          argv.push_back(*it);
+        }
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+      }
+
+      ttl = -1;
+      type_status.clear();
+      type_timestamp = storage_->TTL(key, &type_status);
+      if (type_timestamp[storage::kSets] != -2) {
+        ttl = type_timestamp[storage::kSets];
+      }
+
+      if (s.ok() && ttl > 0) {
+        net::RedisCmdArgsType argv;
+        std::string cmd;
+
+        argv.push_back("EXPIRE");
+        argv.push_back(key);
+        argv.push_back(std::to_string(ttl));
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+      }
+    }
+
+    if (!cursor) {
+      break;
+    }
+  }
+}
+
+void MigratorThread::MigrateZsetsDB() {
+  int64_t scan_batch_num = g_pika_conf->sync_batch_num() * 10;
+  if (MAX_BATCH_NUM < scan_batch_num) {
+    if (g_pika_conf->sync_batch_num() < MAX_BATCH_NUM) {
+      scan_batch_num = MAX_BATCH_NUM;
+    } else {
+      scan_batch_num = g_pika_conf->sync_batch_num() * 2;
+    }
+  }
+
+  int64_t ttl = -1;
+  int64_t cursor = 0;
+  storage::Status s;
+  std::vector<std::string> keys;
+  std::map<storage::DataType, int64_t> type_timestamp;
+  std::map<storage::DataType, rocksdb::Status> type_status;
+
+  while (true) {
+    cursor = storage_->Scan(storage::DataType::kZSets, cursor, "*", scan_batch_num, &keys);
+
+    for (const auto& key : keys) {
+      std::vector<storage::ScoreMember> score_members;
+      storage::Status s = storage_->ZRange(key, 0, -1, &score_members);
+      if (!s.ok()) {
+        LOG(WARNING) << "db->ZRange(key:" << key << ") = " << s.ToString();
+        continue;
+      }
+      auto it = score_members.begin();
+      while (!should_exit_ && it != score_members.end()) {
+        net::RedisCmdArgsType argv;
+        std::string cmd;
+
+        argv.push_back("ZADD");
+        argv.push_back(key);
+        for (int idx = 0;
+             idx < g_pika_conf->sync_batch_num() && !should_exit_ && it != score_members.end();
+             idx++, it++) {
+          argv.push_back(std::to_string(it->score));
+          argv.push_back(it->member);
+        }
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+      }
+
+      ttl = -1;
+      type_status.clear();
+      type_timestamp = storage_->TTL(key, &type_status);
+      if (type_timestamp[storage::kZSets] != -2) {
+        ttl = type_timestamp[storage::kZSets];
+      }
+
+      if (s.ok() && ttl > 0) {
+        net::RedisCmdArgsType argv;
+        std::string cmd;
+
+        argv.push_back("EXPIRE");
+        argv.push_back(key);
+        argv.push_back(std::to_string(ttl));
+
+        net::SerializeRedisCommand(argv, &cmd);
+        PlusNum();
+        DispatchKey(cmd, key);
+      }
+    }
+
+    if (!cursor) {
+      break;
+    }
+  }
+}
+
+void MigratorThread::MigrateDB() {
+  switch (int(type_)) {
+    case int(storage::kStrings) : {
+      MigrateStringsDB();
+      break;
+    }
+
+    case int(storage::kLists) : {
+      MigrateListsDB();
+      break;
+    }
+
+    case int(storage::kHashes) : {
+      MigrateHashesDB();
+      break;
+    }
+
+    case int(storage::kSets) : {
+      MigrateSetsDB();
+      break;
+    }
+
+    case int(storage::kZSets) : {
+      MigrateZsetsDB();
+      break;
+    }
+
+    default: {
+      LOG(WARNING) << "illegal db type " << type_;
+      break;
+    }
+  }
+}
+
+void MigratorThread::DispatchKey(const std::string &command, const std::string& key) {
+  thread_index_ = (thread_index_ + 1) % thread_num_;
+  size_t idx = thread_index_;
+  if (key.size()) { // no empty
+    idx = std::hash<std::string>()(key) % thread_num_;
+  }
+  (*senders_)[idx]->SendRedisCommand(command);
+}
+
+const char* GetDBTypeString(int type) {
+  switch (type) {
+    case int(storage::kStrings) : {
+	  return "storage::kStrings";
+    }
+
+    case int(storage::kLists) : {
+	  return "storage::kLists";
+    }
+
+    case int(storage::kHashes) : {
+	  return "storage::kHashes";
+    }
+
+    case int(storage::kSets) : {
+	  return "storage::kSets";
+    }
+
+    case int(storage::kZSets) : {
+	  return "storage::kZSets";
+    }
+
+    default: {
+	  return "storage::Unknown";
+    }
+  }
+}
+
+void *MigratorThread::ThreadMain() {
+  MigrateDB();
+  should_exit_ = true;
+  LOG(INFO) << GetDBTypeString(type_) << " keys have been dispatched completly";
+  return NULL;
+}

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -212,6 +212,11 @@ int PikaConf::Load() {
 
   if (classic_mode_.load()) {
     GetConfInt("databases", &databases_);
+    // pika-migrate-tool only support 1 db
+    if (databases_ != 1) {
+      LOG(FATAL) << "pika-migrate-tool only support 1 db";
+    }
+
     if (databases_ < 1 || databases_ > MAX_DB_NUM) {
       LOG(FATAL) << "config databases error, limit [1 ~ 8], the actual is: " << databases_;
     }
@@ -649,6 +654,25 @@ int PikaConf::Load() {
   } else {
     sync_window_size_.store(tmp_sync_window_size);
   }
+
+  // redis-migrate conifg args
+  target_redis_host_ = "127.0.0.1";
+  GetConfStr("target-redis-host", &target_redis_host_);
+
+  target_redis_port_ = 6379;
+  GetConfInt("target-redis-port", &target_redis_port_);
+
+  target_redis_pwd_ = "";
+  GetConfStr("target-redis-pwd" , &target_redis_pwd_);
+
+  target_redis_user_ = "";
+  GetConfStr("target-redis-user", &target_redis_user_);
+
+  sync_batch_num_ = 100;
+  GetConfInt("sync-batch-num", &sync_batch_num_);
+
+  redis_sender_num_ = 8;
+  GetConfInt("redis-sender-num", &redis_sender_num_);
 
   // max conn rbuf size
   int tmp_max_conn_rbuf_size = PIKA_MAX_CONN_RBUF;

--- a/src/pika_consensus.cc
+++ b/src/pika_consensus.cc
@@ -337,6 +337,19 @@ Status ConsensusCoordinator::InternalAppendLog(const std::shared_ptr<Cmd>& cmd_p
   return InternalAppendBinlog(cmd_ptr);
 }
 
+Status ConsensusCoordinator::AppendBinlogByContent(const std::shared_ptr<Cmd>& cmd_ptr, const std::string& content) {
+  Status s = stable_logger_->Logger()->Put(content);
+  if (!s.ok()) {
+    std::string db_name = cmd_ptr->db_name().empty() ? g_pika_conf->default_db() : cmd_ptr->db_name();
+    std::shared_ptr<DB> db = g_pika_server->GetDB(db_name);
+    if (db) {
+      db->SetBinlogIoError();
+    }
+    return s;
+  }
+  return stable_logger_->Logger()->IsOpened();
+}
+
 // precheck if prev_offset match && drop this log if this log exist
 Status ConsensusCoordinator::ProcessLeaderLog(const std::shared_ptr<Cmd>& cmd_ptr, const BinlogItem& attribute) {
   LogOffset last_index = mem_logger_->last_offset();
@@ -347,9 +360,10 @@ Status ConsensusCoordinator::ProcessLeaderLog(const std::shared_ptr<Cmd>& cmd_pt
   }
 
   auto opt = cmd_ptr->argv()[0];
+  std::string content = attribute.content();
   if (pstd::StringToLower(opt) != kCmdNameFlushdb) {
     // apply binlog in sync way
-    Status s = InternalAppendLog(cmd_ptr);
+    Status s = AppendBinlogByContent(cmd_ptr, content);
     // apply db in async way
     InternalApplyFollower(cmd_ptr);
   } else {
@@ -362,7 +376,7 @@ Status ConsensusCoordinator::ProcessLeaderLog(const std::shared_ptr<Cmd>& cmd_pt
       wait_ms = wait_ms < 3000 ? wait_ms : 3000;
     }
     // apply flushdb-binlog in sync way
-    Status s = InternalAppendLog(cmd_ptr);
+    Status s = AppendBinlogByContent(cmd_ptr, content);
     // applyDB in sync way
     PikaReplBgWorker::WriteDBInSyncWay(cmd_ptr);
   }

--- a/src/pika_db.cc
+++ b/src/pika_db.cc
@@ -473,6 +473,9 @@ bool DB::TryUpdateMasterOffset() {
             << ",  master_ip: " << master_ip << ", master_port: " << master_port << ", filenum: " << filenum
             << ", offset: " << offset << ", term: " << term << ", index: " << index;
 
+            // Retransmit Data to target redis
+  g_pika_server->RetransmitData(dbsync_path_);
+
   pstd::DeleteFile(info_path);
   if (!ChangeDb(dbsync_path_)) {
     LOG(WARNING) << "DB: " << db_name_ << ", Failed to change db";

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -136,7 +136,7 @@ void PikaReplBgWorker::HandleBGWorkerWriteBinlog(void* arg) {
     if (binlog_res.binlog().empty()) {
       continue;
     }
-    if (!PikaBinlogTransverter::BinlogItemWithoutContentDecode(TypeFirst, binlog_res.binlog(), &worker->binlog_item_)) {
+    if (!PikaBinlogTransverter::BinlogDecode(TypeFirst, binlog_res.binlog(), &worker->binlog_item_)) {
       LOG(WARNING) << "Binlog item decode failed";
       slave_db->SetReplState(ReplState::kTryConnect);
       return;

--- a/src/pika_repl_bgworker.cc
+++ b/src/pika_repl_bgworker.cc
@@ -231,6 +231,7 @@ void PikaReplBgWorker::WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr) {
       && PIKA_CACHE_NONE != g_pika_conf->cache_mode()
       && c_ptr->GetDB()->cache()->CacheStatus() == PIKA_CACHE_STATUS_OK) {
     if (c_ptr->is_write()) {
+      ParseAndSendPikaCommand(c_ptr);
       c_ptr->DoThroughDB();
       if (c_ptr->IsNeedUpdateCache()) {
         c_ptr->DoUpdateCache();
@@ -239,6 +240,7 @@ void PikaReplBgWorker::WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr) {
       LOG(WARNING) << "It is impossbile to reach here";
     }
   } else {
+    ParseAndSendPikaCommand(c_ptr);
     c_ptr->Do();
   }
   if (!c_ptr->IsSuspend()) {
@@ -272,5 +274,35 @@ void PikaReplBgWorker::WriteDBInSyncWay(const std::shared_ptr<Cmd>& c_ptr) {
         LOG(INFO) << "command: " << argv[0] << ", start_time(s): " << start_time << ", duration(us): " << duration;
       }
     }
+  }
+}
+
+void PikaReplBgWorker::ParseAndSendPikaCommand(const std::shared_ptr<Cmd>& c_ptr) {
+  const PikaCmdArgsType& argv = c_ptr->argv();
+    if (!strcasecmp(argv[0].data(), "pksetexat")) {
+    if (argv.size() != 4) {
+      LOG(WARNING) << "find invaild command, command size: " << argv.size();
+      return;
+    } else {
+      std::string key = argv[1];
+      int timestamp = std::atoi(argv[2].data());
+      std::string value = argv[3];
+
+      int seconds = timestamp - time(NULL);
+      PikaCmdArgsType tmp_argv;
+      tmp_argv.push_back("setex");
+      tmp_argv.push_back(key);
+      tmp_argv.push_back(std::to_string(seconds));
+      tmp_argv.push_back(value);
+
+      std::string command;
+      net::SerializeRedisCommand(tmp_argv, &command);
+      g_pika_server->SendRedisCommand(command, key);
+    }
+  } else {
+    std::string key = argv.size() >= 2 ? argv[1] : argv[0];
+    std::string command;
+    net::SerializeRedisCommand(argv, &command);
+    g_pika_server->SendRedisCommand(command, key);
   }
 }

--- a/src/pika_repl_client_conn.cc
+++ b/src/pika_repl_client_conn.cc
@@ -154,6 +154,7 @@ void PikaReplClientConn::HandleMetaSyncResponse(void* arg) {
   LOG(INFO) << "Finish to handle meta sync response";
 }
 
+static bool alerady_full_sync = false;
 void PikaReplClientConn::HandleDBSyncResponse(void* arg) {
   std::unique_ptr<ReplClientTaskArg> task_arg(static_cast<ReplClientTaskArg*>(arg));
   std::shared_ptr<net::PbConn> conn = task_arg->conn;
@@ -176,6 +177,12 @@ void PikaReplClientConn::HandleDBSyncResponse(void* arg) {
     std::string reply = response->has_reply() ? response->reply() : "";
     LOG(WARNING) << "DBSync Failed: " << reply;
     return;
+  }
+
+  if (!alerady_full_sync) {
+    alerady_full_sync = true;
+  } else {
+    LOG(FATAL) << "DBSyncResponse should only be called once";
   }
 
   slave_db->SetMasterSessionId(session_id);

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -24,6 +24,8 @@
 #include "include/pika_monotonic_time.h"
 #include "include/pika_rm.h"
 #include "include/pika_server.h"
+#include "include/redis_sender.h"
+#include "include/migrator_thread.h"
 
 using pstd::Status;
 extern PikaServer* g_pika_server;
@@ -101,6 +103,15 @@ PikaServer::PikaServer()
     }
   }
 
+  // Create redis sender
+  for (int i = 0; i < g_pika_conf->redis_sender_num(); ++i) {
+    redis_senders_.emplace_back(std::make_unique<RedisSender>(int(i),
+                                                              g_pika_conf->target_redis_host(),
+                                                              g_pika_conf->target_redis_port(),
+                                                              g_pika_conf->target_redis_user(),
+                                                              g_pika_conf->target_redis_pwd()));
+  }
+
   acl_ = std::make_unique<::Acl>();
   SetSlowCmdThreadPoolFlag(g_pika_conf->slow_cmd_pool());
   bgsave_thread_.set_thread_name("PikaServer::bgsave_thread_");
@@ -129,6 +140,11 @@ PikaServer::~PikaServer() {
   bgsave_thread_.StopThread();
   key_scan_thread_.StopThread();
   pika_migrate_thread_->StopThread();
+
+  for (size_t i = 0; i < redis_senders_.size(); ++i) {
+    redis_senders_[i]->Stop();
+  }
+  redis_senders_.clear();
 
   dbs_.clear();
 
@@ -208,6 +224,15 @@ void PikaServer::Start() {
     dbs_.clear();
     LOG(FATAL) << "Start Auxiliary Thread Error: " << ret
                << (ret == net::kCreateThreadError ? ": create thread error " : ": other error");
+  }
+
+  for (size_t i = 0; i < redis_senders_.size(); ++i) {
+    ret = redis_senders_[i]->StartThread();
+    if (ret != net::kSuccess) {
+      dbs_.clear();
+      LOG(FATAL) << "Start RedisSender Error: " << ret
+                 << (ret == net::kCreateThreadError ? ": create thread error " : ": other error");
+    }
   }
 
   time(&start_time_s_);
@@ -1541,6 +1566,78 @@ Status PikaServer::GetCmdRouting(std::vector<net::RedisCmdArgsType>& redis_cmds,
   UNUSED(dst);
   *all_local = true;
   return Status::OK();
+}
+
+int PikaServer::SendRedisCommand(const std::string& command, const std::string& key) {
+  // Send command
+  size_t idx = std::hash<std::string>()(key) % redis_senders_.size();
+  redis_senders_[idx]->SendRedisCommand(command);
+  return 0;
+}
+
+void PikaServer::RetransmitData(const std::string& path) {
+  std::shared_ptr<storage::Storage> storage_ = std::make_shared<storage::Storage>();
+  rocksdb::Status s = storage_->Open(g_pika_server->storage_options(), path);
+
+  if (!s.ok()) {
+    LOG(FATAL) << "open received database error: " << s.ToString();
+    return;
+  }
+
+  // Init SenderThread
+  int thread_num = g_pika_conf->redis_sender_num();
+  std::string target_host = g_pika_conf->target_redis_host();
+  int target_port = g_pika_conf->target_redis_port();
+  std::string target_pwd = g_pika_conf->target_redis_pwd();
+  std::string target_user = g_pika_conf->target_redis_user();
+
+  LOG(INFO) << "open received database success, start retransmit data to redis("
+    << target_host << ":" << target_port << ")";
+
+
+  std::vector<std::shared_ptr<RedisSender>> redis_senders_;
+  std::vector<std::shared_ptr<MigratorThread>> migrators;
+
+  for (int i = 0; i < thread_num; i++) {
+    redis_senders_.emplace_back(std::make_shared<RedisSender>(i, target_host, target_port, target_user, target_pwd));
+  }
+  migrators.emplace_back(std::make_shared<MigratorThread>(storage_, &redis_senders_, storage::kStrings, thread_num));
+  migrators.emplace_back(std::make_shared<MigratorThread>(storage_, &redis_senders_, storage::kLists, thread_num));
+  migrators.emplace_back(std::make_shared<MigratorThread>(storage_, &redis_senders_, storage::kHashes, thread_num));
+  migrators.emplace_back(std::make_shared<MigratorThread>(storage_, &redis_senders_, storage::kSets, thread_num));
+  migrators.emplace_back(std::make_shared<MigratorThread>(storage_, &redis_senders_, storage::kZSets, thread_num));
+
+  for (size_t i = 0; i < redis_senders_.size(); i++) {
+    redis_senders_[i]->StartThread();
+  }
+  for (size_t i = 0; i < migrators.size(); i++) {
+    migrators[i]->StartThread();
+  }
+
+  for (size_t i = 0; i < migrators.size(); i++) {
+    migrators[i]->JoinThread();
+  }
+  for (size_t i = 0; i < redis_senders_.size(); i++) {
+    redis_senders_[i]->Stop();
+  }
+  for (size_t i = 0; i < redis_senders_.size(); i++) {
+    redis_senders_[i]->JoinThread();
+  }
+
+  int64_t replies = 0, records = 0;
+  for (size_t i = 0; i < migrators.size(); i++) {
+    records += migrators[i]->num();
+  }
+  migrators.clear();
+  for (size_t i = 0; i < redis_senders_.size(); i++) {
+    replies += redis_senders_[i]->elements();
+  }
+  redis_senders_.clear();
+
+  LOG(INFO) << "=============== Retransmit Finish =====================";
+  LOG(INFO) << "Total records : " << records << " have been Scaned";
+  LOG(INFO) << "Total replies : " << replies << " received from redis server";
+  LOG(INFO) << "=======================================================";
 }
 
 void PikaServer::ServerStatus(std::string* info) {

--- a/src/redis_sender.cc
+++ b/src/redis_sender.cc
@@ -1,0 +1,188 @@
+// Copyright (c) 2015-present, Qihoo, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+
+#include "include/redis_sender.h"
+
+#include <time.h>
+#include <unistd.h>
+
+#include <glog/logging.h>
+
+static time_t kCheckDiff = 1;
+
+RedisSender::RedisSender(int id, std::string ip, int64_t port, std::string user, std::string password):
+  id_(id),
+  cli_(NULL),
+  ip_(ip),
+  port_(port),
+  user_(user),
+  password_(password),
+  should_exit_(false),
+  elements_(0) {
+  last_write_time_ = ::time(NULL);
+}
+
+RedisSender::~RedisSender() {
+  LOG(INFO) << "RedisSender thread " << id_ << " exit!!!";
+}
+
+void RedisSender::ConnectRedis() {
+  while (cli_ == NULL) {
+    // Connect to redis
+    cli_ = std::shared_ptr<net::NetCli>(net::NewRedisCli());
+    cli_->set_connect_timeout(1000);
+    cli_->set_recv_timeout(10000);
+    cli_->set_send_timeout(10000);
+    pstd::Status s = cli_->Connect(ip_, port_);
+    if (!s.ok()) {
+      LOG(WARNING) << "Can not connect to " << ip_ << ":" << port_ << ", status: " << s.ToString();
+      cli_ = NULL;
+      sleep(3);
+      continue;
+    } else {
+      // Connect success
+      // LOG(INFO) << "RedisSender thread " << id_ << "Connect to redis(" << ip_ << ":" << port_ << ") success";
+      // Authentication
+      if (!password_.empty()) {
+        net::RedisCmdArgsType argv, resp;
+        std::string cmd;
+
+        argv.push_back("AUTH");
+        argv.push_back(password_);
+        net::SerializeRedisCommand(argv, &cmd);
+        pstd::Status s = cli_->Send(&cmd);
+
+        if (s.ok()) {
+          s = cli_->Recv(&resp);
+          if (resp[0] == "OK") {
+          } else {
+            LOG(FATAL) << "Connect to redis(" << ip_ << ":" << port_ << ") Invalid password";
+            cli_->Close();
+            cli_ = NULL;
+            should_exit_ = true;
+            return;
+          }
+        } else {
+          LOG(WARNING) << "send auth failed: " << s.ToString();
+          cli_->Close();
+          cli_ = NULL;
+          continue;
+        }
+      } else {
+        // If forget to input password
+        net::RedisCmdArgsType argv, resp;
+        std::string cmd;
+
+        argv.push_back("PING");
+        net::SerializeRedisCommand(argv, &cmd);
+        pstd::Status s = cli_->Send(&cmd);
+
+        if (s.ok()) {
+          s = cli_->Recv(&resp);
+          if (s.ok()) {
+            if (resp[0] == "NOAUTH Authentication required.") {
+              LOG(FATAL) << "Ping redis(" << ip_ << ":" << port_ << ") NOAUTH Authentication required";
+              cli_->Close();
+              cli_ = NULL;
+              should_exit_ = true;
+              return;
+            }
+          } else {
+            LOG(WARNING) << s.ToString();
+            cli_->Close();
+            cli_ = NULL;
+          }
+        }
+      }
+    }
+  }
+}
+
+void RedisSender::Stop() {
+  set_should_stop();
+  should_exit_ = true;
+  rsignal_.notify_all();
+  wsignal_.notify_all();
+}
+
+void RedisSender::SendRedisCommand(const std::string &command) {
+  std::unique_lock lock(signal_mutex_);
+  wsignal_.wait(lock, [this]() { return commandQueueSize() < 100000; });
+  if (!should_exit_) {
+    std::lock_guard l(command_queue_mutex_);
+    commands_queue_.push(command);
+    rsignal_.notify_one();
+  }
+}
+
+int RedisSender::SendCommand(std::string &command) {
+  time_t now = ::time(NULL);
+  if (kCheckDiff < now - last_write_time_) {
+    int ret = cli_->CheckAliveness();
+    if (ret < 0) {
+      cli_ = nullptr;
+      ConnectRedis();
+    }
+    last_write_time_ = now;
+  }
+
+  // Send command
+  int idx = 0;
+  do {
+    pstd::Status s = cli_->Send(&command);
+
+    if (s.ok()) {
+      cli_->Recv(nullptr);
+      return 0;
+    }
+
+    cli_->Close();
+    cli_ = NULL;
+    ConnectRedis();
+  } while(++idx < 3);
+  LOG(FATAL) << "RedisSender " << id_ << " fails to send redis command " << command << ", times: " << idx << ", error: " << "send command failed";
+  return -1;
+}
+
+void *RedisSender::ThreadMain() {
+  LOG(INFO) << "Start redis sender " << id_ << " thread...";
+  // sleep(15);
+  int ret = 0;
+
+  ConnectRedis();
+
+  while (!should_exit_) {
+    std::unique_lock lock(signal_mutex_);
+    while (commandQueueSize() == 0 && !should_exit_) {
+      rsignal_.wait_for(lock, std::chrono::milliseconds(100));
+    }
+
+    if (should_exit_) {
+      break;
+    }
+
+    if (commandQueueSize() == 0) {
+      continue;
+    }
+
+    // get redis command
+    std::string command;
+    {
+      std::lock_guard l(command_queue_mutex_);
+      command = commands_queue_.front();
+      elements_++;
+      commands_queue_.pop();
+    }
+
+    wsignal_.notify_one();
+    ret = SendCommand(command);
+
+  }
+
+  LOG(INFO) << "RedisSender thread " << id_ << " complete";
+  cli_ = NULL;
+  return NULL;
+}


### PR DESCRIPTION
### feature
pika-migrate-tools支持3.5.0。
### Test
写入SET/HSET/LPUSH/SADD/ZADD 各10000000条，然后运行migrate-tool。在迁移期间写入/DEL/HDEL/LPOP/SREM/ZREM各5000000条。在sourceDB和targetDB对操作的key进行一致性测试，结果均一致。