### PR TITLE
fix: Reduced ReadCache tags for some commands

### DIFF
--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -344,7 +344,6 @@ class CmdRes {
     ret_ = kNone;
   }
   bool CacheMiss() const { return ret_ == kCacheMiss; }
-  bool RetIsKNone() const { return ret_ == kNone; }
   std::string raw_message() const { return message_; }
   std::string message() const {
     std::string result;

--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -344,6 +344,7 @@ class CmdRes {
     ret_ = kNone;
   }
   bool CacheMiss() const { return ret_ == kCacheMiss; }
+  bool RetIsKNone() const { return ret_ == kNone; }
   std::string raw_message() const { return message_; }
   std::string message() const {
     std::string result;

--- a/src/cache/include/cache.h
+++ b/src/cache/include/cache.h
@@ -74,7 +74,7 @@ public:
 
   // Hash Commands
   Status HDel(std::string& key, std::vector<std::string> &fields);
-  Status HSet(std::string& key, std::string &field, std::string &value);
+  Status HSetIfKeyExist(std::string& key, std::string &field, std::string &value);
   Status HSetnx(std::string& key, std::string &field, std::string &value);
   Status HMSet(std::string& key, std::vector<storage::FieldValue> &fvs);
   Status HGet(std::string& key, std::string &field, std::string *value);

--- a/src/cache/src/bit.cc
+++ b/src/cache/src/bit.cc
@@ -15,6 +15,9 @@ Status RedisCache::SetBit(std::string& key, size_t offset, int64_t value) {
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   // createObject is a function in redis, the init ref count of robj is 1
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   DEFER {

--- a/src/cache/src/hash.cc
+++ b/src/cache/src/hash.cc
@@ -31,12 +31,15 @@ Status RedisCache::HDel(std::string& key, std::vector<std::string> &fields) {
   return Status::OK();
 }
 
-Status RedisCache::HSet(std::string& key, std::string &field, std::string &value) {
+Status RedisCache::HSetIfKeyExist(std::string& key, std::string &field, std::string &value) {
   int res = RcFreeMemoryIfNeeded(cache_);
   if (C_OK != res) {
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   robj *fobj = createObject(OBJ_STRING, sdsnewlen(field.data(), field.size()));
   robj *vobj = createObject(OBJ_STRING, sdsnewlen(value.data(), value.size()));
@@ -75,6 +78,9 @@ Status RedisCache::HMSet(std::string& key, std::vector<storage::FieldValue> &fvs
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   unsigned int items_size = fvs.size() * 2;
   robj **items = (robj **)zcallocate(sizeof(robj *) * items_size);

--- a/src/cache/src/hash.cc
+++ b/src/cache/src/hash.cc
@@ -141,7 +141,7 @@ Status RedisCache::HMGet(std::string& key, std::vector<std::string> &fields, std
     if (C_OK == items[i].status) {
       vss->push_back({std::string(items[i].value, sdslen(items[i].value)), rocksdb::Status::OK()});
     } else {
-      vss->push_back({std::string(), rocksdb::Status::NotFound()});
+      return Status::NotFound("field not in cache");
     }
   }
 

--- a/src/cache/src/list.cc
+++ b/src/cache/src/list.cc
@@ -99,6 +99,9 @@ Status RedisCache::LPush(std::string& key, std::vector<std::string> &values) {
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   robj **vals = (robj **)zcallocate(sizeof(robj *) * values.size());
   for (unsigned int i = 0; i < values.size(); ++i) {
@@ -244,7 +247,9 @@ Status RedisCache::RPush(std::string& key, std::vector<std::string> &values) {
   if (C_OK != res) {
     return Status::Corruption("[error] Free memory faild !");
   }
-
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   robj **vals = (robj **)zcallocate(sizeof(robj *) * values.size());
   for (unsigned int i = 0; i < values.size(); ++i) {

--- a/src/cache/src/set.cc
+++ b/src/cache/src/set.cc
@@ -14,6 +14,9 @@ Status RedisCache::SAdd(std::string& key, std::vector<std::string> &members) {
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   robj **vals = (robj **)zcallocate(sizeof(robj *) * members.size());
   for (unsigned int i = 0; i < members.size(); ++i) {

--- a/src/cache/src/string.cc
+++ b/src/cache/src/string.cc
@@ -260,6 +260,9 @@ Status RedisCache::SetRange(std::string& key, int64_t start, std::string &value)
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   uint64_t ret = 0;
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   robj *vobj = createObject(OBJ_STRING, sdsnewlen(value.data(), value.size()));

--- a/src/cache/src/zset.cc
+++ b/src/cache/src/zset.cc
@@ -14,6 +14,9 @@ Status RedisCache::ZAdd(std::string& key, std::vector<storage::ScoreMember> &sco
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   unsigned int items_size = score_members.size() * 2;
   robj **items = (robj **)zcallocate(sizeof(robj *) * items_size);
@@ -73,6 +76,9 @@ Status RedisCache::ZIncrby(std::string& key, std::string& member, double increme
     return Status::Corruption("[error] Free memory faild !");
   }
 
+  if (!Exists(key)) {
+    return Status::NotFound("key not exist");
+  }
   robj *kobj = createObject(OBJ_STRING, sdsnewlen(key.data(), key.size()));
   robj **items = (robj **)zcallocate(sizeof(robj *) * 2);
   items[0] = createStringObjectFromLongDouble(increment, 0);

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -419,10 +419,7 @@ Status PikaCache::GetRange(std::string& key, int64_t start, int64_t end, std::st
 Status PikaCache::SetRangexx(std::string& key, int64_t start, std::string &value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  if (caches_[cache_index]->Exists(key)) {
-    return caches_[cache_index]->SetRange(key, start, value);
-  }
-  return Status::NotFound("key not exist");
+  return caches_[cache_index]->SetRange(key, start, value);
 }
 
 Status PikaCache::Strlen(std::string& key, int32_t *len) {
@@ -443,16 +440,13 @@ Status PikaCache::HDel(std::string& key, std::vector<std::string> &fields) {
 Status PikaCache::HSet(std::string& key, std::string &field, std::string &value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  return caches_[cache_index]->HSet(key, field, value);
+  return caches_[cache_index]->HSetIfKeyExist(key, field, value);
 }
 
 Status PikaCache::HSetIfKeyExist(std::string& key, std::string &field, std::string &value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  if (caches_[cache_index]->Exists(key)) {
-    return caches_[cache_index]->HSet(key, field, value);
-  }
-  return Status::NotFound("key not exist");
+  return caches_[cache_index]->HSetIfKeyExist(key, field, value);
 }
 
 Status PikaCache::HSetIfKeyExistAndFieldNotExist(std::string& key, std::string &field, std::string &value) {
@@ -496,11 +490,7 @@ Status PikaCache::HMSetnxWithoutTTL(std::string& key, std::vector<storage::Field
 Status PikaCache::HMSetxx(std::string& key, std::vector<storage::FieldValue> &fvs) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  if (caches_[cache_index]->Exists(key)) {
-    return caches_[cache_index]->HMSet(key, fvs);
-  } else {
-    return Status::NotFound("key not exist");
-  }
+  return caches_[cache_index]->HMSet(key, fvs);
 }
 
 Status PikaCache::HGet(std::string& key, std::string &field, std::string *value) {
@@ -687,10 +677,7 @@ Status PikaCache::SAdd(std::string& key, std::vector<std::string> &members) {
 Status PikaCache::SAddIfKeyExist(std::string& key, std::vector<std::string> &members) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  if (caches_[cache_index]->Exists(key)) {
-    return caches_[cache_index]->SAdd(key, members);
-  }
-  return Status::NotFound("key not exist");
+  return caches_[cache_index]->SAdd(key, members);
 }
 
 Status PikaCache::SAddnx(std::string& key, std::vector<std::string> &members, int64_t ttl) {
@@ -1566,10 +1553,7 @@ Status PikaCache::SetBit(std::string& key, size_t offset, int64_t value) {
 Status PikaCache::SetBitIfKeyExist(std::string& key, size_t offset, int64_t value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  if (caches_[cache_index]->Exists(key)) {
-    return caches_[cache_index]->SetBit(key, offset, value);
-  }
-  return Status::NotFound("key not exist");
+  return caches_[cache_index]->SetBit(key, offset, value);
 }
 
 Status PikaCache::GetBit(std::string& key, size_t offset, int64_t *value) {

--- a/src/pika_cache_load_thread.cc
+++ b/src/pika_cache_load_thread.cc
@@ -69,6 +69,8 @@ bool PikaCacheLoadThread::LoadKV(std::string& key, const std::shared_ptr<DB>& db
 bool PikaCacheLoadThread::LoadHash(std::string& key, const std::shared_ptr<DB>& db) {
   int32_t len = 0;
   db->storage()->HLen(key, &len);
+  // If the Hash type contains more than 2048 data members, 
+  // it will not be updated to RedisCache
   if (0 >= len || CACHE_VALUE_ITEM_MAX_SIZE < len) {
     return false;
   }
@@ -88,6 +90,8 @@ bool PikaCacheLoadThread::LoadHash(std::string& key, const std::shared_ptr<DB>& 
 bool PikaCacheLoadThread::LoadList(std::string& key, const std::shared_ptr<DB>& db) {
   uint64_t len = 0;
   db->storage()->LLen(key, &len);
+  // If the List type contains more than 2048 data members, 
+  // it will not be updated to RedisCache
   if (len <= 0 || CACHE_VALUE_ITEM_MAX_SIZE < len) {
     LOG(WARNING) << "can not load key, because item size:" << len
                  << " beyond max item size:" << CACHE_VALUE_ITEM_MAX_SIZE;
@@ -109,6 +113,8 @@ bool PikaCacheLoadThread::LoadList(std::string& key, const std::shared_ptr<DB>& 
 bool PikaCacheLoadThread::LoadSet(std::string& key, const std::shared_ptr<DB>& db) {
   int32_t len = 0;
   db->storage()->SCard(key, &len);
+  // If the Set type contains more than 2048 data members, 
+  // it will not be updated to RedisCache
   if (0 >= len || CACHE_VALUE_ITEM_MAX_SIZE < len) {
     LOG(WARNING) << "can not load key, because item size:" << len
                  << " beyond max item size:" << CACHE_VALUE_ITEM_MAX_SIZE;
@@ -142,6 +148,9 @@ bool PikaCacheLoadThread::LoadZset(std::string& key, const std::shared_ptr<DB>& 
   if (cache_len != 0) {
     return true;
   }
+  // Only 512 members will be cached (in the default configuration), 
+  // and the first or last 512 elements will be cached depending on 
+  // whether the zset-cache-start-direction is 0 or 1 
   if (zset_cache_start_direction_ == cache::CACHE_START_FROM_BEGIN) {
     if (zset_cache_field_num_per_key_ <= len) {
       stop_index = zset_cache_field_num_per_key_ - 1;

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -152,7 +152,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameDisableWal, std::move(disablewalptr)));
   std::unique_ptr<Cmd> cacheptr = std::make_unique<CacheCmd>(kCmdNameCache, -2, kCmdFlagsAdmin | kCmdFlagsRead);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameCache, std::move(cacheptr)));
-  std::unique_ptr<Cmd> clearcacheptr = std::make_unique<ClearCacheCmd>(kCmdNameClearCache, 1, kCmdFlagsAdmin | kCmdFlagsWrite);
+  std::unique_ptr<Cmd> clearcacheptr = std::make_unique<ClearCacheCmd>(kCmdNameClearCache, 1, kCmdFlagsAdmin | kCmdFlagsRead);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameClearCache, std::move(clearcacheptr)));
   std::unique_ptr<Cmd> lastsaveptr = std::make_unique<LastsaveCmd>(kCmdNameLastSave, 1, kCmdFlagsAdmin | kCmdFlagsRead | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLastSave, std::move(lastsaveptr)));
@@ -921,7 +921,7 @@ void Cmd::DoCommand(const HintKeys& hint_keys) {
       ReadCache();
     }
     if (is_read()
-        && (res().CacheMiss() || cache_missed_in_rtc_)) {
+        && (res().CacheMiss() || cache_missed_in_rtc_ || res().RetIsKNone())) {
       pstd::lock::MultiScopeRecordLock record_lock(db_->LockMgr(), current_key());
       DoThroughDB();
       if (IsNeedUpdateCache()) {
@@ -932,8 +932,6 @@ void Cmd::DoCommand(const HintKeys& hint_keys) {
       if (IsNeedUpdateCache()) {
         DoUpdateCache();
       }
-    } else {
-      Do();
     }
   } else {
     Do();

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -314,7 +314,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameMsetnx, std::move(msetnxptr)));
   ////GetrangeCmd
   std::unique_ptr<Cmd> getrangeptr = std::make_unique<GetrangeCmd>(
-      kCmdNameGetrange, 4, kCmdFlagsRead |  kCmdFlagsKv | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsReadCache | kCmdFlagsSlow);
+      kCmdNameGetrange, 4, kCmdFlagsRead |  kCmdFlagsKv | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameGetrange, std::move(getrangeptr)));
   ////SetrangeCmd
   std::unique_ptr<Cmd> setrangeptr = std::make_unique<SetrangeCmd>(
@@ -400,7 +400,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHGet, std::move(hgetptr)));
   ////HGetallCmd
   std::unique_ptr<Cmd> hgetallptr =
-      std::make_unique<HGetallCmd>(kCmdNameHGetall, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache);
+      std::make_unique<HGetallCmd>(kCmdNameHGetall, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHGetall, std::move(hgetallptr)));
   ////HExistsCmd
   std::unique_ptr<Cmd> hexistsptr =
@@ -416,11 +416,11 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHIncrbyfloat, std::move(hincrbyfloatptr)));
   ////HKeysCmd
   std::unique_ptr<Cmd> hkeysptr =
-      std::make_unique<HKeysCmd>(kCmdNameHKeys, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsFast);
+      std::make_unique<HKeysCmd>(kCmdNameHKeys, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHKeys, std::move(hkeysptr)));
   ////HLenCmd
   std::unique_ptr<Cmd> hlenptr =
-      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsFast);
+      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHLen, std::move(hlenptr)));
   ////HMgetCmd
   std::unique_ptr<Cmd> hmgetptr =
@@ -436,11 +436,11 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHSetnx, std::move(hsetnxptr)));
   ////HStrlenCmd
   std::unique_ptr<Cmd> hstrlenptr =
-      std::make_unique<HStrlenCmd>(kCmdNameHStrlen, 3, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsFast);
+      std::make_unique<HStrlenCmd>(kCmdNameHStrlen, 3, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHStrlen, std::move(hstrlenptr)));
   ////HValsCmd
   std::unique_ptr<Cmd> hvalsptr =
-      std::make_unique<HValsCmd>(kCmdNameHVals, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache);
+      std::make_unique<HValsCmd>(kCmdNameHVals, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHVals, std::move(hvalsptr)));
   ////HScanCmd
   std::unique_ptr<Cmd> hscanptr = std::make_unique<HScanCmd>(
@@ -461,14 +461,14 @@ void InitCmdTable(CmdTable* cmd_table) {
 
   // List
   std::unique_ptr<Cmd> lindexptr =
-      std::make_unique<LIndexCmd>(kCmdNameLIndex, 3, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<LIndexCmd>(kCmdNameLIndex, 3, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLIndex, std::move(lindexptr)));
   std::unique_ptr<Cmd> linsertptr =
       std::make_unique<LInsertCmd>(kCmdNameLInsert, 5, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLInsert, std::move(linsertptr)));
 
   std::unique_ptr<Cmd> llenptr =
-      std::make_unique<LLenCmd>(kCmdNameLLen, 2, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<LLenCmd>(kCmdNameLLen, 2, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLLen, std::move(llenptr)));
   std::unique_ptr<Cmd> blpopptr = std::make_unique<BLPopCmd>(
       kCmdNameBLPop, -3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsSlow);
@@ -486,7 +486,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLPushx, std::move(lpushxptr)));
 
   std::unique_ptr<Cmd> lrangeptr = std::make_unique<LRangeCmd>(
-      kCmdNameLRange, 4, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      kCmdNameLRange, 4, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLRange, std::move(lrangeptr)));
   std::unique_ptr<Cmd> lremptr =
       std::make_unique<LRemCmd>(kCmdNameLRem, 4, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
@@ -522,7 +522,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZAdd, std::move(zaddptr)));
   ////ZCardCmd
   std::unique_ptr<Cmd> zcardptr =
-      std::make_unique<ZCardCmd>(kCmdNameZCard, 2, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsFast);
+      std::make_unique<ZCardCmd>(kCmdNameZCard, 2, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZCard, std::move(zcardptr)));
   ////ZScanCmd
   std::unique_ptr<Cmd> zscanptr = std::make_unique<ZScanCmd>(
@@ -534,11 +534,11 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZIncrby, std::move(zincrbyptr)));
   ////ZRangeCmd
   std::unique_ptr<Cmd> zrangeptr =
-      std::make_unique<ZRangeCmd>(kCmdNameZRange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<ZRangeCmd>(kCmdNameZRange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRange, std::move(zrangeptr)));
   ////ZRevrangeCmd
   std::unique_ptr<Cmd> zrevrangeptr =
-      std::make_unique<ZRevrangeCmd>(kCmdNameZRevrange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<ZRevrangeCmd>(kCmdNameZRevrange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrange, std::move(zrevrangeptr)));
   ////ZRangebyscoreCmd
   std::unique_ptr<Cmd> zrangebyscoreptr = std::make_unique<ZRangebyscoreCmd>(
@@ -551,7 +551,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrangebyscore, std::move(zrevrangebyscoreptr)));
   ////ZCountCmd
   std::unique_ptr<Cmd> zcountptr =
-      std::make_unique<ZCountCmd>(kCmdNameZCount, 4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<ZCountCmd>(kCmdNameZCount, 4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB |  kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZCount, std::move(zcountptr)));
   ////ZRemCmd
   std::unique_ptr<Cmd> zremptr =
@@ -567,15 +567,15 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZInterstore, std::move(zinterstoreptr)));
   ////ZRankCmd
   std::unique_ptr<Cmd> zrankptr =
-      std::make_unique<ZRankCmd>(kCmdNameZRank, 3, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<ZRankCmd>(kCmdNameZRank, 3, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRank, std::move(zrankptr)));
   ////ZRevrankCmd
   std::unique_ptr<Cmd> zrevrankptr =
-      std::make_unique<ZRevrankCmd>(kCmdNameZRevrank, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<ZRevrankCmd>(kCmdNameZRevrank, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrank, std::move(zrevrankptr)));
   ////ZScoreCmd
   std::unique_ptr<Cmd> zscoreptr =
-      std::make_unique<ZScoreCmd>(kCmdNameZScore, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsFast);
+      std::make_unique<ZScoreCmd>(kCmdNameZScore, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZScore, std::move(zscoreptr)));
   ////ZRangebylexCmd
   std::unique_ptr<Cmd> zrangebylexptr =
@@ -623,11 +623,11 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSPop, std::move(spopptr)));
   ////SCardCmd
   std::unique_ptr<Cmd> scardptr =
-      std::make_unique<SCardCmd>(kCmdNameSCard, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<SCardCmd>(kCmdNameSCard, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSCard, std::move(scardptr)));
   ////SMembersCmd
   std::unique_ptr<Cmd> smembersptr =
-      std::make_unique<SMembersCmd>(kCmdNameSMembers, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<SMembersCmd>(kCmdNameSMembers, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSMembers, std::move(smembersptr)));
   ////SScanCmd
   std::unique_ptr<Cmd> sscanptr =
@@ -655,7 +655,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSInterstore, std::move(sinterstoreptr)));
   ////SIsmemberCmd
   std::unique_ptr<Cmd> sismemberptr =
