### PR TITLE
feat: add consistency_check tool

### DIFF
--- a/tools/consistency_check_tool/README_CN.md
+++ b/tools/consistency_check_tool/README_CN.md
@@ -1,0 +1,81 @@
+# 一致性测试工具
+使用方法为*先执行写入操作，再执行读取操作*，最后执行一致性检查操作。两次操作的k-v参数必须完全一致，随机种子也必须一致。
+使用场景为检测主从同步一致性，以及重启/升级前后数据一致性。
+检测原理为先写入数据，从主从节点分别读取数据，最后比较两次读取的数据是否一致。或者比较生成的写数据和读取的数据是否一致。
+
+## 编译
+```shell
+go build
+```
+
+## 支持的参数
+- `-mh`：目标主机的 IP 地址；
+- `-mp`：目标主机的端口号；
+- `mu` : 目标主机用户名；
+- `mpw` : 目标主机密码；
+- `-sh`：从节点的 IP 地址；
+- `-sp`：从节点的端口号；
+- `su` : 从节点用户名；
+- `spw` : 从节点密码；
+- `-r`：生成随机key的长度；
+- `-d`：生成随机value的长度；
+- `-n`: 总共生成到的command数量；
+- `-log-file`：日志文件名；
+- `-checkMode`：检查模式；
+- `randomSeed`：随机种子；
+- `c` : 客户端数量；
+- `ARGS`：为写入的操作的参数
+从节点的IP和端口号可以有多个，但是必须一一对应。
+从节点的用户名和密码可以有多个，但是必须一一对应。
+从节点的用户名和密码可以少于从节点的IP和端口号，匹配规则为前面的的正常配对，后面缺少的按空处理，即不使用
+
+## 写入操作
+```shell
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 60 -d 60 -n 1000 -log-file SET-12345.log SET __key__ __data__
+```
+
+## 读取操作
+```shell
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -sh 127.0.0.1 -sp 9241 -sh 127.0.0.1 -sp 9251 -r 60 -d 60 -n 1000 -checkMode 2 -log-file SET-12345-check.log SET __key__ __data__
+```
+
+
+### 检查模式
+- 0：（默认），此时为写入模式，写入失败会产生logError。
+- 1：（检查模式，不存在写入），可以用作主从一致性检查，检测原理为先从主节点读取数据，再从从节点读取数据，最后比较两次读取的数据是否一致。如果前面的写入失败导致值为空，因为主从仍然是一致的，所以在check时不会产生logError。
+- 2：（检查模式，不存在写入），用作重启/升级前写入埋点数据，重启/升级后检查数据是否一致。此时master和slave都为需要检测的客户端，分别读取数据，并检查是否与随机产生的写入数据一致。因为写入和检查使用的是一样的随机种子。这个时候如果存在节点数据与写入不一致，哪怕主从一致，也会产生logError。
+
+### Args
+直接把写入的命令和参数写在后面，如SET __key__ __data__，写入的key均以__key__替代，写入的value均以__data__替代。
+命令只支持大写，如SET、DEL、HSET等。
+eg:
+*write*:
+```shell
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 60 -d 60 -n 1000 -log-file SET-12345.log SET __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 59 -d 59 -n 1000 -log-file HSET-12345.log HSET __key__ __key__ __data__  
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 58 -d 58 -n 1000 -log-file LPUSH-12345.log LPUSH __key__ __key__ __key__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 57 -d 57 -n 1000 -log-file SADD-12345.log SADD __key__ __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 56 -d 56 -n 1000 -log-file ZADD-12345.log ZADD __key__ 10 __key__ 9 __key__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 55 -d 55 -n 1000 -log-file XADD-12345.log XADD __key__ 1 __key__ __data__ 
+```
+
+*check*:
+```shell
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -r 60 -d 60 -n 1000 -checkMode 2 -log-file SET-12345-check.log SET __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -r 59 -d 59 -n 1000 -checkMode 2 -log-file HSET-12345-check.log HSET __key__ __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -r 58 -d 58 -n 1000 -checkMode 2 -log-file LPUSH-12345-check.log LPUSH __key__ __key__ __key__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -r 57 -d 57 -n 1000 -checkMode 2 -log-file SADD-12345-check.log SADD __key__ __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -r 56 -d 56 -n 1000 -checkMode 2 -log-file ZADD-12345-check.log ZADD __key__ 10 __key__ 9 __key__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -r 55 -d 55 -n 1000 -checkMode 2 -log-file XADD-12345-check.log XADD __key__ 1 __key__ __data__ 
+```
+
+### 删除测试写入的所有key
+*delete*:
+```shell
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 60 -d 60 -n 1000 -log-file DEL-12345.log DEL __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 59 -d 59 -n 1000 -log-file HDEL-12345.log HDEL __key__ __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 58 -d 58 -n 1000 -log-file LPOP-12345.log LPOP __key__ __key__ __key__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 57 -d 57 -n 1000 -log-file SREM-12345.log SREM __key__ __key__ __data__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 56 -d 56 -n 1000 -log-file ZREM-12345.log ZREM __key__ __key__ __key__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 55 -d 55 -n 1000 -log-file XDEL-12345.log XDEL __key__ 1 __key__ __data__ __key__ __data__
+```

