### PR TITLE
fix: The number of element updates in RedisCache is configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,24 @@ ExternalProject_Add(rocksdb
   make -j${CPU_CORE}
 )
 
+ExternalProject_Add(prometheus_cpp
+  URL
+  https://github.com/jupp0r/prometheus-cpp/releases/download/v1.2.4/prometheus-cpp-with-submodules.tar.gz
+  CMAKE_ARGS
+  -DBUILD_SHARED_LIBS=OFF
+  -DENABLE_PUSH=OFF
+  -DENABLE_COMPRESSION=OFF
+  -DCMAKE_INSTALL_LIBDIR=${INSTALL_LIBDIR}
+  -DCMAKE_INSTALL_INCLUDEDIR=${INSTALL_INCLUDEDIR}
+  BUILD_ALWAYS
+  1
+  BUILD_COMMAND
+  make -j${CPU_CORE}
+)
+
+set(PROMETHEUS_CPP_CORE_LIB ${INSTALL_LIBDIR}/libprometheus-cpp-core.a)
+set(PROMETHEUS_CPP_PULL_LIB ${INSTALL_LIBDIR}/libprometheus-cpp-pull.a)
+
 ExternalProject_Add(rediscache
   URL
   https://github.com/pikiwidb/rediscache/archive/refs/tags/v1.0.7.tar.gz
@@ -822,6 +840,8 @@ target_link_libraries(${PROJECT_NAME}
   ${LIB_PROTOBUF}
   ${LIB_GFLAGS}
   ${LIB_FMT}
+  ${PROMETHEUS_CPP_PULL_LIB}
+  ${PROMETHEUS_CPP_CORE_LIB}
   libsnappy.a
   libzstd.a
   liblz4.a

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -537,7 +537,7 @@ cache-type: string, set, zset, list, hash, bit
 cache-value-item-max-size: 1024
 
 # Sets the maximum number of bytes for Key when the String data type is updated in the cache
-max-key-size-in-cache: 1024
+max-key-size-in-cache: 1048576
 
 # Maximum number of keys in the zset redis cache
 # On the disk DB, a zset field may have many fields. In the memory cache, we limit the maximum

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -533,6 +533,12 @@ cache-model : 1
 # cache-type: string, set, zset, list, hash, bit
 cache-type: string, set, zset, list, hash, bit
 
+# Set the maximum number of elements in the cache of the Set, list, Zset data types
+cache-value-item-max-size: 1024
+
+# Sets the maximum number of bytes for Key when the String data type is updated in the cache
+max-key-size-in-cache: 1024
+
 # Maximum number of keys in the zset redis cache
 # On the disk DB, a zset field may have many fields. In the memory cache, we limit the maximum
 # number of keys that can exist in a zset,  which is zset-zset-cache-field-num-per-key, with a

--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -267,6 +267,8 @@ class InfoCmd : public Cmd {
     kInfoAll,
     kInfoDebug,
     kInfoCommandStats,
+    kInfoSlowCommand,
+    kInfoCommandP99,
     kInfoCache
   };
   InfoCmd(const std::string& name, int arity, uint32_t flag) : Cmd(name, arity, flag) {}
@@ -294,6 +296,8 @@ class InfoCmd : public Cmd {
   const static std::string kRocksDBSection;
   const static std::string kDebugSection;
   const static std::string kCommandStatsSection;
+  const static std::string kCommandP99Section;
+  const static std::string kSlowCommandSection;
   const static std::string kCacheSection;
 
   void DoInitial() override;
@@ -314,6 +318,8 @@ class InfoCmd : public Cmd {
   void InfoRocksDB(std::string& info);
   void InfoDebug(std::string& info);
   void InfoCommandStats(std::string& info);
+  void InfoCommandP99(std::string& info);
+  void InfoSlowCommand(std::string& info);
   void InfoCache(std::string& info, std::shared_ptr<DB> db);
 
   std::string CacheStatusToString(int status);

--- a/include/pika_client_conn.h
+++ b/include/pika_client_conn.h
@@ -130,7 +130,7 @@ class PikaClientConn : public net::RedisConn {
   std::shared_ptr<Cmd> DoCmd(const PikaCmdArgsType& argv, const std::string& opt,
                              const std::shared_ptr<std::string>& resp_ptr, bool cache_miss_in_rtc);
 
-  void ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr);
+  void ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, const std::string& opt);
   void ProcessMonitor(const PikaCmdArgsType& argv);
 
   void ExecRedisCmd(const PikaCmdArgsType& argv, std::shared_ptr<std::string>& resp_ptr, bool cache_miss_in_rtc);

--- a/include/pika_cmd_table_manager.h
+++ b/include/pika_cmd_table_manager.h
@@ -8,10 +8,16 @@
 
 #include <shared_mutex>
 #include <thread>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+#include <prometheus/counter.h>
+#include <prometheus/histogram.h>
 
 #include "include/acl.h"
 #include "include/pika_command.h"
 #include "include/pika_data_distribution.h"
+
+using namespace prometheus;
 
 struct CommandStatistics {
   CommandStatistics() = default;
@@ -30,6 +36,7 @@ class PikaCmdTableManager {
   PikaCmdTableManager();
   virtual ~PikaCmdTableManager() = default;
   void InitCmdTable(void);
+  void InitHistograms();
   void RenameCommand(const std::string before, const std::string after);
   std::shared_ptr<Cmd> GetCmd(const std::string& opt);
   bool CmdExist(const std::string& cmd) const;
@@ -42,6 +49,11 @@ class PikaCmdTableManager {
   * Info Commandstats used
   */
   std::unordered_map<std::string, CommandStatistics>* GetCommandStatMap();
+  std::unordered_map<std::string, CommandStatistics> GetSlowCommandCount();
+  void UpdateSlowCommandCount(const std::string& opt);
+  void ResetCommandCount();
+  prometheus::Histogram& GetHistogram(const std::string& opt);
+  prometheus::Family<prometheus::Histogram>* GetHistograms();
 
  private:
   std::shared_ptr<Cmd> NewCommand(const std::string& opt);
@@ -60,5 +72,13 @@ class PikaCmdTableManager {
   * Info Commandstats used
   */
   std::unordered_map<std::string, CommandStatistics> cmdstat_map_;
+  std::unordered_map<std::string, CommandStatistics> slow_command_count_;
+  std::thread reset_thread_;
+  std::mutex command_mutex_;
+  std::shared_mutex histograms_mutex_;
+  std::shared_mutex slow_command_mutex_;
+  std::shared_ptr<prometheus::Registry> prometheus_registry_;
+  prometheus::Family<prometheus::Histogram>* histogram_family_;
+  std::unordered_map<std::string, prometheus::Histogram*> histograms_;
 };
 #endif

--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -531,7 +531,7 @@ class Cmd : public std::enable_shared_from_this<Cmd> {
   // used for execute multikey command into different slots
   virtual void Split(const HintKeys& hint_keys) = 0;
   virtual void Merge() = 0;
-  virtual bool IsTooLargeKey(const int &max_sz) { return false; }
+  virtual bool IsTooLargeKey(const size_t &max_sz) { return false; }
 
   int8_t SubCmdIndex(const std::string& cmdName);  // if the command no subCommand，return -1；
 

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -845,6 +845,7 @@ class PikaConf : public pstd::BaseConf {
   int zset_cache_start_direction() { return zset_cache_start_direction_; }
   int zset_cache_field_num_per_key() { return zset_cache_field_num_per_key_; }
   int max_key_size_in_cache() { return max_key_size_in_cache_; }
+  int value_item_max_size_in_cache() { return cache_value_item_max_size_; }
   int cache_maxmemory_policy() { return cache_maxmemory_policy_; }
   int cache_maxmemory_samples() { return cache_maxmemory_samples_; }
   int cache_lfu_decay_time() { return cache_lfu_decay_time_; }
@@ -983,7 +984,7 @@ class PikaConf : public pstd::BaseConf {
   std::atomic_int zset_cache_start_direction_ = 0;
   std::atomic_int zset_cache_field_num_per_key_ = 512;
   std::atomic_int cache_value_item_max_size_ = 1024;
-  std::atomic_int max_key_size_in_cache_ = 512;
+  std::atomic_int max_key_size_in_cache_ = 1024 * 1024;
   std::atomic_int cache_maxmemory_policy_ = 1;
   std::atomic_int cache_maxmemory_samples_ = 5;
   std::atomic_int cache_lfu_decay_time_ = 1;

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -982,6 +982,7 @@ class PikaConf : public pstd::BaseConf {
   std::atomic_int cache_bit_ = 1;
   std::atomic_int zset_cache_start_direction_ = 0;
   std::atomic_int zset_cache_field_num_per_key_ = 512;
+  std::atomic_int cache_value_item_max_size_ = 1024;
   std::atomic_int max_key_size_in_cache_ = 512;
   std::atomic_int cache_maxmemory_policy_ = 1;
   std::atomic_int cache_maxmemory_samples_ = 5;

--- a/include/pika_hash.h
+++ b/include/pika_hash.h
@@ -54,7 +54,7 @@ class HGetCmd : public Cmd {
   void DoUpdateCache() override;
   void Split(const HintKeys& hint_keys) override {};
   void Merge() override {};
-  bool IsTooLargeKey(const int &max_sz) override { return key_.size() > static_cast<uint32_t>(max_sz); }
+  bool IsTooLargeKey(const size_t &max_sz) override { return key_.size() > max_sz; }
   Cmd* Clone() override { return new HGetCmd(*this); }
 
  private:

--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -29,7 +29,7 @@ class SetCmd : public Cmd {
   void DoThroughDB() override;
   void Split(const HintKeys& hint_keys) override{};
   void Merge() override{};
-  bool IsTooLargeKey(const int& max_sz) override { return key_.size() > static_cast<uint32_t>(max_sz); }
+  bool IsTooLargeKey(const size_t &max_sz) override { return key_.size() > max_sz; }
   Cmd* Clone() override { return new SetCmd(*this); }
 
  private:
@@ -65,7 +65,7 @@ class GetCmd : public Cmd {
   void ReadCache() override;
   void Split(const HintKeys& hint_keys) override{};
   void Merge() override{};
-  bool IsTooLargeKey(const int &max_sz) override { return key_.size() > static_cast<uint32_t>(max_sz); }
+  bool IsTooLargeKey(const size_t &max_sz) override { return key_.size() > max_sz; }
   Cmd* Clone() override { return new GetCmd(*this); }
 
  private:

--- a/src/cache/include/config.h
+++ b/src/cache/include/config.h
@@ -40,6 +40,12 @@ constexpr int CACHE_START_FROM_END = -1;
 #define DEFAULT_CACHE_ITEMS_PER_KEY 512
 #define DEFAULT_CACHE_MAX_KEY_SIZE 512
 
+/*
+ * cache value item default size
+ */
+#define DEFAULT_CACHE_ITEMS_SIZE 1024
+#define MAX_CACHE_ITEMS_SIZE 2048
+
 struct CacheConfig {
   uint64_t maxmemory;                      /* Can used max memory */
   int32_t  maxmemory_policy;               /* Policy for key eviction */
@@ -47,6 +53,8 @@ struct CacheConfig {
   int32_t  lfu_decay_time;                 /* LFU counter decay factor. */
   int32_t  zset_cache_start_direction;
   int32_t  zset_cache_field_num_per_key;
+  int32_t  cache_value_item_max_size;
+
 
   CacheConfig()
     : maxmemory(CACHE_DEFAULT_MAXMEMORY)

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -882,6 +882,8 @@ const std::string InfoCmd::kKeyspaceSection = "keyspace";
 const std::string InfoCmd::kDataSection = "data";
 const std::string InfoCmd::kRocksDBSection = "rocksdb";
 const std::string InfoCmd::kDebugSection = "debug";
+const std::string InfoCmd::kCommandP99Section = "commandp99";
+const std::string InfoCmd::kSlowCommandSection = "slowcommand";
 const std::string InfoCmd::kCommandStatsSection = "commandstats";
 const std::string InfoCmd::kCacheSection = "cache";
 
@@ -967,6 +969,10 @@ void InfoCmd::DoInitial() {
     info_section_ = kInfoDebug;
   } else if (strcasecmp(argv_[1].data(), kCommandStatsSection.data()) == 0) {
     info_section_ = kInfoCommandStats;
+  } else if (strcasecmp(argv_[1].data(), kCommandP99Section.data()) == 0) {
+    info_section_ = kInfoCommandP99;
+  } else if (strcasecmp(argv_[1].data(), kSlowCommandSection.data()) == 0) {
+    info_section_ = kInfoSlowCommand; 
   } else if (strcasecmp(argv_[1].data(), kCacheSection.data()) == 0) {
     info_section_ = kInfoCache;
   } else {
@@ -1007,6 +1013,10 @@ void InfoCmd::Do() {
       InfoExecCount(info);
       info.append("\r\n");
       InfoCommandStats(info);
+      info.append("\r\n");
+      InfoCommandP99(info);
+      info.append("\r\n");
+      InfoSlowCommand(info);
       info.append("\r\n");
       InfoCache(info, db_);
       info.append("\r\n");
@@ -1051,6 +1061,12 @@ void InfoCmd::Do() {
     case kInfoCommandStats:
       InfoCommandStats(info);
       break;
+    case kInfoCommandP99:
+      InfoCommandP99(info);
+      break;
+    case kInfoSlowCommand:
+      InfoSlowCommand(info);
+      break;      
     case kInfoCache:
       InfoCache(info, db_);
       break;
@@ -1480,6 +1496,73 @@ void InfoCmd::InfoDebug(std::string& info) {
   info.append(tmp_stream.str());
   g_pika_server->ServerStatus(&info);
 }
+
+void InfoCmd::InfoCommandP99(std::string& info) {
+  std::stringstream tmp_stream;
+  tmp_stream.precision(2);
+  tmp_stream.setf(std::ios::fixed);
+  tmp_stream << "# Commands P99" << "\r\n";
+  auto histogram_family = g_pika_cmd_table_manager->GetHistograms(); 
+
+  for (const auto& metric_family : histogram_family->Collect()) {
+    for (const auto& metric : metric_family.metric) {
+      std::string command_name;
+  
+      for (const auto& label : metric.label) {
+        if (label.name == "command") {
+          command_name = label.value;
+          break;
+        }
+      }
+  
+      double total_count = metric.histogram.sample_count;
+  
+      if (command_name.empty()) {
+        tmp_stream << "Command: UNKNOWN\r\n";
+      } else {
+        tmp_stream << "Command: " << command_name << "\r\n";
+      }
+  
+      double tp99_threshold = total_count * 0.99;
+      double tp999_threshold = total_count * 0.999;
+      double tp9999_threshold = total_count * 0.9999;
+      double tp99 = 0, tp999 = 0, tp9999 = 0;
+  
+      for (const auto& bucket : metric.histogram.bucket) {
+        if (bucket.cumulative_count >= tp99_threshold && tp99 == 0) {
+          tp99 = bucket.upper_bound;
+        }
+        if (bucket.cumulative_count >= tp999_threshold && tp999 == 0) {
+          tp999 = bucket.upper_bound;
+        }
+        if (bucket.cumulative_count >= tp9999_threshold && tp9999 == 0) {
+          tp9999 = bucket.upper_bound;
+          break;
+        }
+      }
+      tmp_stream << "TP99 ms: " << tp99 << "\r\n";
+      tmp_stream << "TP999 ms: " << tp999 << "\r\n";
+      tmp_stream << "TP9999 ms: " << tp9999 << "\r\n";
+      tmp_stream << "----------------------\r\n";
+    }
+  }
+
+  info.append(tmp_stream.str());
+}
+
+void InfoCmd::InfoSlowCommand(std::string& info) {
+  std::stringstream tmp_stream;
+  tmp_stream.precision(2);
+  tmp_stream.setf(std::ios::fixed);
+  auto stats = g_pika_cmd_table_manager->GetSlowCommandCount();
+  tmp_stream << "# SlowCommand Count" << "\r\n";
+  for (auto iter : stats) {
+    if (iter.second.cmd_count != 0) {
+      tmp_stream << iter.first << ":slow_count=" << iter.second.cmd_count << "\r\n";
+    } 
+  }
+  info.append(tmp_stream.str());
+} 
 
 void InfoCmd::InfoCommandStats(std::string& info) {
   std::stringstream tmp_stream;

--- a/src/pika_cache_load_thread.cc
+++ b/src/pika_cache_load_thread.cc
@@ -72,7 +72,7 @@ bool PikaCacheLoadThread::LoadHash(std::string& key, const std::shared_ptr<DB>& 
   db->storage()->HLen(key, &len);
   // If the Hash type contains more than 2048 data members, 
   // it will not be updated to RedisCache
-  if (0 >= len || g_pika_conf->max_key_size_in_cache() < len) {
+  if (0 >= len || g_pika_conf->value_item_max_size_in_cache() < len) {
     return false;
   }
 
@@ -93,9 +93,9 @@ bool PikaCacheLoadThread::LoadList(std::string& key, const std::shared_ptr<DB>& 
   db->storage()->LLen(key, &len);
   // If the List type contains more than 2048 data members, 
   // it will not be updated to RedisCache
-  if (len <= 0 || g_pika_conf->max_key_size_in_cache() < len) {
+  if (len <= 0 || g_pika_conf->value_item_max_size_in_cache() < len) {
     LOG(WARNING) << "can not load key, because item size:" << len
-                 << " beyond max item size:" << CACHE_VALUE_ITEM_MAX_SIZE;
+                 << " beyond max item size:" << g_pika_conf->value_item_max_size_in_cache();
     return false;
   }
 
@@ -116,9 +116,9 @@ bool PikaCacheLoadThread::LoadSet(std::string& key, const std::shared_ptr<DB>& d
   db->storage()->SCard(key, &len);
   // If the Set type contains more than 2048 data members, 
   // it will not be updated to RedisCache
-  if (0 >= len || g_pika_conf->max_key_size_in_cache() < len) {
+  if (0 >= len || g_pika_conf->value_item_max_size_in_cache() < len) {
     LOG(WARNING) << "can not load key, because item size:" << len
-                 << " beyond max item size:" << CACHE_VALUE_ITEM_MAX_SIZE;
+                 << " beyond max item size:" << g_pika_conf->value_item_max_size_in_cache();
     return false;
   }
 

--- a/src/pika_cache_load_thread.cc
+++ b/src/pika_cache_load_thread.cc
@@ -10,6 +10,7 @@
 #include "pstd/include/scope_record_lock.h"
 
 extern PikaServer* g_pika_server;
+extern std::unique_ptr<PikaConf> g_pika_conf;
 
 PikaCacheLoadThread::PikaCacheLoadThread(int zset_cache_start_direction, int zset_cache_field_num_per_key)
     : should_exit_(false)
@@ -71,7 +72,7 @@ bool PikaCacheLoadThread::LoadHash(std::string& key, const std::shared_ptr<DB>& 
   db->storage()->HLen(key, &len);
   // If the Hash type contains more than 2048 data members, 
   // it will not be updated to RedisCache
-  if (0 >= len || CACHE_VALUE_ITEM_MAX_SIZE < len) {
+  if (0 >= len || g_pika_conf->max_key_size_in_cache() < len) {
     return false;
   }
 
@@ -92,7 +93,7 @@ bool PikaCacheLoadThread::LoadList(std::string& key, const std::shared_ptr<DB>& 
   db->storage()->LLen(key, &len);
   // If the List type contains more than 2048 data members, 
   // it will not be updated to RedisCache
-  if (len <= 0 || CACHE_VALUE_ITEM_MAX_SIZE < len) {
+  if (len <= 0 || g_pika_conf->max_key_size_in_cache() < len) {
     LOG(WARNING) << "can not load key, because item size:" << len
                  << " beyond max item size:" << CACHE_VALUE_ITEM_MAX_SIZE;
     return false;
@@ -115,7 +116,7 @@ bool PikaCacheLoadThread::LoadSet(std::string& key, const std::shared_ptr<DB>& d
   db->storage()->SCard(key, &len);
   // If the Set type contains more than 2048 data members, 
   // it will not be updated to RedisCache
-  if (0 >= len || CACHE_VALUE_ITEM_MAX_SIZE < len) {
+  if (0 >= len || g_pika_conf->max_key_size_in_cache() < len) {
     LOG(WARNING) << "can not load key, because item size:" << len
                  << " beyond max item size:" << CACHE_VALUE_ITEM_MAX_SIZE;
     return false;

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -7,6 +7,10 @@
 #include <glog/logging.h>
 #include <utility>
 #include <vector>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+#include <prometheus/counter.h>
+#include <prometheus/histogram.h>
 
 #include "include/pika_admin.h"
 #include "include/pika_client_conn.h"
@@ -221,19 +225,21 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   c_ptr->Execute();
 
   time_stat_->process_done_ts_ = pstd::NowMicros();
+  g_pika_cmd_table_manager->GetHistogram(opt).Observe(time_stat_->total_time() / 1000);
   auto cmdstat_map = g_pika_cmd_table_manager->GetCommandStatMap();
   (*cmdstat_map)[opt].cmd_count.fetch_add(1);
   (*cmdstat_map)[opt].cmd_time_consuming.fetch_add(time_stat_->total_time());
 
   if (g_pika_conf->slowlog_slower_than() >= 0) {
-    ProcessSlowlog(argv, c_ptr);
+    ProcessSlowlog(argv, c_ptr, opt);
   }
 
   return c_ptr;
 }
 
-void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr) {
+void PikaClientConn::ProcessSlowlog(const PikaCmdArgsType& argv, std::shared_ptr<Cmd> c_ptr, const std::string& opt) {
   if (time_stat_->total_time() > g_pika_conf->slowlog_slower_than()) {
+    g_pika_cmd_table_manager->UpdateSlowCommandCount(opt);
     g_pika_server->SlowlogPushEntry(argv, time_stat_->start_ts() / 1000000, time_stat_->total_time());
     if (g_pika_conf->slowlog_write_errorlog()) {
       bool trim = false;

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -14,9 +14,31 @@
 
 extern std::unique_ptr<PikaConf> g_pika_conf;
 
+void PikaCmdTableManager::ResetCommandCount() {
+  while (true) {
+    std::this_thread::sleep_for(std::chrono::minutes(1)); 
+    {
+      std::lock_guard<std::mutex> lock(command_mutex_);
+      slow_command_count_.clear();
+      InitHistograms(); 
+    }
+  }
+}
+
+void PikaCmdTableManager::InitHistograms() {
+  histograms_.clear();
+  prometheus_registry_ = std::make_shared<prometheus::Registry>();
+  histogram_family_ = &prometheus::BuildHistogram()
+      .Name("pika_command_duration_seconds")
+      .Help("Execution time of Pika commands in seconds")
+      .Register(*prometheus_registry_);
+}
+
 PikaCmdTableManager::PikaCmdTableManager() {
   cmds_ = std::make_unique<CmdTable>();
   cmds_->reserve(300);
+  InitHistograms();
+  reset_thread_ = std::thread(&PikaCmdTableManager::ResetCommandCount, this);
 }
 
 void PikaCmdTableManager::InitCmdTable(void) {
@@ -61,6 +83,49 @@ void PikaCmdTableManager::RenameCommand(const std::string before, const std::str
     }
     cmds_->erase(it);
   }
+}
+
+prometheus::Histogram& PikaCmdTableManager::GetHistogram(const std::string& opt) {
+  {
+    std::shared_lock<std::shared_mutex> read_lock(histograms_mutex_);
+    auto it = histograms_.find(opt);
+    if (it != histograms_.end()) {
+      return *(it->second);
+    }
+  }
+  std::unique_lock<std::shared_mutex> write_lock(histograms_mutex_);
+  auto& new_histogram = histogram_family_->Add(
+    {{"command", opt}}, 
+    prometheus::Histogram::BucketBoundaries{0.5, 1, 2, 3, 5, 7, 10, 15, 20, 30, 40, 50, 65, 75, 85, 100, 125, 140, 150, 160, 175, 185, 200, 300, 400, 500, 750, 1000, 2000, 5000, 10000}
+  );
+  histograms_[opt] = &new_histogram;
+  return new_histogram;
+}
+
+prometheus::Family<prometheus::Histogram>* PikaCmdTableManager::GetHistograms() {
+  return histogram_family_;
+}
+
+void PikaCmdTableManager::UpdateSlowCommandCount(const std::string& opt) {
+  {
+    std::shared_lock<std::shared_mutex> read_lock(slow_command_mutex_);
+    if (slow_command_count_.find(opt) != slow_command_count_.end()) {
+      slow_command_count_[opt].cmd_count.fetch_add(1);
+      return;
+    }
+  }
+
+  {
+    std::unique_lock<std::shared_mutex> write_lock(slow_command_mutex_);
+    slow_command_count_[opt]; 
+  }
+
+  slow_command_count_[opt].cmd_count.fetch_add(1);
+}
+
+std::unordered_map<std::string, CommandStatistics> PikaCmdTableManager::GetSlowCommandCount() {
+  std::shared_lock<std::shared_mutex> lock(slow_command_mutex_);
+  return slow_command_count_;
 }
 
 std::unordered_map<std::string, CommandStatistics>* PikaCmdTableManager::GetCommandStatMap() {

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -609,6 +609,15 @@ int PikaConf::Load() {
   }
   zset_cache_field_num_per_key_ = zset_cache_field_num_per_key;
 
+  int cache_value_item_max_size = DEFAULT_CACHE_ITEMS_SIZE;
+  GetConfInt("cache-value-item-max-size", &cache_value_item_max_size);
+  if (cache_value_item_max_size <= 0) {
+    cache_value_item_max_size = DEFAULT_CACHE_ITEMS_SIZE;
+  } else if (cache_value_item_max_size > MAX_CACHE_ITEMS_SIZE) {
+    cache_value_item_max_size = MAX_CACHE_ITEMS_SIZE;
+  }
+  cache_value_item_max_size_ = cache_value_item_max_size;
+
   int max_key_size_in_cache = DEFAULT_CACHE_MAX_KEY_SIZE;
   GetConfInt("max-key-size-in-cache", &max_key_size_in_cache);
   if (max_key_size_in_cache <= 0) {

--- a/tools/pika_exporter/config/info.toml
+++ b/tools/pika_exporter/config/info.toml
@@ -5,8 +5,9 @@ stats = true
 cpu = true
 replication = true
 keyspace = true
-cache = true
-
+cache = false
+commandp99 = true
+slowcommand = true
 execcount = false
 commandstats = false
 rocksdb = false

--- a/tools/pika_exporter/exporter/client.go
+++ b/tools/pika_exporter/exporter/client.go
@@ -127,6 +127,8 @@ func (c *client) InfoNoneCommandList() (string, error) {
 		"COMMAND_EXEC_COUNT": InfoConf.Execcount,
 		"COMMANDSTATS":       InfoConf.Commandstats,
 		"ROCKSDB":            InfoConf.Rocksdb,
+		"CommandP99":         InfoConf.CommandP99,
+		"SlowCommand":        InfoConf.SlowCommand,
 	}
 	for section, flag := range sectionsMap {
 		if flag {
@@ -155,6 +157,8 @@ func (c *client) InfoAllCommandList() (string, error) {
 		"COMMAND_EXEC_COUNT": InfoConf.Execcount,
 		"COMMANDSTATS":       InfoConf.Commandstats,
 		"ROCKSDB":            InfoConf.Rocksdb,
+		"CommandP99":         InfoConf.CommandP99,
+		"SlowCommand":        InfoConf.SlowCommand,
 	}
 	for section, flag := range sectionsMap {
 		if flag {

--- a/tools/pika_exporter/exporter/conf.go
+++ b/tools/pika_exporter/exporter/conf.go
@@ -21,6 +21,8 @@ type InfoConfig struct {
 	Keyspace     bool `toml:"keyspace"`
 	Execcount    bool `toml:"execcount"`
 	Commandstats bool `toml:"commandstats"`
+	CommandP99   bool `toml:"commandp99"`
+	SlowCommand  bool `toml:"slowcommand"`
 	Rocksdb      bool `toml:"rocksdb"`
 	Cache        bool `toml:"cache"`
 

--- a/tools/pika_exporter/exporter/metrics/commandp99.go
+++ b/tools/pika_exporter/exporter/metrics/commandp99.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+    "regexp"
+)
+
+func RegisterCommandP99() {
+    Register(collectCommandP99Metrics)
+}
+
+var collectCommandP99Metrics = map[string]MetricConfig{
+    "command_p99_info": {
+        Parser: &regexParser{
+            name: "command_p99_info",
+            reg: regexp.MustCompile(`Command:\s*(?P<cmd>\S+)\s*\r?\n(?:.*\r?\n)*?TP99 ms:\s*(?P<tp99>[\d.]+)\s*\r?\n.*?TP999 ms:\s*(?P<tp999>[\d.]+)\s*\r?\n.*?TP9999 ms:\s*(?P<tp9999>[\d.]+)`),
+            Parser: &normalParser{},
+        },
+        MetricMeta: MetaDatas{
+            {
+                Name:      "command_p99_latency",
+                Help:      "99th percentile latency (ms) for each Pika command",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "tp99",
+            },
+            {
+                Name:      "command_p999_latency",
+                Help:      "99.9th percentile latency (ms) for each Pika command",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "tp999",
+            },
+            {
+                Name:      "command_p9999_latency",
+                Help:      "99.99th percentile latency (ms) for each Pika command",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "tp9999",
+            },
+        },
+    },
+}

--- a/tools/pika_exporter/exporter/metrics/slowcommand.go
+++ b/tools/pika_exporter/exporter/metrics/slowcommand.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+    "regexp"
+)
+
+func RegisterSlowCommand() {
+    Register(collectSlowCommandMetrics)
+}
+
+var collectSlowCommandMetrics = map[string]MetricConfig{
+    "slow_command_info": {
+        Parser: &regexParser{
+            name: "slow_command_info",
+            reg: regexp.MustCompile(`(?P<cmd>\S+):slow_count=(?P<slow_count>\d+)`),
+            Parser: &normalParser{},
+        },
+        MetricMeta: MetaDatas{
+            {
+                Name:      "command_slow_count",
+                Help:      "Number of times each Pika command was slow",
+                Type:      metricTypeGauge,
+                Labels:    []string{LabelNameAddr, LabelNameAlias, "cmd"},
+                ValueName: "slow_count",
+            },
+        },
+    },
+}
+

--- a/tools/pika_exporter/exporter/pika.go
+++ b/tools/pika_exporter/exporter/pika.go
@@ -355,6 +355,12 @@ func (e *exporter) registerMetrics() {
 	if config.Commandstats {
 		metrics.RegisterCommandstats()
 	}
+	if config.CommandP99 {
+		metrics.RegisterCommandP99()
+	}
+	if config.SlowCommand {
+	    metrics.RegisterSlowCommand()
+	}
 	if config.Rocksdb {
 		metrics.RegisterRocksDB()
 	}


### PR DESCRIPTION
1. String 类型的 Key 可以在配置文件中的 `max-key-size-in-cache` 参数配置 RedisCache 中最大的 Key 的大小
2. Set, List, Zset 类型可以在配置文件中的 `cache-value-item-max-size` 参数配置 RedisCache 中最大元素个数