-      std::make_unique<SIsmemberCmd>(kCmdNameSIsmember, 3, kCmdFlagsRead |  kCmdFlagsSet |kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<SIsmemberCmd>(kCmdNameSIsmember, 3, kCmdFlagsRead |  kCmdFlagsSet |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSIsmember, std::move(sismemberptr)));
   ////SDiffCmd
   std::unique_ptr<Cmd> sdiffptr =
@@ -685,7 +685,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameBitGet, std::move(bitgetptr)));
   ////bitcountCmd
   std::unique_ptr<Cmd> bitcountptr =
-      std::make_unique<BitCountCmd>(kCmdNameBitCount, -2, kCmdFlagsRead | kCmdFlagsBit | kCmdFlagsSlow | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache);
+      std::make_unique<BitCountCmd>(kCmdNameBitCount, -2, kCmdFlagsRead | kCmdFlagsBit | kCmdFlagsSlow | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameBitCount, std::move(bitcountptr)));
   ////bitposCmd
   std::unique_ptr<Cmd> bitposptr =

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -412,11 +412,11 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHIncrby, std::move(hincrbyptr)));
   ////HIncrbyfloatCmd
   std::unique_ptr<Cmd> hincrbyfloatptr =
-      std::make_unique<HIncrbyfloatCmd>(kCmdNameHIncrbyfloat, 4, kCmdFlagsWrite |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsFast);
+      std::make_unique<HIncrbyfloatCmd>(kCmdNameHIncrbyfloat, 4, kCmdFlagsWrite |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHIncrbyfloat, std::move(hincrbyfloatptr)));
   ////HKeysCmd
   std::unique_ptr<Cmd> hkeysptr =
