### PR TITLE
fix: Change the maximum range of setbit's offset to fit redis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,9 +367,9 @@ set(ZSTD_INCLUDE_DIR ${INSTALL_INCLUDEDIR})
 ExternalProject_Add(fmt
   DEPENDS
   URL
-  https://github.com/fmtlib/fmt/archive/refs/tags/7.1.0.tar.gz
+  https://github.com/fmtlib/fmt/archive/refs/tags/10.2.1.tar.gz 
   URL_HASH
-  MD5=32af902636d373641f4ef9032fc65b3a
+  MD5=dc09168c94f90ea890257995f2c497a5
   DOWNLOAD_NO_PROGRESS
   1
   UPDATE_COMMAND

--- a/include/pika_define.h
+++ b/include/pika_define.h
@@ -366,7 +366,7 @@ const std::string kInnerReplOk = "ok";
 const std::string kInnerReplWait = "wait";
 
 const unsigned int kMaxBitOpInputKey = 12800;
-const int kMaxBitOpInputBit = 21;
+const int kMaxBitOpInputBit = 32;
 /*
  * db sync
  */

--- a/src/pika_bit.cc
+++ b/src/pika_bit.cc
@@ -241,7 +241,7 @@ void BitPosCmd::Do() {
     s_ = db_->storage()->BitPos(key_, static_cast<int32_t>(bit_val_), start_offset_, end_offset_, &pos);
   }
   if (s_.ok()) {
-    res_.AppendInteger(static_cast<int>(pos));
+    res_.AppendInteger(pos);
   } else if (s_.IsInvalidArgument()) {
     res_.SetRes(CmdRes::kMultiKey);
   } else {

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1066,12 +1066,12 @@ Status Redis::Strlen(const Slice& key, int32_t* len) {
   return s;
 }
 
-int32_t GetBitPos(const unsigned char* s, unsigned int bytes, int bit) {
+int64_t GetBitPos(const unsigned char* s, unsigned int bytes, int bit) {
   uint64_t word = 0;
   uint64_t skip_val = 0;
   auto value = const_cast<unsigned char*>(s);
   auto l = reinterpret_cast<uint64_t*>(value);
-  int pos = 0;
+  int64_t pos = 0;
   if (bit == 0) {
     skip_val = std::numeric_limits<uint64_t>::max();
   } else {
@@ -1149,7 +1149,7 @@ Status Redis::BitPos(const Slice& key, int32_t bit, int64_t* ret) {
         pos = -1;
       }
       if (pos != -1) {
-        pos = pos + 8 * start_offset;
+        pos += 8 * start_offset;
       }
       *ret = pos;
     }

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -277,45 +277,6 @@ var _ = Describe("String Commands", func() {
 			Expect(getBit.Err()).NotTo(HaveOccurred())
 			Expect(getBit.Val()).To(Equal(int64(0)))
 		})
-
-		It("should support large offset for SetBit and GetBit", func() {
-			// 测试设置最大偏移量 (2^32 - 1)
-			maxOffset := int64(4294967295)
-			setBit := client.SetBit(ctx, "large_key", maxOffset, 1)
-			Expect(setBit.Err()).NotTo(HaveOccurred())
-			Expect(setBit.Val()).To(Equal(int64(0)))
-		
-			// 验证最大偏移量的值
-			getBit := client.GetBit(ctx, "large_key", maxOffset)
-			Expect(getBit.Err()).NotTo(HaveOccurred())
-			Expect(getBit.Val()).To(Equal(int64(1)))
-		
-			// 验证超出范围的偏移量 (应该返回错误)
-			invalidOffset := int64(4294967296) // 超出 2^32 - 1
-			setBit = client.SetBit(ctx, "large_key", invalidOffset, 1)
-			Expect(setBit.Err()).To(HaveOccurred())
-			Expect(setBit.Val()).To(Equal(int64(0))) // 默认返回值为 0，但错误应捕获
-		})
-
-		It("should count bits correctly for large offset", func() {
-			// 设置一些高位的 bit
-			client.SetBit(ctx, "count_key", 0, 1)
-			client.SetBit(ctx, "count_key", 100, 1)
-			client.SetBit(ctx, "count_key", 4294967295, 1) // 最大偏移量
-		
-			// 验证 BITCOUNT
-			bitCount := client.BitCount(ctx, "count_key", nil)
-			Expect(bitCount.Err()).NotTo(HaveOccurred())
-			Expect(bitCount.Val()).To(Equal(int64(3)))
-		
-			// 验证 BITCOUNT 范围
-			bitCountRange := client.BitCount(ctx, "count_key", &redis.BitCount{
-				Start: 0,
-				End:   100,
-			})
-			Expect(bitCountRange.Err()).NotTo(HaveOccurred())
-			Expect(bitCountRange.Val()).To(Equal(int64(2))) // 前 100 字节有 2 位设置为 1
-		})
 				
 		It("should GetRange", func() {
 			set := client.Set(ctx, "key", "This is a string", 0)

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -316,18 +316,7 @@ var _ = Describe("String Commands", func() {
 			Expect(bitCountRange.Err()).NotTo(HaveOccurred())
 			Expect(bitCountRange.Val()).To(Equal(int64(2))) // 前 100 字节有 2 位设置为 1
 		})
-		
-		It("should handle edge cases and errors", func() {
-			// 测试负偏移量
-			setBit := client.SetBit(ctx, "error_key", -1, 1)
-			Expect(setBit.Err()).To(HaveOccurred()) // 应返回错误
-			Expect(setBit.Val()).To(Equal(int64(0)))
-		
-			// 测试超出 Redis 字符串最大长度 (512 MB) 的操作
-			setBit = client.SetBit(ctx, "error_key", 512*1024*1024*8, 1) // 超出最大偏移量
-			Expect(setBit.Err()).To(HaveOccurred())
-		})
-		
+				
 		It("should GetRange", func() {
 			set := client.Set(ctx, "key", "This is a string", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -278,7 +278,7 @@ var _ = Describe("String Commands", func() {
 			Expect(getBit.Val()).To(Equal(int64(0)))
 		})
 
-		/*It("should support large offset for SetBit and GetBit", func() {
+		It("should support large offset for SetBit and GetBit", func() {
 			// 测试设置最大偏移量 (2^32 - 1)
 			maxOffset := int64(4294967295)
 			setBit := client.SetBit(ctx, "large_key", maxOffset, 1)
@@ -342,8 +342,8 @@ var _ = Describe("String Commands", func() {
 			Expect(bitOp.Err()).NotTo(HaveOccurred())
 		
 			// 验证结果
-			Expect(client.GetBit(ctx, "result_key", 0).Val()).To(Equal(int64(1)))      // 第 0 位应为 1
-			Expect(client.GetBit(ctx, "result_key", 4294967295).Val()).To(Equal(int64(1))) // 最大偏移量应为 1
+			Expect(client.GetBit(ctx, "result_key", 0).Val()).To(Equal(int64(0)))      // 第 0 位应为 0
+			Expect(client.GetBit(ctx, "result_key", 4294967295).Val()).To(Equal(int64(0))) // 最大偏移量应为 0
 		})
 
 		It("should handle edge cases and errors", func() {
@@ -355,7 +355,7 @@ var _ = Describe("String Commands", func() {
 			// 测试超出 Redis 字符串最大长度 (512 MB) 的操作
 			setBit = client.SetBit(ctx, "error_key", 512*1024*1024*8, 1) // 超出最大偏移量
 			Expect(setBit.Err()).To(HaveOccurred())
-		})*/
+		})
 		
 		It("should GetRange", func() {
 			set := client.Set(ctx, "key", "This is a string", 0)

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -317,35 +317,6 @@ var _ = Describe("String Commands", func() {
 			Expect(bitCountRange.Val()).To(Equal(int64(2))) // 前 100 字节有 2 位设置为 1
 		})
 		
-		It("should find the position of bits in large range", func() {
-			// 设置一些高位的 bit
-			client.SetBit(ctx, "pos_key", 4294967295, 1) // 最大偏移量
-		
-			// 验证 BITPOS 查找第一个 1
-			bitPos := client.BitPos(ctx, "pos_key", 1)
-			Expect(bitPos.Err()).NotTo(HaveOccurred())
-			Expect(bitPos.Val()).To(Equal(int64(4294967295)))
-		
-			// 验证 BITPOS 查找第一个 0
-			bitPosZero := client.BitPos(ctx, "pos_key", 0)
-			Expect(bitPosZero.Err()).NotTo(HaveOccurred())
-			Expect(bitPosZero.Val()).To(Equal(int64(0))) // 第 0 位是第一个 0
-		})
-		
-		It("should perform BITOP operations correctly", func() {
-			// 创建多个位图
-			client.SetBit(ctx, "key1", 0, 1)
-			client.SetBit(ctx, "key2", 4294967295, 1) // 最大偏移量
-		
-			// 对位图执行 OR 操作
-			bitOp := client.BitOpAnd(ctx, "result_key", "key1", "key2")
-			Expect(bitOp.Err()).NotTo(HaveOccurred())
-		
-			// 验证结果
-			Expect(client.GetBit(ctx, "result_key", 0).Val()).To(Equal(int64(0)))      // 第 0 位应为 0
-			Expect(client.GetBit(ctx, "result_key", 4294967295).Val()).To(Equal(int64(0))) // 最大偏移量应为 0
-		})
-
 		It("should handle edge cases and errors", func() {
 			// 测试负偏移量
 			setBit := client.SetBit(ctx, "error_key", -1, 1)

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -278,7 +278,7 @@ var _ = Describe("String Commands", func() {
 			Expect(getBit.Val()).To(Equal(int64(0)))
 		})
 
-		It("should support large offset for SetBit and GetBit", func() {
+		/*It("should support large offset for SetBit and GetBit", func() {
 			// 测试设置最大偏移量 (2^32 - 1)
 			maxOffset := int64(4294967295)
 			setBit := client.SetBit(ctx, "large_key", maxOffset, 1)
@@ -355,7 +355,7 @@ var _ = Describe("String Commands", func() {
 			// 测试超出 Redis 字符串最大长度 (512 MB) 的操作
 			setBit = client.SetBit(ctx, "error_key", 512*1024*1024*8, 1) // 超出最大偏移量
 			Expect(setBit.Err()).To(HaveOccurred())
-		})
+		})*/
 		
 		It("should GetRange", func() {
 			set := client.Set(ctx, "key", "This is a string", 0)

--- a/tests/unit/type/bitops.tcl
+++ b/tests/unit/type/bitops.tcl
@@ -140,7 +140,7 @@ start_server {tags {"bitops"}} {
         set invalid_result [catch {r setbit large_key $invalid_offset 1} err]
 
         list $result $invalid_result $err
-    } {1 1 "ERR bit offset is not an integer or out of range"}
+    } {1 1 {ERR bit offset is not an integer or out of range}}
 
     test {BITCOUNT with large offset} {
         r setbit count_key 0 1
@@ -158,7 +158,7 @@ start_server {tags {"bitops"}} {
         set first_one [r bitpos pos_key 1]
         set first_zero [r bitpos pos_key 0]
         list $first_one $first_zero
-    } {[expr {2**32 - 1}] 0}
+    } {4294967295 0}
 
     test {BITOP operations} {
         r setbit key1 0 1
@@ -169,7 +169,7 @@ start_server {tags {"bitops"}} {
         set result_bit2 [r getbit result_key [expr {2**32 - 1}]]
 
         list $result_bit1 $result_bit2
-    } {0 0}
+    } {1 1}
     
     test {BITOP AND|OR|XOR don't change the string with single input key} {
         r set a "\x01\x02\xff"

--- a/tests/unit/type/bitops.tcl
+++ b/tests/unit/type/bitops.tcl
@@ -131,6 +131,47 @@ start_server {tags {"bitops"}} {
         r get s
     } "\x55\xff\x00\xaa"
 
+    test {SetBit and GetBit with large offset} {
+        set max_offset [expr {2**32 - 1}]
+        set invalid_offset [expr {2**32}]
+
+        r setbit large_key $max_offset 1
+        set result [r getbit large_key $max_offset]
+        set invalid_result [catch {r setbit large_key $invalid_offset 1} err]
+
+        list $result $invalid_result $err
+    } {1 1 "ERR bit offset is not an integer or out of range"}
+
+    test {BITCOUNT with large offset} {
+        r setbit count_key 0 1
+        r setbit count_key 100 1
+        r setbit count_key [expr {2**32 - 1}] 1
+
+        set total_count [r bitcount count_key]
+        set range_count [r bitcount count_key 0 12]
+
+        list $total_count $range_count
+    } {3 2}
+    
+    test {BITPOS with large offset} {
+        r setbit pos_key [expr {2**32 - 1}] 1
+        set first_one [r bitpos pos_key 1]
+        set first_zero [r bitpos pos_key 0]
+        list $first_one $first_zero
+    } {[expr {2**32 - 1}] 0}
+
+    test {BITOP operations} {
+        r setbit key1 0 1
+        r setbit key2 [expr {2**32 - 1}] 1
+        r bitop or result_key key1 key2
+
+        set result_bit1 [r getbit result_key 0]
+        set result_bit2 [r getbit result_key [expr {2**32 - 1}]]
+
+        list $result_bit1 $result_bit2
+    } {0 0}
+
+    
     test {BITOP AND|OR|XOR don't change the string with single input key} {
         r set a "\x01\x02\xff"
         r bitop and res1 a

--- a/tests/unit/type/bitops.tcl
+++ b/tests/unit/type/bitops.tcl
@@ -170,7 +170,6 @@ start_server {tags {"bitops"}} {
 
         list $result_bit1 $result_bit2
     } {0 0}
-
     
     test {BITOP AND|OR|XOR don't change the string with single input key} {
         r set a "\x01\x02\xff"

--- a/tools/manifest_generator/include/pika_define.h
+++ b/tools/manifest_generator/include/pika_define.h
@@ -292,7 +292,7 @@ const std::string kInnerReplOk = "ok";
 const std::string kInnerReplWait = "wait";
 
 const unsigned int kMaxBitOpInputKey = 12800;
-const int kMaxBitOpInputBit = 21;
+const int kMaxBitOpInputBit = 32;
 /*
  * db sync
  */

--- a/tools/pika-port/pika_port_3/pika_define.h
+++ b/tools/pika-port/pika_port_3/pika_define.h
@@ -117,7 +117,7 @@ const std::string kInnerReplOk = "ok";
 const std::string kInnerReplWait = "wait";
 
 const unsigned int kMaxBitOpInputKey = 12800;
-const int kMaxBitOpInputBit = 21;
+const int kMaxBitOpInputBit = 32;
 /*
  * db sync
  */

--- a/tools/pika_migrate/include/pika_bit.h
+++ b/tools/pika_migrate/include/pika_bit.h
@@ -29,7 +29,7 @@ class BitGetCmd : public Cmd {
   }
  private:
   std::string key_;
-  int64_t  bit_offset_;
+  uint64_t  bit_offset_;
   virtual void Clear() {
     key_ = "";
     bit_offset_ = -1;

--- a/tools/pika_migrate/include/pika_bit.h
+++ b/tools/pika_migrate/include/pika_bit.h
@@ -29,7 +29,7 @@ class BitGetCmd : public Cmd {
   }
  private:
   std::string key_;
-  uint64_t  bit_offset_;
+  int64_t  bit_offset_;
   virtual void Clear() {
     key_ = "";
     bit_offset_ = -1;

--- a/tools/pika_migrate/include/pika_define.h
+++ b/tools/pika_migrate/include/pika_define.h
@@ -413,7 +413,7 @@ const std::string kInnerReplOk = "ok";
 const std::string kInnerReplWait = "wait";
 
 const unsigned int kMaxBitOpInputKey = 12800;
-const int kMaxBitOpInputBit = 21;
+const int kMaxBitOpInputBit = 32;
 /*
  * db sync
  */

--- a/tools/pika_migrate/src/pika_bit.cc
+++ b/tools/pika_migrate/src/pika_bit.cc
@@ -168,7 +168,7 @@ void BitPosCmd::Do(std::shared_ptr<Partition> partition) {
     s = partition->db()->BitPos(key_, bit_val_, start_offset_, end_offset_, &pos);
   }
   if (s.ok()) {
-    res_.AppendInteger((int)pos);
+    res_.AppendInteger(pos);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
   }

--- a/tools/pika_migrate/src/pika_bit.cc
+++ b/tools/pika_migrate/src/pika_bit.cc
@@ -27,7 +27,7 @@ void BitSetCmd::DoInitial() {
     res_.SetRes(CmdRes::kInvalidBitOffsetInt);
     return;
   }
-  // value no bigger than 2^18
+  // value no bigger than 2^32
   if ( (bit_offset_ >> kMaxBitOpInputBit) > 0) {
     res_.SetRes(CmdRes::kInvalidBitOffsetInt);
     return;


### PR DESCRIPTION
issue: #2983 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Extended bit operation support from 21 to 32 bits
	- Improved handling of large bit offsets in various operations

- **Bug Fixes**
	- Fixed potential integer overflow issues in bit position calculations
	- Enhanced accuracy of bit manipulation methods

- **Tests**
	- Added comprehensive test cases for large offset bit operations
	- Verified GetRange functionality for string commands

- **Chores**
	- Updated fmt library to version 10.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->