### PR TITLE
fix: fix replication on pika node recovering

### DIFF
--- a/codis/pkg/topom/topom_group.go
+++ b/codis/pkg/topom/topom_group.go
@@ -381,14 +381,11 @@ func (s *Topom) tryFixReplicationRelationship(group *models.Group, groupServer *
 			}
 		}
 	} else {
-		// skip if it has right replication relationship
-		if state.Replication.GetMasterAddr() == curMasterAddr {
-			return nil
-		}
-
-		// current server is slave, execute the command `slaveof [new master ip] [new master port]`
-		if err = updateMasterToNewOne(groupServer.Addr, curMasterAddr, s.config.ProductAuth); err != nil {
-			return err
+		if state.Replication.GetMasterAddr() != curMasterAddr {
+			// current server is slave, execute the command `slaveof [new master ip] [new master port]`
+			if err = updateMasterToNewOne(groupServer.Addr, curMasterAddr, s.config.ProductAuth); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/codis/pkg/topom/topom_sentinel.go
+++ b/codis/pkg/topom/topom_sentinel.go
@@ -48,7 +48,7 @@ func (s *Topom) CheckStateAndSwitchSlavesAndMasters(filter func(index int, g *mo
 
 	if len(recoveredGroupServersState) > 0 {
 		// offline GroupServer's service has recovered, check and fix it's master-slave replication relationship
-		s.tryFixReplicationRelationships(ctx, recoveredGroupServersState, len(masterOfflineGroups))
+		s.tryFixReplicationRelationships(ctx, recoveredGroupServersState)
 	}
 
 	return nil

--- a/codis/pkg/topom/topom_sentinel.go
+++ b/codis/pkg/topom/topom_sentinel.go
@@ -85,6 +85,18 @@ func (s *Topom) checkAndUpdateGroupServerState(conf *Config, group *models.Group
 			*recoveredGroupServers = append(*recoveredGroupServers, state)
 			// update GroupServer to GroupServerStateNormal state later
 		} else {
+			// This may contains any of following condition:
+			// 1. groupServer.State is Normal
+			// 2. groupServer.State is GroupServerStateSubjectiveOffline and is Master
+			// 3. groupServer.State is GroupServerStateSubjectiveOffline and is Slave
+			// for condition 3, if current server's previous state is SubjectiveOffline
+			// and has been added to slaveofflinegroups before,
+			// should also resync mappings to proxy to enable replicationgroup
+			if groupServer.State == models.GroupServerStateSubjectiveOffline &&
+				!isGroupMaster(state, group) &&
+				group.OutOfSync {
+				*recoveredGroupServers = append(*recoveredGroupServers, state)
+			}
 			// Update the offset information of the state and role nodes
 			groupServer.State = models.GroupServerStateNormal
 			groupServer.ReCallTimes = 0

--- a/codis/pkg/utils/redis/client.go
+++ b/codis/pkg/utils/redis/client.go
@@ -341,7 +341,7 @@ func (c *Client) SetMaster(master string, force bool) error {
 		}
 
 		if force {
-			if _, err := c.Do("SLAVEOF", host, port, "-f"); err != nil {
+			if _, err := c.Do("SLAVEOF", host, port, "force"); err != nil {
 				return err
 			}
 		} else {

--- a/codis/pkg/utils/redis/sentinel.go
+++ b/codis/pkg/utils/redis/sentinel.go
@@ -106,8 +106,8 @@ func (i *InfoReplication) UnmarshalJSON(b []byte) error {
 	}
 
 	i.Role = kvmap["role"]
-	i.MasterPort = kvmap["master_host"]
-	i.MasterHost = kvmap["master_port"]
+	i.MasterPort = kvmap["master_port"]
+	i.MasterHost = kvmap["master_host"]
 	i.MasterLinkStatus = kvmap["master_link_status"]
 	i.IsEligibleForMasterElection = kvmap["is_eligible_for_master_election"] == "true"
 


### PR DESCRIPTION
1. 修复pika slave节点恢复之后，dashboard没有更新元信息的问题。
2. 修复info replication master ip:port 解析失败的问题。