-      std::make_unique<HKeysCmd>(kCmdNameHKeys, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
+      std::make_unique<HKeysCmd>(kCmdNameHKeys, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHKeys, std::move(hkeysptr)));
   ////HLenCmd
   std::unique_ptr<Cmd> hlenptr =
@@ -551,7 +551,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrangebyscore, std::move(zrevrangebyscoreptr)));
   ////ZCountCmd
   std::unique_ptr<Cmd> zcountptr =
-      std::make_unique<ZCountCmd>(kCmdNameZCount, 4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB |  kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
+      std::make_unique<ZCountCmd>(kCmdNameZCount, 4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZCount, std::move(zcountptr)));
   ////ZRemCmd
   std::unique_ptr<Cmd> zremptr =

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -313,6 +313,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       kCmdNameMsetnx, -3, kCmdFlagsWrite | kCmdFlagsKv | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameMsetnx, std::move(msetnxptr)));
   ////GetrangeCmd
+  //To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> getrangeptr = std::make_unique<GetrangeCmd>(
       kCmdNameGetrange, 4, kCmdFlagsRead |  kCmdFlagsKv | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameGetrange, std::move(getrangeptr)));
@@ -399,6 +400,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<HGetCmd>(kCmdNameHGet, -3, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache |kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHGet, std::move(hgetptr)));
   ////HGetallCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hgetallptr =
       std::make_unique<HGetallCmd>(kCmdNameHGetall, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHGetall, std::move(hgetallptr)));
