### PR TITLE
feat: Add p99 and slow command count

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,24 @@ ExternalProject_Add(rocksdb
   make -j${CPU_CORE}
 )
 
+ExternalProject_Add(prometheus_cpp
+  URL
+  https://github.com/jupp0r/prometheus-cpp/releases/download/v1.2.4/prometheus-cpp-with-submodules.tar.gz
+  CMAKE_ARGS
+  -DBUILD_SHARED_LIBS=OFF
+  -DENABLE_PUSH=OFF
+  -DENABLE_COMPRESSION=OFF
+  -DCMAKE_INSTALL_LIBDIR=${INSTALL_LIBDIR}
+  -DCMAKE_INSTALL_INCLUDEDIR=${INSTALL_INCLUDEDIR}
+  BUILD_ALWAYS
+  1
+  BUILD_COMMAND
+  make -j${CPU_CORE}
+)
+
+set(PROMETHEUS_CPP_CORE_LIB ${INSTALL_LIBDIR}/libprometheus-cpp-core.a)
+set(PROMETHEUS_CPP_PULL_LIB ${INSTALL_LIBDIR}/libprometheus-cpp-pull.a)
+
 ExternalProject_Add(rediscache
   URL
   https://github.com/pikiwidb/rediscache/archive/refs/tags/v1.0.7.tar.gz
@@ -822,6 +840,8 @@ target_link_libraries(${PROJECT_NAME}
   ${LIB_PROTOBUF}
   ${LIB_GFLAGS}
   ${LIB_FMT}
+  ${PROMETHEUS_CPP_PULL_LIB}
+  ${PROMETHEUS_CPP_CORE_LIB}
   libsnappy.a
   libzstd.a
   liblz4.a

--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -267,6 +267,8 @@ class InfoCmd : public Cmd {
     kInfoAll,
     kInfoDebug,
     kInfoCommandStats,
+    kInfoSlowCommand,
+    kInfoCommandP99,
     kInfoCache
   };
   InfoCmd(const std::string& name, int arity, uint32_t flag) : Cmd(name, arity, flag) {}
@@ -294,6 +296,8 @@ class InfoCmd : public Cmd {
   const static std::string kRocksDBSection;
   const static std::string kDebugSection;
   const static std::string kCommandStatsSection;
+  const static std::string kCommandP99Section;
+  const static std::string kSlowCommandSection;
   const static std::string kCacheSection;
 
   void DoInitial() override;
@@ -314,6 +318,8 @@ class InfoCmd : public Cmd {
   void InfoRocksDB(std::string& info);
   void InfoDebug(std::string& info);
   void InfoCommandStats(std::string& info);
+  void InfoCommandP99(std::string& info);
+  void InfoSlowCommand(std::string& info);
   void InfoCache(std::string& info, std::shared_ptr<DB> db);
 
   std::string CacheStatusToString(int status);

--- a/include/pika_client_conn.h
+++ b/include/pika_client_conn.h
@@ -130,7 +130,7 @@ class PikaClientConn : public net::RedisConn {
   std::shared_ptr<Cmd> DoCmd(const PikaCmdArgsType& argv, const std::string& opt,
                              const std::shared_ptr<std::string>& resp_ptr, bool cache_miss_in_rtc);
 
-  void ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, std::string opt);
+  void ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, const std::string& opt);
   void ProcessMonitor(const PikaCmdArgsType& argv);
 
   void ExecRedisCmd(const PikaCmdArgsType& argv, std::shared_ptr<std::string>& resp_ptr, bool cache_miss_in_rtc);

--- a/include/pika_client_conn.h
+++ b/include/pika_client_conn.h
@@ -130,7 +130,7 @@ class PikaClientConn : public net::RedisConn {
   std::shared_ptr<Cmd> DoCmd(const PikaCmdArgsType& argv, const std::string& opt,
                              const std::shared_ptr<std::string>& resp_ptr, bool cache_miss_in_rtc);
 
-  void ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr);
+  void ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, std::string opt);
   void ProcessMonitor(const PikaCmdArgsType& argv);
 
   void ExecRedisCmd(const PikaCmdArgsType& argv, std::shared_ptr<std::string>& resp_ptr, bool cache_miss_in_rtc);

--- a/include/pika_cmd_table_manager.h
+++ b/include/pika_cmd_table_manager.h
@@ -49,7 +49,8 @@ class PikaCmdTableManager {
   * Info Commandstats used
   */
   std::unordered_map<std::string, CommandStatistics>* GetCommandStatMap();
-  std::unordered_map<std::string, CommandStatistics>* GetSlowCommandCount();
+  std::unordered_map<std::string, CommandStatistics> GetSlowCommandCount();
+  void UpdateSlowCommandCount(const std::string& opt);
   void ResetCommandCount();
   prometheus::Histogram& GetHistogram(const std::string& opt);
   prometheus::Family<prometheus::Histogram>* GetHistograms();
@@ -74,7 +75,8 @@ class PikaCmdTableManager {
   std::unordered_map<std::string, CommandStatistics> slow_command_count_;
   std::thread reset_thread_;
   std::mutex command_mutex_;
-  std::shared_mutex histograms_mutex_; 
+  std::shared_mutex histograms_mutex_;
+  std::shared_mutex slow_command_mutex_;
   std::shared_ptr<prometheus::Registry> prometheus_registry_;
   prometheus::Family<prometheus::Histogram>* histogram_family_;
   std::unordered_map<std::string, prometheus::Histogram*> histograms_;

--- a/include/pika_cmd_table_manager.h
+++ b/include/pika_cmd_table_manager.h
@@ -8,10 +8,16 @@
 
 #include <shared_mutex>
 #include <thread>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+#include <prometheus/counter.h>
+#include <prometheus/histogram.h>
 
 #include "include/acl.h"
 #include "include/pika_command.h"
 #include "include/pika_data_distribution.h"
+
+using namespace prometheus;
 
 struct CommandStatistics {
   CommandStatistics() = default;
@@ -42,6 +48,10 @@ class PikaCmdTableManager {
   * Info Commandstats used
   */
   std::unordered_map<std::string, CommandStatistics>* GetCommandStatMap();
+  std::unordered_map<std::string, CommandStatistics>* GetSlowCommandCount();
+  void ResetSlowCommandCount();
+  prometheus::Histogram& GetHistogram(const std::string& opt);
+  prometheus::Family<prometheus::Histogram>& GetHistograms();
 
  private:
   std::shared_ptr<Cmd> NewCommand(const std::string& opt);
@@ -60,5 +70,12 @@ class PikaCmdTableManager {
   * Info Commandstats used
   */
   std::unordered_map<std::string, CommandStatistics> cmdstat_map_;
+  std::unordered_map<std::string, CommandStatistics> slow_command_count_;
+  std::thread reset_thread_;
+  std::mutex slow_command_mutex_;
+  std::mutex histograms_mutex_;
+  prometheus::Registry prometheus_registry_;
+  prometheus::Family<prometheus::Histogram>& histogram_family_;
+  std::unordered_map<std::string, prometheus::Histogram*> histograms_;
 };
 #endif

--- a/include/pika_cmd_table_manager.h
+++ b/include/pika_cmd_table_manager.h
@@ -36,6 +36,7 @@ class PikaCmdTableManager {
   PikaCmdTableManager();
   virtual ~PikaCmdTableManager() = default;
   void InitCmdTable(void);
+  void InitHistograms();
   void RenameCommand(const std::string before, const std::string after);
   std::shared_ptr<Cmd> GetCmd(const std::string& opt);
   bool CmdExist(const std::string& cmd) const;
@@ -49,9 +50,9 @@ class PikaCmdTableManager {
   */
   std::unordered_map<std::string, CommandStatistics>* GetCommandStatMap();
   std::unordered_map<std::string, CommandStatistics>* GetSlowCommandCount();
-  void ResetSlowCommandCount();
+  void ResetCommandCount();
   prometheus::Histogram& GetHistogram(const std::string& opt);
-  prometheus::Family<prometheus::Histogram>& GetHistograms();
+  prometheus::Family<prometheus::Histogram>* GetHistograms();
 
  private:
   std::shared_ptr<Cmd> NewCommand(const std::string& opt);
@@ -72,10 +73,10 @@ class PikaCmdTableManager {
   std::unordered_map<std::string, CommandStatistics> cmdstat_map_;
   std::unordered_map<std::string, CommandStatistics> slow_command_count_;
   std::thread reset_thread_;
-  std::mutex slow_command_mutex_;
-  std::mutex histograms_mutex_;
-  prometheus::Registry prometheus_registry_;
-  prometheus::Family<prometheus::Histogram>& histogram_family_;
+  std::mutex command_mutex_;
+  std::shared_mutex histograms_mutex_; 
+  std::shared_ptr<prometheus::Registry> prometheus_registry_;
+  prometheus::Family<prometheus::Histogram>* histogram_family_;
   std::unordered_map<std::string, prometheus::Histogram*> histograms_;
 };
 #endif

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -882,6 +882,8 @@ const std::string InfoCmd::kKeyspaceSection = "keyspace";
 const std::string InfoCmd::kDataSection = "data";
 const std::string InfoCmd::kRocksDBSection = "rocksdb";
 const std::string InfoCmd::kDebugSection = "debug";
+const std::string InfoCmd::kCommandP99Section = "commandp99";
+const std::string InfoCmd::kSlowCommandSection = "slowcommand";
 const std::string InfoCmd::kCommandStatsSection = "commandstats";
 const std::string InfoCmd::kCacheSection = "cache";
 
@@ -967,6 +969,10 @@ void InfoCmd::DoInitial() {
     info_section_ = kInfoDebug;
   } else if (strcasecmp(argv_[1].data(), kCommandStatsSection.data()) == 0) {
     info_section_ = kInfoCommandStats;
+  } else if (strcasecmp(argv_[1].data(), kCommandP99Section.data()) == 0) {
+    info_section_ = kInfoCommandP99;
+  } else if (strcasecmp(argv_[1].data(), kSlowCommandSection.data()) == 0) {
+    info_section_ = kInfoSlowCommand; 
   } else if (strcasecmp(argv_[1].data(), kCacheSection.data()) == 0) {
     info_section_ = kInfoCache;
   } else {
@@ -1007,6 +1013,10 @@ void InfoCmd::Do() {
       InfoExecCount(info);
       info.append("\r\n");
       InfoCommandStats(info);
+      info.append("\r\n");
+      InfoCommandP99(info);
+      info.append("\r\n");
+      InfoSlowCommand(info);
       info.append("\r\n");
       InfoCache(info, db_);
       info.append("\r\n");
@@ -1051,6 +1061,12 @@ void InfoCmd::Do() {
     case kInfoCommandStats:
       InfoCommandStats(info);
       break;
+    case kInfoCommandP99:
+      InfoCommandP99(info);
+      break;
+    case kInfoSlowCommand:
+      InfoSlowCommand(info);
+      break;      
     case kInfoCache:
       InfoCache(info, db_);
       break;
@@ -1480,6 +1496,78 @@ void InfoCmd::InfoDebug(std::string& info) {
   info.append(tmp_stream.str());
   g_pika_server->ServerStatus(&info);
 }
+
+void InfoCmd::InfoCommandP99(std::string& info) {
+  std::stringstream tmp_stream;
+  tmp_stream.precision(2);
+  tmp_stream.setf(std::ios::fixed);
+  tmp_stream << "# Commands P99" << "\r\n";
+  auto& histogram_family = g_pika_cmd_table_manager->GetHistograms(); 
+
+  for (const auto& metric_family : histogram_family.Collect()) {
+    for (const auto& metric : metric_family.metric) {
+      std::string command_name;
+  
+      for (const auto& label : metric.label) {
+        if (label.name == "command") {
+          command_name = label.value;
+          break;
+        }
+      }
+  
+      double total_count = metric.histogram.sample_count;
+      double total_time = metric.histogram.sample_sum;
+  
+      if (command_name.empty()) {
+        tmp_stream << "Command: UNKNOWN\r\n";
+      } else {
+        tmp_stream << "Command: " << command_name << "\r\n";
+      }
+  
+      tmp_stream << "Total calls: " << total_count << ", Total usec: " << total_time << "\r\n";
+  
+      if (total_count < 10) { 
+        tmp_stream << "TP99: Not enough data\r\n";
+        continue;
+      }
+      double tp99_threshold = total_count * 0.99;
+      double cumulative_count = 0;
+      double tp99 = 0;
+  
+      for (const auto& bucket : metric.histogram.bucket) {
+        cumulative_count += bucket.cumulative_count;
+        tmp_stream << "Bucket[" << bucket.upper_bound << "]: " << bucket.cumulative_count << "\r\n";
+  
+        if (cumulative_count >= tp99_threshold) {
+          tp99 = bucket.upper_bound;
+          break;
+        }
+      }
+  
+      double total_time_usec = total_time * 1e6;
+      double avg_time = total_count > 0 ? total_time_usec / total_count * 1e6 : 0;
+      double tp99_usec = tp99 * 1e6;
+      tmp_stream << "Average usec_per_call: " << avg_time << "\r\n";
+      tmp_stream << "TP99 usec: " << tp99 << "\r\n";
+      tmp_stream << "----------------------\r\n";
+    }
+  } 
+  info.append(tmp_stream.str());
+}
+
+void InfoCmd::InfoSlowCommand(std::string& info) {
+  std::stringstream tmp_stream;
+  tmp_stream.precision(2);
+  tmp_stream.setf(std::ios::fixed);
+  auto stats = g_pika_cmd_table_manager->GetSlowCommandCount();
+  tmp_stream << "# SlowCommand Count" << "\r\n";
+  for (auto iter : *stats) {
+    if (iter.second.cmd_count != 0) {
+      tmp_stream << "Command: " << iter.first << ", Slow count: " << iter.second.cmd_count << "\r\n";
+    } 
+  }
+  info.append(tmp_stream.str());
+} 
 
 void InfoCmd::InfoCommandStats(std::string& info) {
   std::stringstream tmp_stream;

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1502,9 +1502,9 @@ void InfoCmd::InfoCommandP99(std::string& info) {
   tmp_stream.precision(2);
   tmp_stream.setf(std::ios::fixed);
   tmp_stream << "# Commands P99" << "\r\n";
-  auto& histogram_family = g_pika_cmd_table_manager->GetHistograms(); 
+  auto histogram_family = g_pika_cmd_table_manager->GetHistograms(); 
 
-  for (const auto& metric_family : histogram_family.Collect()) {
+  for (const auto& metric_family : histogram_family->Collect()) {
     for (const auto& metric : metric_family.metric) {
       std::string command_name;
   
@@ -1516,7 +1516,6 @@ void InfoCmd::InfoCommandP99(std::string& info) {
       }
   
       double total_count = metric.histogram.sample_count;
-      double total_time = metric.histogram.sample_sum;
   
       if (command_name.empty()) {
         tmp_stream << "Command: UNKNOWN\r\n";
@@ -1524,34 +1523,25 @@ void InfoCmd::InfoCommandP99(std::string& info) {
         tmp_stream << "Command: " << command_name << "\r\n";
       }
   
-      tmp_stream << "Total calls: " << total_count << ", Total usec: " << total_time << "\r\n";
+      tmp_stream << "Total calls: " << total_count <<  "\r\n";
   
-      if (total_count < 10) { 
-        tmp_stream << "TP99: Not enough data\r\n";
-        continue;
-      }
       double tp99_threshold = total_count * 0.99;
-      double cumulative_count = 0;
       double tp99 = 0;
   
       for (const auto& bucket : metric.histogram.bucket) {
-        cumulative_count += bucket.cumulative_count;
-        tmp_stream << "Bucket[" << bucket.upper_bound << "]: " << bucket.cumulative_count << "\r\n";
+        tmp_stream << "Bucket[" << bucket.upper_bound << " ms]: " << bucket.cumulative_count << "\r\n"; 
   
-        if (cumulative_count >= tp99_threshold) {
-          tp99 = bucket.upper_bound;
+        if (bucket.cumulative_count >= tp99_threshold) {
+          tp99 = bucket.upper_bound; 
           break;
         }
       }
   
-      double total_time_usec = total_time * 1e6;
-      double avg_time = total_count > 0 ? total_time_usec / total_count * 1e6 : 0;
-      double tp99_usec = tp99 * 1e6;
-      tmp_stream << "Average usec_per_call: " << avg_time << "\r\n";
-      tmp_stream << "TP99 usec: " << tp99 << "\r\n";
+      tmp_stream << "TP99 ms: " << tp99 << "\r\n";
       tmp_stream << "----------------------\r\n";
     }
-  } 
+  }
+
   info.append(tmp_stream.str());
 }
 

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1553,7 +1553,7 @@ void InfoCmd::InfoSlowCommand(std::string& info) {
   tmp_stream << "# SlowCommand Count" << "\r\n";
   for (auto iter : *stats) {
     if (iter.second.cmd_count != 0) {
-      tmp_stream << "Command: " << iter.first << ", Slow count: " << iter.second.cmd_count << "\r\n";
+      tmp_stream << iter.first << ":slow_count=" << iter.second.cmd_count << "\r\n";
     } 
   }
   info.append(tmp_stream.str());

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1523,21 +1523,26 @@ void InfoCmd::InfoCommandP99(std::string& info) {
         tmp_stream << "Command: " << command_name << "\r\n";
       }
   
-      tmp_stream << "Total calls: " << total_count <<  "\r\n";
-  
       double tp99_threshold = total_count * 0.99;
-      double tp99 = 0;
+      double tp999_threshold = total_count * 0.999;
+      double tp9999_threshold = total_count * 0.9999;
+      double tp99 = 0, tp999 = 0, tp9999 = 0;
   
       for (const auto& bucket : metric.histogram.bucket) {
-        tmp_stream << "Bucket[" << bucket.upper_bound << " ms]: " << bucket.cumulative_count << "\r\n"; 
-  
-        if (bucket.cumulative_count >= tp99_threshold) {
-          tp99 = bucket.upper_bound; 
+        if (bucket.cumulative_count >= tp99_threshold && tp99 == 0) {
+          tp99 = bucket.upper_bound;
+        }
+        if (bucket.cumulative_count >= tp999_threshold && tp999 == 0) {
+          tp999 = bucket.upper_bound;
+        }
+        if (bucket.cumulative_count >= tp9999_threshold && tp9999 == 0) {
+          tp9999 = bucket.upper_bound;
           break;
         }
       }
-  
       tmp_stream << "TP99 ms: " << tp99 << "\r\n";
+      tmp_stream << "TP999 ms: " << tp999 << "\r\n";
+      tmp_stream << "TP9999 ms: " << tp9999 << "\r\n";
       tmp_stream << "----------------------\r\n";
     }
   }
@@ -1551,7 +1556,7 @@ void InfoCmd::InfoSlowCommand(std::string& info) {
   tmp_stream.setf(std::ios::fixed);
   auto stats = g_pika_cmd_table_manager->GetSlowCommandCount();
   tmp_stream << "# SlowCommand Count" << "\r\n";
-  for (auto iter : *stats) {
+  for (auto iter : stats) {
     if (iter.second.cmd_count != 0) {
       tmp_stream << iter.first << ":slow_count=" << iter.second.cmd_count << "\r\n";
     } 

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -7,6 +7,10 @@
 #include <glog/logging.h>
 #include <utility>
 #include <vector>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+#include <prometheus/counter.h>
+#include <prometheus/histogram.h>
 
 #include "include/pika_admin.h"
 #include "include/pika_client_conn.h"
@@ -218,22 +222,28 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   // Perform some operations
   rocksdb::get_perf_context()->Reset();
   // Process Command
+  auto start_time = std::chrono::high_resolution_clock::now();
   c_ptr->Execute();
+  auto end_time = std::chrono::high_resolution_clock::now();
 
   time_stat_->process_done_ts_ = pstd::NowMicros();
+  std::chrono::duration<double> elapsed = end_time - start_time;
+  g_pika_cmd_table_manager->GetHistogram(opt).Observe(elapsed.count());
   auto cmdstat_map = g_pika_cmd_table_manager->GetCommandStatMap();
   (*cmdstat_map)[opt].cmd_count.fetch_add(1);
   (*cmdstat_map)[opt].cmd_time_consuming.fetch_add(time_stat_->total_time());
 
   if (g_pika_conf->slowlog_slower_than() >= 0) {
-    ProcessSlowlog(argv, c_ptr);
+    ProcessSlowlog(argv, c_ptr, opt);
   }
 
   return c_ptr;
 }
 
-void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr) {
+void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, std::string opt) {
   if (time_stat_->total_time() > g_pika_conf->slowlog_slower_than()) {
+    auto slow_command_count = g_pika_cmd_table_manager->GetSlowCommandCount();
+    (*slow_command_count)[opt].cmd_count.fetch_add(1);
     g_pika_server->SlowlogPushEntry(argv, time_stat_->start_ts() / 1000000, time_stat_->total_time());
     if (g_pika_conf->slowlog_write_errorlog()) {
       bool trim = false;

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -227,7 +227,7 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   auto end_time = std::chrono::high_resolution_clock::now();
 
   time_stat_->process_done_ts_ = pstd::NowMicros();
-  std::chrono::duration<double> elapsed = end_time - start_time;
+  std::chrono::duration<double, std::milli> elapsed = end_time - start_time; 
   g_pika_cmd_table_manager->GetHistogram(opt).Observe(elapsed.count());
   auto cmdstat_map = g_pika_cmd_table_manager->GetCommandStatMap();
   (*cmdstat_map)[opt].cmd_count.fetch_add(1);

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -222,13 +222,10 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   // Perform some operations
   rocksdb::get_perf_context()->Reset();
   // Process Command
-  auto start_time = std::chrono::high_resolution_clock::now();
   c_ptr->Execute();
-  auto end_time = std::chrono::high_resolution_clock::now();
 
   time_stat_->process_done_ts_ = pstd::NowMicros();
-  std::chrono::duration<double, std::milli> elapsed = end_time - start_time; 
-  g_pika_cmd_table_manager->GetHistogram(opt).Observe(elapsed.count());
+  g_pika_cmd_table_manager->GetHistogram(opt).Observe(time_stat_->total_time() / 1000);
   auto cmdstat_map = g_pika_cmd_table_manager->GetCommandStatMap();
   (*cmdstat_map)[opt].cmd_count.fetch_add(1);
   (*cmdstat_map)[opt].cmd_time_consuming.fetch_add(time_stat_->total_time());
@@ -240,10 +237,9 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   return c_ptr;
 }
 
-void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, std::string opt) {
+void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, const std::string& opt) {
   if (time_stat_->total_time() > g_pika_conf->slowlog_slower_than()) {
-    auto slow_command_count = g_pika_cmd_table_manager->GetSlowCommandCount();
-    (*slow_command_count)[opt].cmd_count.fetch_add(1);
+    g_pika_cmd_table_manager->UpdateSlowCommandCount(opt);
     g_pika_server->SlowlogPushEntry(argv, time_stat_->start_ts() / 1000000, time_stat_->total_time());
     if (g_pika_conf->slowlog_write_errorlog()) {
       bool trim = false;

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -96,7 +96,7 @@ prometheus::Histogram& PikaCmdTableManager::GetHistogram(const std::string& opt)
   std::unique_lock<std::shared_mutex> write_lock(histograms_mutex_);
   auto& new_histogram = histogram_family_->Add(
     {{"command", opt}}, 
-    prometheus::Histogram::BucketBoundaries{0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000}
+    prometheus::Histogram::BucketBoundaries{0.5, 1, 2, 3, 5, 7, 10, 15, 20, 30, 40, 50, 65, 75, 85, 100, 125, 140, 150, 160, 175, 185, 200, 300, 400, 500, 750, 1000, 2000, 5000, 10000}
   );
   histograms_[opt] = &new_histogram;
   return new_histogram;

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -14,25 +14,31 @@
 
 extern std::unique_ptr<PikaConf> g_pika_conf;
 
-void PikaCmdTableManager::ResetSlowCommandCount() {
+void PikaCmdTableManager::ResetCommandCount() {
   while (true) {
     std::this_thread::sleep_for(std::chrono::minutes(1)); 
     {
-      std::lock_guard<std::mutex> lock(slow_command_mutex_);
+      std::lock_guard<std::mutex> lock(command_mutex_);
       slow_command_count_.clear();
+      InitHistograms(); 
     }
-    LOG(INFO) << "Slow command statistics reset.";
   }
 }
 
-PikaCmdTableManager::PikaCmdTableManager() 
-   : histogram_family_(prometheus::BuildHistogram()
-                      .Name("pika_command_duration_seconds")
-                      .Help("Execution time of Pika commands in seconds")
-                      .Register(prometheus_registry_)) {
+void PikaCmdTableManager::InitHistograms() {
+  histograms_.clear();
+  prometheus_registry_ = std::make_shared<prometheus::Registry>();
+  histogram_family_ = &prometheus::BuildHistogram()
+      .Name("pika_command_duration_seconds")
+      .Help("Execution time of Pika commands in seconds")
+      .Register(*prometheus_registry_);
+}
+
+PikaCmdTableManager::PikaCmdTableManager() {
   cmds_ = std::make_unique<CmdTable>();
   cmds_->reserve(300);
-  reset_thread_ = std::thread(&PikaCmdTableManager::ResetSlowCommandCount, this);
+  InitHistograms();
+  reset_thread_ = std::thread(&PikaCmdTableManager::ResetCommandCount, this);
 }
 
 void PikaCmdTableManager::InitCmdTable(void) {
@@ -80,20 +86,23 @@ void PikaCmdTableManager::RenameCommand(const std::string before, const std::str
 }
 
 prometheus::Histogram& PikaCmdTableManager::GetHistogram(const std::string& opt) {
-  std::lock_guard<std::mutex> lock(histograms_mutex_);
-  auto it = histograms_.find(opt);
-  if (it != histograms_.end()) {
-    return *(it->second);
+  {
+    std::shared_lock<std::shared_mutex> read_lock(histograms_mutex_);
+    auto it = histograms_.find(opt);
+    if (it != histograms_.end()) {
+      return *(it->second);
+    }
   }
-  auto& new_histogram = histogram_family_.Add(
+  std::unique_lock<std::shared_mutex> write_lock(histograms_mutex_);
+  auto& new_histogram = histogram_family_->Add(
     {{"command", opt}}, 
-    prometheus::Histogram::BucketBoundaries{0.00001, 0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5}
+    prometheus::Histogram::BucketBoundaries{0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000}
   );
   histograms_[opt] = &new_histogram;
   return new_histogram;
 }
 
-prometheus::Family<prometheus::Histogram>& PikaCmdTableManager::GetHistograms() {
+prometheus::Family<prometheus::Histogram>* PikaCmdTableManager::GetHistograms() {
   return histogram_family_;
 }
 std::unordered_map<std::string, CommandStatistics>* PikaCmdTableManager::GetSlowCommandCount() {

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -14,9 +14,25 @@
 
 extern std::unique_ptr<PikaConf> g_pika_conf;
 
-PikaCmdTableManager::PikaCmdTableManager() {
+void PikaCmdTableManager::ResetSlowCommandCount() {
+  while (true) {
+    std::this_thread::sleep_for(std::chrono::minutes(1)); 
+    {
+      std::lock_guard<std::mutex> lock(slow_command_mutex_);
+      slow_command_count_.clear();
+    }
+    LOG(INFO) << "Slow command statistics reset.";
+  }
+}
+
+PikaCmdTableManager::PikaCmdTableManager() 
+   : histogram_family_(prometheus::BuildHistogram()
+                      .Name("pika_command_duration_seconds")
+                      .Help("Execution time of Pika commands in seconds")
+                      .Register(prometheus_registry_)) {
   cmds_ = std::make_unique<CmdTable>();
   cmds_->reserve(300);
+  reset_thread_ = std::thread(&PikaCmdTableManager::ResetSlowCommandCount, this);
 }
 
 void PikaCmdTableManager::InitCmdTable(void) {
@@ -61,6 +77,27 @@ void PikaCmdTableManager::RenameCommand(const std::string before, const std::str
     }
     cmds_->erase(it);
   }
+}
+
+prometheus::Histogram& PikaCmdTableManager::GetHistogram(const std::string& opt) {
+  std::lock_guard<std::mutex> lock(histograms_mutex_);
+  auto it = histograms_.find(opt);
+  if (it != histograms_.end()) {
+    return *(it->second);
+  }
+  auto& new_histogram = histogram_family_.Add(
+    {{"command", opt}}, 
+    prometheus::Histogram::BucketBoundaries{0.00001, 0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5}
+  );
+  histograms_[opt] = &new_histogram;
+  return new_histogram;
+}
+
+prometheus::Family<prometheus::Histogram>& PikaCmdTableManager::GetHistograms() {
+  return histogram_family_;
+}
+std::unordered_map<std::string, CommandStatistics>* PikaCmdTableManager::GetSlowCommandCount() {
+  return &slow_command_count_;
 }
 
 std::unordered_map<std::string, CommandStatistics>* PikaCmdTableManager::GetCommandStatMap() {

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -105,8 +105,27 @@ prometheus::Histogram& PikaCmdTableManager::GetHistogram(const std::string& opt)
 prometheus::Family<prometheus::Histogram>* PikaCmdTableManager::GetHistograms() {
   return histogram_family_;
 }
-std::unordered_map<std::string, CommandStatistics>* PikaCmdTableManager::GetSlowCommandCount() {
-  return &slow_command_count_;
+
+void PikaCmdTableManager::UpdateSlowCommandCount(const std::string& opt) {
+  {
+    std::shared_lock<std::shared_mutex> read_lock(slow_command_mutex_);
+    if (slow_command_count_.find(opt) != slow_command_count_.end()) {
+      slow_command_count_[opt].cmd_count.fetch_add(1);
+      return;
+    }
+  }
+
+  {
+    std::unique_lock<std::shared_mutex> write_lock(slow_command_mutex_);
+    slow_command_count_[opt]; 
+  }
+
+  slow_command_count_[opt].cmd_count.fetch_add(1);
+}
+
+std::unordered_map<std::string, CommandStatistics> PikaCmdTableManager::GetSlowCommandCount() {
+  std::shared_lock<std::shared_mutex> lock(slow_command_mutex_);
+  return slow_command_count_;
 }
 
 std::unordered_map<std::string, CommandStatistics>* PikaCmdTableManager::GetCommandStatMap() {

--- a/tools/pika_exporter/config/info.toml
+++ b/tools/pika_exporter/config/info.toml
@@ -5,8 +5,9 @@ stats = true
 cpu = true
 replication = true
 keyspace = true
-cache = true
-
+cache = false
+commandp99 = true
+slowcommand = true
 execcount = false
 commandstats = false
 rocksdb = false

--- a/tools/pika_exporter/exporter/client.go
+++ b/tools/pika_exporter/exporter/client.go
@@ -127,6 +127,8 @@ func (c *client) InfoNoneCommandList() (string, error) {
 		"COMMAND_EXEC_COUNT": InfoConf.Execcount,
 		"COMMANDSTATS":       InfoConf.Commandstats,
 		"ROCKSDB":            InfoConf.Rocksdb,
+		"CommandP99":         InfoConf.CommandP99,
+		"SlowCommand":        InfoConf.SlowCommand,
 	}
 	for section, flag := range sectionsMap {
 		if flag {
@@ -155,6 +157,8 @@ func (c *client) InfoAllCommandList() (string, error) {
 		"COMMAND_EXEC_COUNT": InfoConf.Execcount,
 		"COMMANDSTATS":       InfoConf.Commandstats,
 		"ROCKSDB":            InfoConf.Rocksdb,
+		"CommandP99":         InfoConf.CommandP99,
+		"SlowCommand":        InfoConf.SlowCommand,
 	}
 	for section, flag := range sectionsMap {
 		if flag {

--- a/tools/pika_exporter/exporter/conf.go
+++ b/tools/pika_exporter/exporter/conf.go
@@ -21,6 +21,8 @@ type InfoConfig struct {
 	Keyspace     bool `toml:"keyspace"`
 	Execcount    bool `toml:"execcount"`
 	Commandstats bool `toml:"commandstats"`
+	CommandP99   bool `toml:"commandp99"`
+	SlowCommand  bool `toml:"slowcommand"`
 	Rocksdb      bool `toml:"rocksdb"`
 	Cache        bool `toml:"cache"`
 

--- a/tools/pika_exporter/exporter/metrics/commandp99.go
+++ b/tools/pika_exporter/exporter/metrics/commandp99.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+    "regexp"
+)
+
+func init() {
+    Register(collectCommandP99Metrics)
+}
+
+var collectCommandP99Metrics = map[string]MetricConfig{
+    "command_p99_info": {
+        Parser: &regexParser{
+            name: "command_p99_info",
+            reg: regexp.MustCompile(`Command:\s*(?P<cmd>[\w]+)\s*\r?\nTotal calls:\s*(?P<total_calls>[\d.]+)\s*\r?\n(?:(?:Bucket\[(?P<bucket_time>[\d.]+)\s*ms\]:\s*(?P<bucket_count>[\d.]+)\s*\r?\n)*)TP99 ms:\s*(?P<tp99>[\d.]+)`),
+            Parser: &normalParser{},
+        },
+        MetricMeta: MetaDatas{
+            {
+                Name:      "command_total_calls",
+                Help:      "Total number of calls for each Pika command",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "total_calls",
+            },
+            {
+                Name:      "command_p99_latency",
+                Help:      "99th percentile latency (ms) for each Pika command",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "tp99",
+            },
+            {
+                Name:      "command_latency_buckets",
+                Help:      "Latency distribution buckets for Pika commands",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd", "bucket"},
+                ValueName: "bucket_count",
+            },
+        },
+    },
+}

--- a/tools/pika_exporter/exporter/metrics/commandp99.go
+++ b/tools/pika_exporter/exporter/metrics/commandp99.go
@@ -4,7 +4,7 @@ import (
     "regexp"
 )
 
-func init() {
+func RegisterCommandP99() {
     Register(collectCommandP99Metrics)
 }
 
@@ -12,30 +12,16 @@ var collectCommandP99Metrics = map[string]MetricConfig{
     "command_p99_info": {
         Parser: &regexParser{
             name: "command_p99_info",
-            reg: regexp.MustCompile(`Command:\s*(?P<cmd>[\w]+)\s*\r?\nTotal calls:\s*(?P<total_calls>[\d.]+)\s*\r?\n(?:(?:Bucket\[(?P<bucket_time>[\d.]+)\s*ms\]:\s*(?P<bucket_count>[\d.]+)\s*\r?\n)*)TP99 ms:\s*(?P<tp99>[\d.]+)`),
+            reg: regexp.MustCompile(`Command:\s*(?P<cmd>\S+)\s*\r?\n(?:.*\r?\n)*?TP99 ms:\s*(?P<tp99>[\d.]+)`),
             Parser: &normalParser{},
         },
         MetricMeta: MetaDatas{
-            {
-                Name:      "command_total_calls",
-                Help:      "Total number of calls for each Pika command",
-                Type:      metricTypeGauge,
-                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
-                ValueName: "total_calls",
-            },
             {
                 Name:      "command_p99_latency",
                 Help:      "99th percentile latency (ms) for each Pika command",
                 Type:      metricTypeGauge,
                 Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
                 ValueName: "tp99",
-            },
-            {
-                Name:      "command_latency_buckets",
-                Help:      "Latency distribution buckets for Pika commands",
-                Type:      metricTypeGauge,
-                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd", "bucket"},
-                ValueName: "bucket_count",
             },
         },
     },

--- a/tools/pika_exporter/exporter/metrics/commandp99.go
+++ b/tools/pika_exporter/exporter/metrics/commandp99.go
@@ -12,7 +12,7 @@ var collectCommandP99Metrics = map[string]MetricConfig{
     "command_p99_info": {
         Parser: &regexParser{
             name: "command_p99_info",
-            reg: regexp.MustCompile(`Command:\s*(?P<cmd>\S+)\s*\r?\n(?:.*\r?\n)*?TP99 ms:\s*(?P<tp99>[\d.]+)`),
+            reg: regexp.MustCompile(`Command:\s*(?P<cmd>\S+)\s*\r?\n(?:.*\r?\n)*?TP99 ms:\s*(?P<tp99>[\d.]+)\s*\r?\n.*?TP999 ms:\s*(?P<tp999>[\d.]+)\s*\r?\n.*?TP9999 ms:\s*(?P<tp9999>[\d.]+)`),
             Parser: &normalParser{},
         },
         MetricMeta: MetaDatas{
@@ -22,6 +22,20 @@ var collectCommandP99Metrics = map[string]MetricConfig{
                 Type:      metricTypeGauge,
                 Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
                 ValueName: "tp99",
+            },
+            {
+                Name:      "command_p999_latency",
+                Help:      "99.9th percentile latency (ms) for each Pika command",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "tp999",
+            },
+            {
+                Name:      "command_p9999_latency",
+                Help:      "99.99th percentile latency (ms) for each Pika command",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "tp9999",
             },
         },
     },

--- a/tools/pika_exporter/exporter/metrics/slowcommand.go
+++ b/tools/pika_exporter/exporter/metrics/slowcommand.go
@@ -4,7 +4,7 @@ import (
     "regexp"
 )
 
-func init() {
+func RegisterSlowCommand() {
     Register(collectSlowCommandMetrics)
 }
 
@@ -12,7 +12,7 @@ var collectSlowCommandMetrics = map[string]MetricConfig{
     "slow_command_info": {
         Parser: &regexParser{
             name: "slow_command_info",
-            reg: regexp.MustCompile(`Command:\s*(?P<cmd>[\w]+),\s*Slow count:\s*(?P<slow_count>[\d]+)`),
+            reg: regexp.MustCompile(`(?P<cmd>\S+):slow_count=(?P<slow_count>\d+)`),
             Parser: &normalParser{},
         },
         MetricMeta: MetaDatas{
@@ -26,3 +26,4 @@ var collectSlowCommandMetrics = map[string]MetricConfig{
         },
     },
 }
+

--- a/tools/pika_exporter/exporter/metrics/slowcommand.go
+++ b/tools/pika_exporter/exporter/metrics/slowcommand.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+    "regexp"
+)
+
+func init() {
+    Register(collectSlowCommandMetrics)
+}
+
+var collectSlowCommandMetrics = map[string]MetricConfig{
+    "slow_command_info": {
+        Parser: &regexParser{
+            name: "slow_command_info",
+            reg: regexp.MustCompile(`Command:\s*(?P<cmd>[\w]+),\s*Slow count:\s*(?P<slow_count>[\d]+)`),
+            Parser: &normalParser{},
+        },
+        MetricMeta: MetaDatas{
+            {
+                Name:      "command_slow_count",
+                Help:      "Number of times each Pika command was slow",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "slow_count",
+            },
+        },
+    },
+}

--- a/tools/pika_exporter/exporter/pika.go
+++ b/tools/pika_exporter/exporter/pika.go
@@ -355,6 +355,12 @@ func (e *exporter) registerMetrics() {
 	if config.Commandstats {
 		metrics.RegisterCommandstats()
 	}
+	if config.CommandP99 {
+		metrics.RegisterCommandP99()
+	}
+	if config.SlowCommand {
+	    metrics.RegisterSlowCommand()
+	}
 	if config.Rocksdb {
 		metrics.RegisterRocksDB()
 	}


### PR DESCRIPTION
1. P99 命令的统计， 每分钟会重置一次
```cpp
127.0.0.1:9221> info commandp99
# Commands P99
Command: set
TP99 ms: 0.50
TP999 ms: 0.50
TP9999 ms: 0.50
----------------------
Command: config
TP99 ms: 0.50
TP999 ms: 0.50
TP9999 ms: 0.50
----------------------
```

2. Slow 慢命令统计, 每分钟会重置一次
```cpp
127.0.0.1:9221> info slowcommand
# SlowCommand Count
info:slow_count=229
hset:slow_count=72866
config:slow_count=186
```