### PR TITLE
fix: hello command not return information of pika version

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -3387,8 +3387,12 @@ void HelloCmd::Do() {
   }
 
   std::string raw;
+  char version[32];
+  snprintf(version, sizeof(version), "%d.%d.%d", 5, 0, 0);
+
   std::vector<storage::FieldValue> fvs{
       {"server", "redis"},
+      {"version", version}
   };
   // just for redis resp2 protocol
   fvs.push_back({"proto", "2"});


### PR DESCRIPTION
fix #2957 spring boot 3.x 连接pika报错 Version must not be null 
hello cmmand 输出增加pika verison信息，避免某些连接需要读取verison信息，但是pika没有输出所导致的错误。
输出由:
1) "server"
2) "redis"
3) "proto"
4) (integer) 2
5) "mode"
6) "classic"
7) "role"
8) "master"
变更为:
 1) "server"
 2) "redis"
 3) "version"
 4) "4.0.0"
 5) "proto"
 6) (integer) 2
 7) "mode"
 8) "classic"
 9) "role"
10) "master"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced HELLO command to include server version information in the response
- **Improvements**
	- Provides more detailed server information during connection initialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->