@@ -415,10 +417,12 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<HIncrbyfloatCmd>(kCmdNameHIncrbyfloat, 4, kCmdFlagsWrite |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHIncrbyfloat, std::move(hincrbyfloatptr)));
   ////HKeysCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hkeysptr =
       std::make_unique<HKeysCmd>(kCmdNameHKeys, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHKeys, std::move(hkeysptr)));
   ////HLenCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hlenptr =
       std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHLen, std::move(hlenptr)));
@@ -435,10 +439,12 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<HSetnxCmd>(kCmdNameHSetnx, 4, kCmdFlagsWrite |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHSetnx, std::move(hsetnxptr)));
   ////HStrlenCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hstrlenptr =
       std::make_unique<HStrlenCmd>(kCmdNameHStrlen, 3, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHStrlen, std::move(hstrlenptr)));
   ////HValsCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hvalsptr =
       std::make_unique<HValsCmd>(kCmdNameHVals, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHVals, std::move(hvalsptr)));
@@ -460,6 +466,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNamePKHRScanRange, std::move(pkhrscanrangeptr)));
 
   // List
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> lindexptr =
       std::make_unique<LIndexCmd>(kCmdNameLIndex, 3, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLIndex, std::move(lindexptr)));
@@ -467,6 +474,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<LInsertCmd>(kCmdNameLInsert, 5, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLInsert, std::move(linsertptr)));
 
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> llenptr =
       std::make_unique<LLenCmd>(kCmdNameLLen, 2, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLLen, std::move(llenptr)));
