### PR TITLE
fix: Resolve core issues at runtime

### DIFF
--- a/include/pika_cmd_table_manager.h
+++ b/include/pika_cmd_table_manager.h
@@ -73,7 +73,6 @@ class PikaCmdTableManager {
   */
   std::unordered_map<std::string, CommandStatistics> cmdstat_map_;
   std::unordered_map<std::string, CommandStatistics> slow_command_count_;
-  std::mutex command_mutex_;
   std::shared_mutex histograms_mutex_;
   std::shared_mutex slow_command_mutex_;
   std::shared_ptr<prometheus::Registry> prometheus_registry_;

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -15,9 +15,15 @@
 extern std::unique_ptr<PikaConf> g_pika_conf;
 
 void PikaCmdTableManager::ResetCommandCount() {
-  std::lock_guard<std::mutex> lock(command_mutex_);
-  slow_command_count_.clear();
-  InitHistograms(); 
+  {
+    std::unique_lock<std::shared_mutex> write_lock(slow_command_mutex_); 
+    slow_command_count_.clear();
+  }
+
+  {
+    std::unique_lock<std::shared_mutex> write_lock(histograms_mutex_);
+    InitHistograms();
+  }
 }
 
 void PikaCmdTableManager::InitHistograms() {

--- a/src/pika_cmd_table_manager.cc
+++ b/src/pika_cmd_table_manager.cc
@@ -103,6 +103,7 @@ prometheus::Histogram& PikaCmdTableManager::GetHistogram(const std::string& opt)
 }
 
 prometheus::Family<prometheus::Histogram>* PikaCmdTableManager::GetHistograms() {
+  std::shared_lock<std::shared_mutex> read_lock(histograms_mutex_); 
   return histogram_family_;
 }
 


### PR DESCRIPTION
在 GetHistogram () 方法中的  histogram_family_->Add 这里会出现 core dump，因为 histogram_family_ 会每分钟重置一次，由于在重置的时候没有对 histogram_family_ 有上锁的操作，这里会产生在调用 Add 的情况下 histogram_family_ 是空指针导致进程崩溃
```cpp

prometheus::Histogram& PikaCmdTableManager::GetHistogram(const std::string& opt) {
  {
    std::shared_lock<std::shared_mutex> read_lock(histograms_mutex_);
    auto it = histograms_.find(opt);
    if (it != histograms_.end()) {
      return *(it->second);
    }
  }
  std::unique_lock<std::shared_mutex> write_lock(histograms_mutex_);
  auto& new_histogram = histogram_family_->Add(  // 这里可能会产生崩溃
    {{"command", opt}}, 
    prometheus::Histogram::BucketBoundaries{0.5, 1, 2, 3, 5, 7, 10, 15, 20, 30, 40, 50, 65, 75, 85, 100, 125, 140, 150, 160, 175, 185, 200, 300, 400, 500, 750, 1000, 2000, 5000, 10000}
  );
  histograms_[opt] = &new_histogram; // 这里可能会产生崩溃
  return new_histogram;
}

prometheus::Family<prometheus::Histogram>* PikaCmdTableManager::GetHistograms() {
  std::shared_lock<std::shared_mutex> read_lock(histograms_mutex_);  // 增加了读锁保护 histogram_family_
  return histogram_family_;
}
```

在修复后，新增加了在重置 `histogram_family_` 上了一个互斥锁进行保护
```cpp
void PikaCmdTableManager::ResetCommandCount() {
  {
    std::unique_lock<std::shared_mutex> write_lock(slow_command_mutex_); 
    slow_command_count_.clear();
  }

  {
    std::unique_lock<std::shared_mutex> write_lock(histograms_mutex_); // 在重置的时候新加的互斥锁保护 histogram_family_ 是线程安全的  
    InitHistograms();                
  }
}

void PikaCmdTableManager::InitHistograms() {
  histograms_.clear();
  prometheus_registry_ = std::make_shared<prometheus::Registry>();
  histogram_family_ = &prometheus::BuildHistogram()
      .Name("pika_command_duration_seconds")
      .Help("Execution time of Pika commands in seconds")
      .Register(*prometheus_registry_);
}

PikaCmdTableManager::PikaCmdTableManager() {
  cmds_ = std::make_unique<CmdTable>();
  cmds_->reserve(300);
  InitHistograms();
}
```