### PR TITLE
fix: Fixed version information for Pika, Pika_exporter, Codis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,7 +737,7 @@ aux_source_directory(src DIR_SRCS)
 
 # # generate version
 string(TIMESTAMP TS "%Y-%m-%d %H:%M:%S" UTC)
-set(PIKA_BUILD_DATE "${TS}" CACHE STRING "the time we first built pika")
+set(PIKA_BUILD_DATE "${TS}")
 
 find_package(Git)
 

--- a/codis/Makefile
+++ b/codis/Makefile
@@ -2,14 +2,13 @@
 
 export GO111MODULE=on
 
-build-all: codis-dashboard codis-proxy codis-admin codis-ha codis-fe
+build-all: codis-dashboard codis-proxy codis-admin codis-ha codis-fe generate-version
 
 PRJ_ROOT=${CURDIR}
 
 
 codis-deps:
 	@mkdir -p ./bin && go version
-
 codis-dashboard: codis-deps
 	$(info build codis-dashboard)
 	@cd ${PRJ_ROOT}/cmd/dashboard && go mod tidy && go build -buildvcs=false -o ${PRJ_ROOT}/bin/codis-dashboard .
@@ -32,6 +31,10 @@ codis-fe: codis-deps
 	$(info build codis-fe)
 	@cd ${PRJ_ROOT}/cmd/fe && go mod tidy && go build -buildvcs=false -o ${PRJ_ROOT}/bin/codis-fe .
 	@rm -rf ${PRJ_ROOT}/bin/assets && cp -rf ${PRJ_ROOT}/cmd/fe/assets ./bin/
+
+generate-version:
+	$(info generate version)
+	@./version
 
 clean:
 	$(info ...Clean Start!)

--- a/tools/pika_exporter/Makefile
+++ b/tools/pika_exporter/Makefile
@@ -4,10 +4,6 @@
 
 # export PATH := $(PATH):$(GOPATH)/bin
 
-# for mac
-BRANCH			:= $(shell git branch | sed -n 's/* \(.*\)/\1/p')
-# for Linux
-# BRANCH			:= $(shell git branch | sed --quiet 's/* \(.*\)/\1/p')
 GITREV 			:= $(shell git rev-parse HEAD)
 BUILDTIME 		:= $(shell date '+%F %T %Z')
 COMPILERVERSION	:= $(subst go version ,,$(shell go version))

--- a/tools/pika_exporter/Makefile
+++ b/tools/pika_exporter/Makefile
@@ -5,10 +5,10 @@
 # export PATH := $(PATH):$(GOPATH)/bin
 
 # for mac
-BRANCH			:= $(shell git branch | sed  's/* \(.*\)/\1/p')
+BRANCH			:= $(shell git branch | sed -n 's/* \(.*\)/\1/p')
 # for Linux
 # BRANCH			:= $(shell git branch | sed --quiet 's/* \(.*\)/\1/p')
-GITREV 			:= $(shell git rev-parse --short HEAD)
+GITREV 			:= $(shell git rev-parse HEAD)
 BUILDTIME 		:= $(shell date '+%F %T %Z')
 COMPILERVERSION	:= $(subst go version ,,$(shell go version))
 PROJNAME        := pika_exporter

--- a/tools/pika_exporter/main.go
+++ b/tools/pika_exporter/main.go
@@ -55,7 +55,10 @@ func getEnvInt(key string, defaultVal int) int {
 func main() {
 	flag.Parse()
 
-	log.Println("Pika Metrics Exporter ", BuildVersion, "build date:", BuildDate, "sha:", BuildCommitSha, "go version:", GoVersion)
+	log.Println("Pika Metrics Exporter")
+    log.Println("Build Date: ", BuildDate)
+    log.Println("Commit SHA: ", BuildCommitSha)
+    log.Println("Go Version: ", GoVersion)
 	if *showVersion {
 		return
 	}

--- a/tools/pika_exporter/main.go
+++ b/tools/pika_exporter/main.go
@@ -56,9 +56,9 @@ func main() {
 	flag.Parse()
 
 	log.Println("Pika Metrics Exporter")
-    log.Println("Build Date: ", BuildDate)
-    log.Println("Commit SHA: ", BuildCommitSha)
-    log.Println("Go Version: ", GoVersion)
+	log.Println("Build Date: ", BuildDate)
+	log.Println("Commit SHA: ", BuildCommitSha)
+	log.Println("Go Version: ", GoVersion)
 	if *showVersion {
 		return
 	}


### PR DESCRIPTION
1. 对 Codis 的修改
```bash
[mixficsol@Mixficsol bin (dev ✗)]$ ./codis-dashboard --version
version: 2025-03-20 11:08:52 +0800 @05d1c37518abb8736e103612bef6999f3bda4318 @v3.5.5-56-g05d1c375
compile: 2025-03-20 15:25:25 +0800 by go version go1.23.4 darwin/amd64
[mixficsol@Mixficsol bin (dev ✗)]$ ./codis-proxy --version    
version: 2025-03-20 11:08:52 +0800 @05d1c37518abb8736e103612bef6999f3bda4318 @v3.5.5-56-g05d1c375
compile: 2025-03-20 15:25:25 +0800 by go version go1.23.4 darwin/amd64
[mixficsol@Mixficsol bin (dev ✗)]$ ./codis-fe --version   
version: 2025-03-20 11:08:52 +0800 @05d1c37518abb8736e103612bef6999f3bda4318 @v3.5.5-56-g05d1c375
compile: 2025-03-20 15:25:25 +0800 by go version go1.23.4 darwin/amd64
```
2. 对 Pika 的修改 (由于 Pika 之前 pika_build_compile_date 记录的时间是 Cmake 构造时的时间，现在改为了 Make 时候的时间，但是由于使用 UTC 时间标准时间，比北京时间默认少 8 个小时
```bash
[mixficsol@Mixficsol local_pika (dev ✗)]$ ./output/pika -v
-----------Pika server----------
pika_version: 3.5.5
pika_git_sha:05d1c37518abb8736e103612bef6999f3bda4318
pika_build_compile_date: 2025-03-20 08:20:38
redis_version: 3.5.5
```
3. 对 Pika_exporter 的修改
```bash
[mixficsol@Mixficsol pika_exporter (dev ✗)]$ ./bin/pika_exporter -version
INFO[0000] Pika Metrics Exporter                        
INFO[0000] Build Date:  2025-03-20 15:41:23 CST         
INFO[0000] Commit SHA:  05d1c37518abb8736e103612bef6999f3bda4318 
INFO[0000] Go Version:  go1.23.4 darwin/amd64    
```