@@ -485,6 +493,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   std::unique_ptr<Cmd> lpushxptr = std::make_unique<LPushxCmd>(kCmdNameLPushx, -3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLPushx, std::move(lpushxptr)));
 
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> lrangeptr = std::make_unique<LRangeCmd>(
       kCmdNameLRange, 4, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLRange, std::move(lrangeptr)));
@@ -521,6 +530,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<ZAddCmd>(kCmdNameZAdd, -4, kCmdFlagsWrite |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZAdd, std::move(zaddptr)));
   ////ZCardCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zcardptr =
       std::make_unique<ZCardCmd>(kCmdNameZCard, 2, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZCard, std::move(zcardptr)));
@@ -533,10 +543,12 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<ZIncrbyCmd>(kCmdNameZIncrby, 4, kCmdFlagsWrite |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast) ;
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZIncrby, std::move(zincrbyptr)));
   ////ZRangeCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrangeptr =
       std::make_unique<ZRangeCmd>(kCmdNameZRange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRange, std::move(zrangeptr)));
   ////ZRevrangeCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrevrangeptr =
       std::make_unique<ZRevrangeCmd>(kCmdNameZRevrange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrange, std::move(zrevrangeptr)));
@@ -550,6 +562,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(
       std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrangebyscore, std::move(zrevrangebyscoreptr)));
   ////ZCountCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zcountptr =
       std::make_unique<ZCountCmd>(kCmdNameZCount, 4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB |  kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZCount, std::move(zcountptr)));
