### PR TITLE
fix: hello command not return information of pika version

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -3303,8 +3303,11 @@ void HelloCmd::Do() {
   }
 
   std::string raw;
+  char version[32];
+  snprintf(version, sizeof(version), "%d.%d.%d", 5, 0, 0);
   std::vector<storage::FieldValue> fvs{
       {"server", "redis"},
+      {"version", version}
   };
   // just for redis resp2 protocol
   fvs.push_back({"proto", "2"});


### PR DESCRIPTION
fix https://github.com/OpenAtomFoundation/pika/issues/2957 spring boot 3.x 连接pika报错 Version must not be null
hello cmmand 输出增加pika verison信息，避免某些连接需要读取verison信息，但是pika没有输出所导致的错误。
输出由:

"server"
"redis"
"proto"
(integer) 2
"mode"
"classic"
"role"
"master"
变更为:
"server"
"redis"
"version"
"4.0.0"
"proto"
(integer) 2
"mode"
"classic"
"role"
"master"