--- a/tools/consistency_check_tool/commands.go
+++ b/tools/consistency_check_tool/commands.go
@@ -1,0 +1,14 @@
+package main
+
+var getcommandForWrite = map[string]string{
+	"SET":   "GET",
+	"MSET":  "MGET",
+	"HSET":  "HGET",
+	"HMSET": "HMGET",
+	"LPUSH": "LRANGE",
+	"SADD":  "SMEMBERS",
+	"ZADD":  "ZRANGE",
+	"XADD":  "XRANGE",
+}
+
+var delCommand = []string{"DEL", "HDEL", "LREM", "SREM", "ZREM", "XDEL"}

--- a/tools/consistency_check_tool/common.go
+++ b/tools/consistency_check_tool/common.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"log"
+	"math/rand"
+	"strings"
+)
+
+const charSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+type datapoint struct {
+	cmdSuccess   bool
+	durationMS   int64
+	isConsistent bool
+}
+
+func stringWithCharset(length int, charset string, r *rand.Rand) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[r.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func keyBuildLogic(keyPos []int, dataPos []int, datasize, keyspacelen uint64, cmdS []string, charset string, r *rand.Rand) (newCmdS []string, key string) {
+	newCmdS = make([]string, len(cmdS))
+	copy(newCmdS, cmdS)
+	for i := range keyPos {
+		keyV := stringWithCharset(int(keyspacelen), charset, r)
+		key = strings.Replace(newCmdS[keyPos[i]], "__key__", keyV, -1)
+		newCmdS[keyPos[i]] = key
+	}
+	for i := range dataPos {
+		newCmdS[dataPos[i]] = stringWithCharset(int(datasize), charset, r)
+	}
+	// only reserve keyPos in newCmdS
+	if isDelCommand(newCmdS[0]) && newCmdS[0] != "XDEL" {
+		delCommand := make([]string, len(keyPos)+1)
+		delCommand[0] = newCmdS[0]
+		for i := range keyPos {
+			delCommand[i+1] = newCmdS[keyPos[i]]
+		}
+		return delCommand, key
+	}
+	return newCmdS, key
+}
+
+func getplaceholderpos(args []string) (keyPlaceOlderPos []int, dataPlaceOlderPos []int) {
+	keyPlaceOlderPos = make([]int, 0)
+	dataPlaceOlderPos = make([]int, 0)
+	for pos, arg := range args {
+		if arg == "__data__" {
+			dataPlaceOlderPos = append(dataPlaceOlderPos, pos)
+		}
+
+		if strings.Contains(arg, "__key__") {
+			keyPlaceOlderPos = append(keyPlaceOlderPos, pos)
+		}
+	}
+	return
+}
+
+func getReadCmdsFromWriteCmds(writeCmds []string) (readCmds, result []string) {
+	readCmd := getcommandForWrite[writeCmds[0]]
+	if readCmd == "" {
+		// error print
+		log.Fatalf("No read command found for write command %s", writeCmds[0])
+	}
+	switch readCmd {
+	case "GET":
+		// SET key value
+		// writeCmds[SET, key, value]
+		// readCmds[GET, key]
+		readCmds = []string{"GET", writeCmds[1]}
+		result = []string{writeCmds[2]}
+	case "MGET":
+		// MSET key value [key value ...]
+		// writeCmds[MSET, key, value, key, value]
+		// readCmds[MGET, key, key]
+		readCmds = []string{"MGET"}
+		for i := 1; i < len(writeCmds); i += 2 {
+			readCmds = append(readCmds, writeCmds[i])
+		}
+		var values []string
+		for i := 2; i < len(writeCmds); i += 2 {
+			values = append(values, writeCmds[i])
+		}
+		result = append(result, values...)
+	case "HGET":
+		// HSET key filed value
+		// writeCmds[HSET, key, field, value]
+		// readCmds[HGET, key, field]
+		readCmds = []string{"HGET"}
+		readCmds = append(readCmds, writeCmds[1], writeCmds[2])
+		result = []string{writeCmds[3]}
+	case "HMGET":
+		// HMSET key field value [field value ...]
+		// writeCmds[HMSET, key, field, value, field, value]
+		var fields []string
+		for i := 2; i < len(writeCmds); i += 2 {
+			fields = append(fields, writeCmds[i])
+		}
+		var values []string
+		for i := 3; i < len(writeCmds); i += 2 {
+			values = append(values, writeCmds[i])
+		}
+		readCmds = []string{"HMGET", writeCmds[1]}
+		readCmds = append(readCmds, fields...)
+		result = append(result, values...)
+	case "LRANGE":
+		// LPUSH key value [value ...]
+		// writeCmds[LPUSH, key, value, value]
+		readCmds = []string{"LRANGE", writeCmds[1], "0", "-1"}
+		result = writeCmds[2:]
+	case "SMEMBERS":
+		// SADD key member [member ...]
+		// writeCmds[SADD, key, member, member]
+		readCmds = []string{"SMEMBERS", writeCmds[1]}
+		result = writeCmds[2:]
+	case "ZRANGE":
+		// ZADD key score member [score member ...]
+		// writeCmds[ZADD, key, score, member]
+		readCmds = []string{"ZRANGE", writeCmds[1], "0", "-1"}
+		var members []string
+		for i := 3; i < len(writeCmds); i += 2 {
+			members = append(members, writeCmds[i])
+		}
+		result = append(result, members...)
+	case "XRANGE":
+		// XADD key id field value [field value ...]
+		// writeCmds[XADD, key, id, field, value]
+		readCmds = []string{"XRANGE", writeCmds[1], "-", "+"}
+		result = writeCmds[3:]
+	}
+	return
+}
+
+func isDelCommand(cmd string) bool {
+	for _, delCmd := range delCommand {
+		if cmd == delCmd {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/consistency_check_tool/consistency.go
+++ b/tools/consistency_check_tool/consistency.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"os/signal"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type StringSlice []string
+
+var checkMode int64
+
+func (s *StringSlice) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *StringSlice) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+func main() {
+	var slaves StringSlice
+	var slavesPort StringSlice
+	var slavesUser StringSlice
+	var slavesPasswd StringSlice
+
+	master := flag.String("mh", "", "Master hostName")
+	masterPort := flag.String("mp", "", "Master port")
+	masterUser := flag.String("mu", "", "Master user")
+	masterPassword := flag.String("mpw", "", "Master password")
+	flag.Var(&slaves, "sh", "Slave hostName")
+	flag.Var(&slavesPort, "sp", "Slave port")
+	flag.Var(&slavesUser, "su", "Slave user")
+	flag.Var(&slavesPasswd, "spw", "Slave password")
+	consistencyCheck := flag.Int64("checkMode", 0, "0: just write to master;\n 1: Check consistency of master and slaves(might write failded in master;\n 2: Check that all nodes(master and slaves) are consistent with the written value previously")
+	logFile := flag.String("log-file", "", "Log file. If empty will not save.")
+	seed := flag.Int64("random-seed", 12345, "random seed to be used.")
+	clients := flag.Uint64("c", 50, "number of clients.")
+	keyspacelen := flag.Uint64("r", 100000, "keyspace length. The benchmark will expand the string __key__ inside an argument with a number in the specified range from 0 to keyspacelen-1. The substitution changes every time a command is executed.")
+	datasize := flag.Uint64("d", 30, "Data size of the expanded string __data__ value in bytes. The benchmark will expand the string __data__ inside an argument with a charset with length specified by this parameter. The substitution changes every time a command is executed.")
+	numberRequests := flag.Uint64("n", 10000000, "Total number of requests")
+
+	flag.Parse()
+	cmd := flag.Args()
+
+	// check if the number of slaves and slave ports are equal
+	if len(slaves) != len(slavesPort) {
+		panic("The number of slaves and slave ports should be equal")
+	}
+
+	// check if the user and password
+	if len(slavesUser) != len(slavesPasswd) {
+		panic("The number of slaves user and password should be equal")
+	}
+
+	if len(slavesPasswd) < len(slaves) {
+		for i := len(slavesPasswd); i < len(slaves); i++ {
+			slavesPasswd = append(slavesPasswd, "")
+			slavesUser = append(slavesUser, "")
+		}
+	}
+
+	if len(cmd) < 2 {
+		log.Fatalf("You need to specify a command after the flag command arguments. The commands requires a minimum size of 2 ( command name and key )")
+	}
+
+	if *logFile != "" {
+		f, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			log.Fatalf("error opening file: %v", err)
+		}
+		defer f.Close()
+		log.SetOutput(f)
+	}
+
+	checkMode = *consistencyCheck
+	cmdKeyplaceHolderPos, cmdDataplaceHolderPos := getplaceholderpos(cmd)
+	samplesPerClient := *numberRequests / *clients
+	masterOpts := redis.Options{}
+	if *masterUser != "" {
+		masterOpts.Username = *masterUser
+	}
+	if *masterPassword != "" {
+		masterOpts.Password = *masterPassword
+	}
+	masterOpts.Addr = *master + ":" + *masterPort
+	slavesOpts := make([]redis.Options, len(slaves))
+
+	for i, slave := range slaves {
+		slavesOpts[i].Addr = slave + ":" + slavesPort[i]
+		if slavesUser[i] != "" {
+			slavesOpts[i].Username = slavesUser[i]
+		}
+		if slavesPasswd[i] != "" {
+			slavesOpts[i].Password = slavesPasswd[i]
+		}
+	}
+
+	stopChan := make(chan struct{})
+	datapointsChan := make(chan datapoint, *clients)
+
+	wg := sync.WaitGroup{}
+	var sourceClient *redis.Client
+	var targetClient []*redis.Client
+	for clientID := 1; clientID <= int(*clients); clientID++ {
+		wg.Add(1)
+		sourceClient = redis.NewClient(&masterOpts)
+		targetClient = make([]*redis.Client, len(slaves))
+		for i, slave := range slavesOpts {
+			targetClient[i] = redis.NewClient(&slave)
+		}
+		go checkRoutine(sourceClient, targetClient, cmd, *keyspacelen, *datasize, samplesPerClient, cmdKeyplaceHolderPos, cmdDataplaceHolderPos, *seed+int64(clientID), &wg, datapointsChan)
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	tick := time.NewTicker(1 * time.Second)
+	closed, totalCommands, totalErrors, totalDiffCommand := updateCLI(*numberRequests, *tick, c, datapointsChan)
+	if !closed {
+		tick.Stop()
+	}
+	if checkMode == 0 {
+		log.Printf("Total commands: %d\nTotal errors: %d\n", totalCommands, totalErrors)
+	} else {
+		log.Printf("Total commands: %d\nTotal errors: %d\nTotal diff commands: %d\n", totalCommands, totalErrors, totalDiffCommand)
+	}
+	close(stopChan)
+	wg.Wait()
+	os.Exit(0)
+	fmt.Printf("\nTest finished\n")
+}
+
+func checkRoutine(sourceClient *redis.Client, targetClient []*redis.Client, cmds []string, keySpaceLen, dataSize, samplesPerClient uint64, keyPlace, dataPlace []int, seed int64, wg *sync.WaitGroup, dataPointsChan chan datapoint) {
+	defer wg.Done()
+	r := rand.New(rand.NewSource(seed))
+	for i := uint64(0); i < samplesPerClient; i++ {
+		writeCmds, _ := keyBuildLogic(keyPlace, dataPlace, dataSize, keySpaceLen, cmds, charSet, r)
+		if writeCmds[0] == "LPOP" {
+			writeCmds = writeCmds[:2]
+		} else if writeCmds[0] == "XDEL" {
+			writeCmds = writeCmds[:3]
+		}
+		sendCmd(sourceClient, targetClient, writeCmds, dataPointsChan)
+	}
+}
+
+func sendCmd(sourceClient *redis.Client, targetClients []*redis.Client, writeCmdS []string, dataPointsChan chan datapoint) {
+	ctx := context.TODO()
+	var err error
+	startT := time.Now()
+	isConsistent := true
+
+	if checkMode == 0 {
+		// send write command to master
+		args := make([]interface{}, len(writeCmdS))
+		for i, v := range writeCmdS {
+			args[i] = v
+		}
+		err = sourceClient.Do(ctx, args...).Err()
+		// log.Printf("Source write command is: %v", writeCmdS)
+
+		if err != nil {
+			log.Printf("Received an error with the following command(s): %v, error: %v", writeCmdS, err)
+		}
+
+	} else if checkMode == 1 {
+		// check master and all slave consistency
+
+		// get read command from write command
+		readCmds, _ := getReadCmdsFromWriteCmds(writeCmdS)
+		readArgs := make([]interface{}, len(readCmds))
+		for i, v := range readCmds {
+			readArgs[i] = v
+		}
+		sourceResult := sourceClient.Do(ctx, readArgs...).Val()
+		// send read command to all slave node
+		for _, targetClient := range targetClients {
+			targetResult := targetClient.Do(ctx, readArgs...).Val()
+			if readCmds[0] == "XRANGE" {
+				isConsistent = compareXStreamResults(sourceResult, targetResult)
+			} else {
+				isConsistent = compareResults(sourceResult, targetResult)
+			}
+			if isConsistent {
+				// log.Printf("Target read command is: %v\nSuccess:\nMaster result: %v\nSlave result: %v\n", readCmds, sourceResult, targetResult)
+			} else {
+				isConsistent = false
+				log.Printf("Target:%s read command is: %v\nFailed:\nMaster result: %v\nSlave result: %v\n", targetClient.Options().Addr, readCmds, sourceResult, targetResult)
+			}
+		}
+	} else {
+		// check that all nodes are consistent with the written value previously
+		readCmds, result := getReadCmdsFromWriteCmds(writeCmdS)
+		readArgs := make([]interface{}, len(readCmds))
+		expectResult := make([]interface{}, len(result))
+		for i, v := range readCmds {
+			readArgs[i] = v
+		}
+		for i, v := range result {
+			expectResult[i] = v
+		}
+		targetClients = append(targetClients, sourceClient)
+		// send read command to all slave node
+		for _, targetClient := range targetClients {
+			targetResult := targetClient.Do(ctx, readArgs...).Val()
+			if readCmds[0] == "XRANGE" {
+				isConsistent = compareXStreamResults(expectResult, targetResult)
+			} else {
+				isConsistent = compareResults(expectResult, targetResult)
+			}
+			if isConsistent {
+				// log.Printf("Target read command is: %v\nSuccess:\nMaster result: %v\nSlave result: %v\n", readCmds, sourceResult, targetResult)
+			} else {
+				log.Printf("Target:%s read command is: %v\nFailed:\nMaster result: %v\nSlave result: %v\n", targetClient.Options().Addr, readCmds, expectResult, targetResult)
+			}
+		}
+	}
+
+	endT := time.Now()
+	duration := endT.Sub(startT)
+	dataPointsChan <- datapoint{cmdSuccess: err == nil, durationMS: duration.Microseconds(), isConsistent: isConsistent}
+}
+
+func updateCLI(message_limit uint64, tick time.Ticker, c chan os.Signal, datadatapointsChan chan datapoint) (closed bool, totalCommands uint64, totalErrors uint64, totalDiffCommand uint64) {
+	var currentErr uint64 = 0
+	var currentCount uint64 = 0
+	var diffComandCount uint64 = 0
+	start := time.Now()
+	prevTime := time.Now()
+	prevMessageCount := uint64(0)
+	var dp datapoint
+	if checkMode == 0 {
+		fmt.Printf("%26s %25s %7s %25s %7s %25s\n", "Test time", "Total Commands", " ", "Total Errors", " ", "Command Rate")
+	} else {
+		fmt.Printf("%26s %25s %7s %25s %7s %25s %25s\n", "Test time", "Total Commands", " ", "Total Errors", " ", "Total Diff Commands", "Command Rate")
+	}
+	for {
+		select {
+		case dp = <-datadatapointsChan:
+			{
+				if !dp.cmdSuccess {
+					currentErr++
+				}
+				if !dp.isConsistent {
+					diffComandCount++
+				}
+				currentCount++
+			}
+		case <-tick.C:
+			{
+				totalCommands += currentCount
+				totalErrors += currentErr
+				totalDiffCommand += diffComandCount
+				currentErr = 0
+				currentCount = 0
+				diffComandCount = 0
+				now := time.Now()
+				took := now.Sub(prevTime)
+				messageRate := float64(totalCommands-prevMessageCount) / float64(took.Seconds())
+				completionPercent := float64(totalCommands) / float64(message_limit) * 100
+				errorPercent := float64(totalErrors) / float64(totalCommands) * 100
+				if prevMessageCount == 0 && totalCommands != 0 {
+					start = time.Now()
+				}
+
+				prevMessageCount = totalCommands
+				prevTime = now
+				if checkMode == 0 {
+					fmt.Printf("%25.0fs %25d [%3.2f%%] %25d [%3.2f%%] %25.0f\t", time.Since(start).Seconds(), totalCommands, completionPercent, totalErrors, errorPercent, messageRate)
+				} else {
+					fmt.Printf("%25.0fs %25d [%3.2f%%] %25d [%3.2f%%] %25d  %25.0f\t", time.Since(start).Seconds(), totalCommands, completionPercent, totalErrors, errorPercent, totalDiffCommand, messageRate)
+				}
+				fmt.Printf("\n")
+				if messageRate > 0 && totalCommands >= uint64(message_limit) {
+					return true, totalCommands, totalErrors, totalDiffCommand
+				}
+			}
+		case <-c:
+			log.Printf("\nreceived signal to stop\n")
+			return true, totalCommands, totalErrors, totalDiffCommand
+		}
+	}
+}
+
+func compareResults(expectResult, targetResult interface{}) bool {
+	expectStrSlice := convertToStringSlice(expectResult)
+	targetStrSlice := convertToStringSlice(targetResult)
+	sort.Strings(expectStrSlice)
+	sort.Strings(targetStrSlice)
+	return reflect.DeepEqual(expectStrSlice, targetStrSlice)
+}
+
+func convertToStringSlice(result interface{}) []string {
+	var strSlice []string
+	switch v := result.(type) {
+	case []interface{}:
+		for _, item := range v {
+			strSlice = append(strSlice, fmt.Sprintf("%v", item))
+		}
+	case []string:
+		strSlice = v
+	case string:
+		strSlice = append(strSlice, v)
+	default:
+		strSlice = append(strSlice, fmt.Sprintf("%v", v))
+	}
+	return strSlice
+}
+
+func compareXStreamResults(expectResult, targetResult interface{}) bool {
+	expectValues := extractXStreamValues(expectResult)
+	targetValues := extractXStreamValues(targetResult)
+	sort.Strings(expectValues)
+	sort.Strings(targetValues)
+	return reflect.DeepEqual(expectValues, targetValues)
+}
+
+func extractXStreamValues(result interface{}) []string {
+	var values []string
+	switch v := result.(type) {
+	case []interface{}:
+		for _, item := range v {
+			switch item := item.(type) {
+			case []interface{}:
+				if len(item) > 1 {
+					if innerValues, ok := item[1].([]interface{}); ok {
+						for _, innerValue := range innerValues {
+							values = append(values, fmt.Sprintf("%v", innerValue))
+						}
+					}
+				}
+			default:
+				values = append(values, fmt.Sprintf("%v", item))
+			}
+		}
+	case []string:
+		values = v
+	case string:
+		values = append(values, v)
+	default:
+		values = append(values, fmt.Sprintf("%v", v))
+	}
+	return values
+}

--- a/tools/consistency_check_tool/consistencyCheck.sh
+++ b/tools/consistency_check_tool/consistencyCheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -sh 127.0.0.1 -sp 9241 -sh 127.0.0.1 -sp 9251 -r 60 -d 60 -n 1000 -checkMode 2 -log-file SET-12345-check.log SET __key__ __data__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -sh 127.0.0.1 -sp 9241 -sh 127.0.0.1 -sp 9251 -r 59 -d 59 -n 1000 -checkMode 2 -log-file HSET-12345-check.log HSET __key__ __key__ __data__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -sh 127.0.0.1 -sp 9241 -sh 127.0.0.1 -sp 9251 -r 58 -d 58 -n 1000 -checkMode 2 -log-file LPUSH-12345-check.log LPUSH __key__ __key__ __key__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -sh 127.0.0.1 -sp 9241 -sh 127.0.0.1 -sp 9251 -r 57 -d 57 -n 1000 -checkMode 2 -log-file SADD-12345-check.log SADD __key__ __key__ __data__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -sh 127.0.0.1 -sp 9241 -sh 127.0.0.1 -sp 9251 -r 56 -d 56 -n 1000 -checkMode 2 -log-file ZADD-12345-check.log ZADD __key__ 10 __key__ 9 __key__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -sh 127.0.0.1 -sp 9231 -sh 127.0.0.1 -sp 9241 -sh 127.0.0.1 -sp 9251 -r 55 -d 55 -n 1000 -checkMode 2 -log-file XADD-12345-check.log XADD __key__ 1 __key__ __data__ 

--- a/tools/consistency_check_tool/go.mod
+++ b/tools/consistency_check_tool/go.mod
@@ -1,0 +1,10 @@
+module consistency_check_tool
+
+go 1.23.4
+
+require github.com/redis/go-redis/v9 v9.3.0
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)

--- a/tools/consistency_check_tool/write.sh
+++ b/tools/consistency_check_tool/write.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# start write
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 60 -d 60 -n 1000 -log-file SET-12345.log SET __key__ __data__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 59 -d 59 -n 1000 -log-file HSET-12345.log HSET __key__ __key__ __data__ & 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 58 -d 58 -n 1000 -log-file LPUSH-12345.log LPUSH __key__ __key__ __key__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 57 -d 57 -n 1000 -log-file SADD-12345.log SADD __key__ __key__ __data__ &
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 56 -d 56 -n 1000 -log-file ZADD-12345.log ZADD __key__ 10 __key__ 9 __key__ 
+./consistency_check_tool -mh 127.0.0.1 -mp 9221 -r 55 -d 55 -n 1000 -log-file XADD-12345.log XADD __key__ 1 __key__ __data__ 
+
+


### PR DESCRIPTION
使用方法为*先执行写入操作，再执行读取操作*，最后执行一致性检查操作。两次操作的k-v参数必须完全一致，随机种子也必须一致。
使用场景为检测主从同步一致性，以及重启/升级前后数据一致性。
检测原理为先写入数据，从主从节点分别读取数据，最后比较两次读取的数据是否一致。或者比较生成的写数据和读取的数据是否一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive tool to verify data consistency across database nodes with multiple operational modes, including write operations and post-upgrade validations.
	- Enabled concurrent execution for consistency checks with configurable parameters and detailed logging.
  
- **Documentation**
	- Added extensive usage instructions and examples in Chinese to guide users in setting up and running the consistency checks effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->