@@ -566,14 +579,17 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<ZInterstoreCmd>(kCmdNameZInterstore, -4, kCmdFlagsWrite | kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZInterstore, std::move(zinterstoreptr)));
   ////ZRankCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrankptr =
       std::make_unique<ZRankCmd>(kCmdNameZRank, 3, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRank, std::move(zrankptr)));
   ////ZRevrankCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrevrankptr =
       std::make_unique<ZRevrankCmd>(kCmdNameZRevrank, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrank, std::move(zrevrankptr)));
   ////ZScoreCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zscoreptr =
       std::make_unique<ZScoreCmd>(kCmdNameZScore, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZScore, std::move(zscoreptr)));
@@ -622,10 +638,12 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<SPopCmd>(kCmdNameSPop, -2, kCmdFlagsWrite |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSPop, std::move(spopptr)));
   ////SCardCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> scardptr =
       std::make_unique<SCardCmd>(kCmdNameSCard, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSCard, std::move(scardptr)));
   ////SMembersCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> smembersptr =
       std::make_unique<SMembersCmd>(kCmdNameSMembers, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSMembers, std::move(smembersptr)));
@@ -654,6 +672,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<SInterstoreCmd>(kCmdNameSInterstore, -3, kCmdFlagsWrite | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSInterstore, std::move(sinterstoreptr)));
   ////SIsmemberCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> sismemberptr =
       std::make_unique<SIsmemberCmd>(kCmdNameSIsmember, 3, kCmdFlagsRead |  kCmdFlagsSet |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSIsmember, std::move(sismemberptr)));
@@ -670,8 +689,9 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<SMoveCmd>(kCmdNameSMove, 4, kCmdFlagsWrite | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSMove, std::move(smoveptr)));
   ////SRandmemberCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> srandmemberptr =
-      std::make_unique<SRandmemberCmd>(kCmdNameSRandmember, -2, kCmdFlagsRead | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<SRandmemberCmd>(kCmdNameSRandmember, -2, kCmdFlagsRead | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSRandmember, std::move(srandmemberptr)));
 
   // BitMap
@@ -684,6 +704,7 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<BitGetCmd>(kCmdNameBitGet, 3, kCmdFlagsRead | kCmdFlagsBit | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameBitGet, std::move(bitgetptr)));
   ////bitcountCmd
+  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> bitcountptr =
       std::make_unique<BitCountCmd>(kCmdNameBitCount, -2, kCmdFlagsRead | kCmdFlagsBit | kCmdFlagsSlow | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameBitCount, std::move(bitcountptr)));
@@ -911,6 +932,8 @@ void Cmd::DoCommand(const HintKeys& hint_keys) {
       if (IsNeedUpdateCache()) {
         DoUpdateCache();
       }
+    } else {
+      Do();
     }
   } else {
     Do();

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -313,9 +313,8 @@ void InitCmdTable(CmdTable* cmd_table) {
       kCmdNameMsetnx, -3, kCmdFlagsWrite | kCmdFlagsKv | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameMsetnx, std::move(msetnxptr)));
   ////GetrangeCmd
-  //To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> getrangeptr = std::make_unique<GetrangeCmd>(
-      kCmdNameGetrange, 4, kCmdFlagsRead |  kCmdFlagsKv | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      kCmdNameGetrange, 4, kCmdFlagsRead |  kCmdFlagsKv | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsReadCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameGetrange, std::move(getrangeptr)));
   ////SetrangeCmd
   std::unique_ptr<Cmd> setrangeptr = std::make_unique<SetrangeCmd>(
@@ -400,9 +399,8 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<HGetCmd>(kCmdNameHGet, -3, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache |kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHGet, std::move(hgetptr)));
   ////HGetallCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hgetallptr =
-      std::make_unique<HGetallCmd>(kCmdNameHGetall, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB);
+      std::make_unique<HGetallCmd>(kCmdNameHGetall, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHGetall, std::move(hgetallptr)));
   ////HExistsCmd
   std::unique_ptr<Cmd> hexistsptr =
@@ -414,17 +412,15 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHIncrby, std::move(hincrbyptr)));
   ////HIncrbyfloatCmd
   std::unique_ptr<Cmd> hincrbyfloatptr =
-      std::make_unique<HIncrbyfloatCmd>(kCmdNameHIncrbyfloat, 4, kCmdFlagsWrite |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
+      std::make_unique<HIncrbyfloatCmd>(kCmdNameHIncrbyfloat, 4, kCmdFlagsWrite |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHIncrbyfloat, std::move(hincrbyfloatptr)));
   ////HKeysCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hkeysptr =
       std::make_unique<HKeysCmd>(kCmdNameHKeys, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHKeys, std::move(hkeysptr)));
   ////HLenCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hlenptr =
