### PR TITLE
fix: Solution The set command cache does not take effect

### DIFF
--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -111,7 +111,7 @@ void SetCmd::DoUpdateCache() {
   }
   if (s_.ok()) {
     if (has_ttl_) {
-      db_->cache()->Setxx(key_, value_, ttl_millsec / 1000);
+      db_->cache()->Setxx(key_, value_, ttl_millsec > 0 ? ttl_millsec / 1000 : ttl_millsec);
     } else {
       db_->cache()->SetxxWithoutTTL(key_, value_);
     }
@@ -191,7 +191,7 @@ void GetCmd::DoUpdateCache() {
     return;
   }
   if (s_.ok()) {
-    db_->cache()->WriteKVToCache(key_, value_, ttl_millsec_ / 1000);
+    db_->cache()->WriteKVToCache(key_, value_, ttl_millsec_ > 0 ? ttl_millsec_ / 1000 : ttl_millsec_);
   }
 }
 


### PR DESCRIPTION
解决了 Set 命令更新 Cache 不生效的问题，原因在于使用 Set 命令时设置 TTL 为 0
issue: #3014 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved cache expiration logic by converting TTL values only when they are positive, ensuring that non-positive TTL values remain unchanged for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->