-      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
+      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHLen, std::move(hlenptr)));
   ////HMgetCmd
   std::unique_ptr<Cmd> hmgetptr =
@@ -439,14 +435,12 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<HSetnxCmd>(kCmdNameHSetnx, 4, kCmdFlagsWrite |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHSetnx, std::move(hsetnxptr)));
   ////HStrlenCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hstrlenptr =
-      std::make_unique<HStrlenCmd>(kCmdNameHStrlen, 3, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast);
+      std::make_unique<HStrlenCmd>(kCmdNameHStrlen, 3, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHStrlen, std::move(hstrlenptr)));
   ////HValsCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> hvalsptr =
-      std::make_unique<HValsCmd>(kCmdNameHVals, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB);
+      std::make_unique<HValsCmd>(kCmdNameHVals, 2, kCmdFlagsRead | kCmdFlagsHash | kCmdFlagsSlow | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHVals, std::move(hvalsptr)));
   ////HScanCmd
   std::unique_ptr<Cmd> hscanptr = std::make_unique<HScanCmd>(
@@ -466,17 +460,15 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNamePKHRScanRange, std::move(pkhrscanrangeptr)));
 
   // List
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> lindexptr =
-      std::make_unique<LIndexCmd>(kCmdNameLIndex, 3, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<LIndexCmd>(kCmdNameLIndex, 3, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLIndex, std::move(lindexptr)));
   std::unique_ptr<Cmd> linsertptr =
       std::make_unique<LInsertCmd>(kCmdNameLInsert, 5, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLInsert, std::move(linsertptr)));
 
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> llenptr =
-      std::make_unique<LLenCmd>(kCmdNameLLen, 2, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<LLenCmd>(kCmdNameLLen, 2, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLLen, std::move(llenptr)));
   std::unique_ptr<Cmd> blpopptr = std::make_unique<BLPopCmd>(
       kCmdNameBLPop, -3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsSlow);
@@ -493,9 +485,8 @@ void InitCmdTable(CmdTable* cmd_table) {
   std::unique_ptr<Cmd> lpushxptr = std::make_unique<LPushxCmd>(kCmdNameLPushx, -3, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLPushx, std::move(lpushxptr)));
 
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> lrangeptr = std::make_unique<LRangeCmd>(
-      kCmdNameLRange, 4, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      kCmdNameLRange, 4, kCmdFlagsRead |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameLRange, std::move(lrangeptr)));
   std::unique_ptr<Cmd> lremptr =
       std::make_unique<LRemCmd>(kCmdNameLRem, 4, kCmdFlagsWrite |  kCmdFlagsList | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
@@ -530,9 +521,8 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<ZAddCmd>(kCmdNameZAdd, -4, kCmdFlagsWrite |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZAdd, std::move(zaddptr)));
   ////ZCardCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zcardptr =
-      std::make_unique<ZCardCmd>(kCmdNameZCard, 2, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsFast);
+      std::make_unique<ZCardCmd>(kCmdNameZCard, 2, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZCard, std::move(zcardptr)));
   ////ZScanCmd
   std::unique_ptr<Cmd> zscanptr = std::make_unique<ZScanCmd>(
@@ -543,14 +533,12 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<ZIncrbyCmd>(kCmdNameZIncrby, 4, kCmdFlagsWrite |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast) ;
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZIncrby, std::move(zincrbyptr)));
   ////ZRangeCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrangeptr =
-      std::make_unique<ZRangeCmd>(kCmdNameZRange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<ZRangeCmd>(kCmdNameZRange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRange, std::move(zrangeptr)));
   ////ZRevrangeCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrevrangeptr =
-      std::make_unique<ZRevrangeCmd>(kCmdNameZRevrange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<ZRevrangeCmd>(kCmdNameZRevrange, -4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrange, std::move(zrevrangeptr)));
   ////ZRangebyscoreCmd
   std::unique_ptr<Cmd> zrangebyscoreptr = std::make_unique<ZRangebyscoreCmd>(
@@ -562,9 +550,8 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(
       std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrangebyscore, std::move(zrevrangebyscoreptr)));
   ////ZCountCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zcountptr =
-      std::make_unique<ZCountCmd>(kCmdNameZCount, 4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB |  kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<ZCountCmd>(kCmdNameZCount, 4, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB |  kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZCount, std::move(zcountptr)));
   ////ZRemCmd
   std::unique_ptr<Cmd> zremptr =
@@ -579,19 +566,16 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<ZInterstoreCmd>(kCmdNameZInterstore, -4, kCmdFlagsWrite | kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZInterstore, std::move(zinterstoreptr)));
   ////ZRankCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrankptr =
-      std::make_unique<ZRankCmd>(kCmdNameZRank, 3, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<ZRankCmd>(kCmdNameZRank, 3, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRank, std::move(zrankptr)));
   ////ZRevrankCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zrevrankptr =
-      std::make_unique<ZRevrankCmd>(kCmdNameZRevrank, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<ZRevrankCmd>(kCmdNameZRevrank, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrank, std::move(zrevrankptr)));
   ////ZScoreCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> zscoreptr =
-      std::make_unique<ZScoreCmd>(kCmdNameZScore, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsFast);
+      std::make_unique<ZScoreCmd>(kCmdNameZScore, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZScore, std::move(zscoreptr)));
   ////ZRangebylexCmd
   std::unique_ptr<Cmd> zrangebylexptr =
@@ -638,14 +622,12 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<SPopCmd>(kCmdNameSPop, -2, kCmdFlagsWrite |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSPop, std::move(spopptr)));
   ////SCardCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> scardptr =
-      std::make_unique<SCardCmd>(kCmdNameSCard, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<SCardCmd>(kCmdNameSCard, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSCard, std::move(scardptr)));
   ////SMembersCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> smembersptr =
-      std::make_unique<SMembersCmd>(kCmdNameSMembers, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<SMembersCmd>(kCmdNameSMembers, 2, kCmdFlagsRead |  kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow | kCmdFlagsReadCache );
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSMembers, std::move(smembersptr)));
   ////SScanCmd
   std::unique_ptr<Cmd> sscanptr =
@@ -672,9 +654,8 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<SInterstoreCmd>(kCmdNameSInterstore, -3, kCmdFlagsWrite | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSInterstore, std::move(sinterstoreptr)));
   ////SIsmemberCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> sismemberptr =
-      std::make_unique<SIsmemberCmd>(kCmdNameSIsmember, 3, kCmdFlagsRead |  kCmdFlagsSet |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
+      std::make_unique<SIsmemberCmd>(kCmdNameSIsmember, 3, kCmdFlagsRead |  kCmdFlagsSet |kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSIsmember, std::move(sismemberptr)));
   ////SDiffCmd
   std::unique_ptr<Cmd> sdiffptr =
@@ -689,9 +670,8 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<SMoveCmd>(kCmdNameSMove, 4, kCmdFlagsWrite | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsFast);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSMove, std::move(smoveptr)));
   ////SRandmemberCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> srandmemberptr =
-      std::make_unique<SRandmemberCmd>(kCmdNameSRandmember, -2, kCmdFlagsRead | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow);
+      std::make_unique<SRandmemberCmd>(kCmdNameSRandmember, -2, kCmdFlagsRead | kCmdFlagsSet | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsSlow | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameSRandmember, std::move(srandmemberptr)));
 
   // BitMap
@@ -704,9 +684,8 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<BitGetCmd>(kCmdNameBitGet, 3, kCmdFlagsRead | kCmdFlagsBit | kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameBitGet, std::move(bitgetptr)));
   ////bitcountCmd
-  // To ensure data consistency between cache and database, disable the Redis-cache reading function of the command temporarily
   std::unique_ptr<Cmd> bitcountptr =
-      std::make_unique<BitCountCmd>(kCmdNameBitCount, -2, kCmdFlagsRead | kCmdFlagsBit | kCmdFlagsSlow | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache);
+      std::make_unique<BitCountCmd>(kCmdNameBitCount, -2, kCmdFlagsRead | kCmdFlagsBit | kCmdFlagsSlow | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameBitCount, std::move(bitcountptr)));
   ////bitposCmd
   std::unique_ptr<Cmd> bitposptr =
@@ -921,7 +900,7 @@ void Cmd::DoCommand(const HintKeys& hint_keys) {
       ReadCache();
     }
     if (is_read()
-        && (res().CacheMiss() || cache_missed_in_rtc_ || res().RetIsKNone())) {
+        && (res().CacheMiss() || cache_missed_in_rtc_)) {
       pstd::lock::MultiScopeRecordLock record_lock(db_->LockMgr(), current_key());
       DoThroughDB();
       if (IsNeedUpdateCache()) {

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -618,7 +618,7 @@ int PikaConf::Load() {
 
   int64_t cache_maxmemory = PIKA_CACHE_SIZE_DEFAULT;
   GetConfInt64("cache-maxmemory", &cache_maxmemory);
-  cache_maxmemory_ = (PIKA_CACHE_SIZE_MIN > cache_maxmemory) ? PIKA_CACHE_SIZE_DEFAULT : cache_maxmemory;
+  cache_maxmemory_ = (PIKA_CACHE_SIZE_MIN > cache_maxmemory) ? PIKA_CACHE_SIZE_MIN : cache_maxmemory;
 
   int cache_maxmemory_policy = 1;
   GetConfInt("cache-maxmemory-policy", &cache_maxmemory_policy);

--- a/src/pika_hash.cc
+++ b/src/pika_hash.cc
@@ -627,7 +627,7 @@ void HSetnxCmd::DoThroughDB() {
 void HSetnxCmd::DoUpdateCache() {
   if (s_.ok()) {
     std::string CachePrefixKeyH = PCacheKeyPrefixH + key_;
-    db_->cache()->HSetIfKeyExistAndFieldNotExist(CachePrefixKeyH, field_, value_);
+    db_->cache()->HSetIfKeyExist(CachePrefixKeyH, field_, value_);
   }
 }
 


### PR DESCRIPTION
fix: #3030
1. 将 clearcache 改为读命令
2. 修复部分接口因为数据不一致导致的问题
3. 修改配置文件中对 redis-cache 限制阈值错误的问题