### PR TITLE
fix: Fixed versions of Pika, Pika_exporter, Codis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,7 +736,7 @@ endif()
 aux_source_directory(src DIR_SRCS)
 
 # # generate version
-string(TIMESTAMP TS "%Y-%m-%d %H:%M:%S" UTC)
+string(TIMESTAMP TS "%Y-%m-%d %H:%M:%S")
 set(PIKA_BUILD_DATE "${TS}")
 
 find_package(Git)

--- a/codis/Makefile
+++ b/codis/Makefile
@@ -2,13 +2,16 @@
 
 export GO111MODULE=on
 
-build-all: codis-dashboard codis-proxy codis-admin codis-ha codis-fe generate-version
+build-all: generate-version codis-dashboard codis-proxy codis-admin codis-ha codis-fe
 
 PRJ_ROOT=${CURDIR}
 
+generate-version:
+	$(info generate version)
+	@mkdir -p ./bin && ./version
 
 codis-deps:
-	@mkdir -p ./bin && go version
+	@go version
 codis-dashboard: codis-deps
 	$(info build codis-dashboard)
 	@cd ${PRJ_ROOT}/cmd/dashboard && go mod tidy && go build -buildvcs=false -o ${PRJ_ROOT}/bin/codis-dashboard .
@@ -31,10 +34,6 @@ codis-fe: codis-deps
 	$(info build codis-fe)
 	@cd ${PRJ_ROOT}/cmd/fe && go mod tidy && go build -buildvcs=false -o ${PRJ_ROOT}/bin/codis-fe .
 	@rm -rf ${PRJ_ROOT}/bin/assets && cp -rf ${PRJ_ROOT}/cmd/fe/assets ./bin/
-
-generate-version:
-	$(info generate version)
-	@./version
 
 clean:
 	$(info ...Clean Start!)

--- a/codis/cmd/dashboard/main.go
+++ b/codis/cmd/dashboard/main.go
@@ -48,8 +48,11 @@ Options:
 		return
 
 	case d["--version"].(bool):
-		fmt.Println("version:", utils.Version)
-		fmt.Println("compile:", utils.Compile)
+		fmt.Printf("-----------Codis Dashboard----------\n")
+		fmt.Println("codis_version:", utils.Version)
+		fmt.Println("codis_git_sha:", utils.Gitsha)
+		fmt.Println("codis_build_compile_date:", utils.Compile)
+		fmt.Println("go version:", utils.GoVersion)
 		return
 
 	}

--- a/codis/cmd/fe/main.go
+++ b/codis/cmd/fe/main.go
@@ -72,8 +72,11 @@ Options:
 	}
 
 	if d["--version"].(bool) {
-		fmt.Println("version:", utils.Version)
-		fmt.Println("compile:", utils.Compile)
+		fmt.Printf("-----------Codis FE----------\n")
+		fmt.Println("codis_version:", utils.Version)
+		fmt.Println("codis_git_sha:", utils.Gitsha)
+		fmt.Println("codis_build_compile_date:", utils.Compile)
+		fmt.Println("go version:", utils.GoVersion)
 		return
 	}
 

--- a/codis/cmd/ha/main.go
+++ b/codis/cmd/ha/main.go
@@ -33,8 +33,11 @@ Options:
 	}
 
 	if d["--version"].(bool) {
-		fmt.Println("version:", utils.Version)
-		fmt.Println("compile:", utils.Compile)
+		fmt.Printf("-----------Codis HA----------\n")
+		fmt.Println("codis_version:", utils.Version)
+		fmt.Println("codis_git_sha:", utils.Gitsha)
+		fmt.Println("codis_build_compile_date:", utils.Compile)
+		fmt.Println("go version:", utils.GoVersion)
 		return
 	}
 

--- a/codis/cmd/proxy/main.go
+++ b/codis/cmd/proxy/main.go
@@ -55,8 +55,11 @@ Options:
 		return
 
 	case d["--version"].(bool):
-		fmt.Println("version:", utils.Version)
-		fmt.Println("compile:", utils.Compile)
+		fmt.Printf("-----------Codis Proxy----------\n")
+		fmt.Println("codis_version:", utils.Version)
+		fmt.Println("codis_git_sha:", utils.Gitsha)
+		fmt.Println("codis_build_compile_date:", utils.Compile)
+		fmt.Println("go version:", utils.GoVersion)
 		return
 
 	}

--- a/codis/pkg/utils/version.go
+++ b/codis/pkg/utils/version.go
@@ -1,6 +1,8 @@
 package utils
 
 const (
-	Version = "2018-11-04 16:22:35 +0800 @de1ad026e329561c22e2a3035fbfe89dc7fef764 @3.2.2-12-gde1ad026"
-	Compile = "2023-02-23 11:25:09 +0800 by go version go1.19.6 linux/amd64"
+	Version   = "3.5.4"
+	Gitsha    = "61a9b5a6737759459a50684b8c018338ebe5808e"
+	Compile   = "2025-03-21 17:26:57 CST"
+	GoVersion = "go1.23.4 darwin/amd64"
 )

--- a/codis/version
+++ b/codis/version
@@ -1,30 +1,36 @@
 #!/bin/bash
 
-version=`git log --date=iso --pretty=format:"%cd @%H" -1`
+CODIS_MAJOR=3
+CODIS_MINOR=5
+CODIS_PATCH=4
+
+gitsha=`git log --pretty=format:"%H" -1`
 if [ $? -ne 0 ]; then
-    version="unknown version"
+    gitsha="unknown git log"
 fi
 
-compile=`date +"%F %T %z"`" by "`go version`
+compile=`date +"%F %T %Z"`
 if [ $? -ne 0 ]; then
     compile="unknown datetime"
 fi
 
-describe=`git describe --tags 2>/dev/null`
-if [ $? -eq 0 ]; then
-    version="${version} @${describe}"
+goversion=$(go version | sed 's/go version //')
+if [ $? -ne 0 ]; then
+    compile="unknown go version"
 fi
 
 cat << EOF | gofmt > pkg/utils/version.go
 package utils
 
 const (
-    Version = "$version"
+    Version   = "$CODIS_MAJOR.$CODIS_MINOR.$CODIS_PATCH"
+    Gitsha = "$gitsha"
     Compile = "$compile"
+    GoVersion = "$goversion"
 )
 EOF
 
 cat << EOF > bin/version
-version = $version
+gitsha = $gitsha
 compile = $compile
 EOF

--- a/tools/pika_exporter/Makefile
+++ b/tools/pika_exporter/Makefile
@@ -10,7 +10,7 @@ COMPILERVERSION	:= $(subst go version ,,$(shell go version))
 PROJNAME        := pika_exporter
 PIKA_EXPORTER_MAJOR := 3
 PIKA_EXPORTER_MINOR := 5
-PIKA_EXPORTER_PATCH := 4
+PIKA_EXPORTER_PATCH := 5
 
 define GENERATE_VERSION_CODE
 cat << EOF | gofmt > version.go

--- a/tools/pika_exporter/Makefile
+++ b/tools/pika_exporter/Makefile
@@ -3,17 +3,21 @@
 # endif
 
 # export PATH := $(PATH):$(GOPATH)/bin
-
+BRANCH			:= $(shell git branch | sed -n 's/* \(.*\)/\1/p')
 GITREV 			:= $(shell git rev-parse HEAD)
 BUILDTIME 		:= $(shell date '+%F %T %Z')
 COMPILERVERSION	:= $(subst go version ,,$(shell go version))
 PROJNAME        := pika_exporter
+PIKA_EXPORTER_MAJOR := 3
+PIKA_EXPORTER_MINOR := 5
+PIKA_EXPORTER_PATCH := 4
 
 define GENERATE_VERSION_CODE
 cat << EOF | gofmt > version.go
 package main
 
 const (
+	PikaExporterVersion = "$(PIKA_EXPORTER_MAJOR).$(PIKA_EXPORTER_MINOR).$(PIKA_EXPORTER_PATCH)"
 	BuildVersion   = "$(BRANCH)"
     BuildCommitSha = "$(GITREV)"
     BuildDate      = "$(BUILDTIME)"

--- a/tools/pika_exporter/main.go
+++ b/tools/pika_exporter/main.go
@@ -56,6 +56,7 @@ func main() {
 	flag.Parse()
 
 	log.Println("Pika Metrics Exporter")
+	log.Println("Pika Exporter Version: ", PikaExporterVersion)
 	log.Println("Build Date: ", BuildDate)
 	log.Println("Commit SHA: ", BuildCommitSha)
 	log.Println("Go Version: ", GoVersion)

--- a/tools/pika_exporter/version.go
+++ b/tools/pika_exporter/version.go
@@ -1,9 +1,8 @@
 package main
 
 const (
-	PikaExporterVersion = "3.5.4"
-	BuildVersion        = "fix_codis"
-	BuildCommitSha      = "61a9b5a6737759459a50684b8c018338ebe5808e"
-	BuildDate           = "2025-03-21 17:15:41 CST"
-	GoVersion           = "go1.23.4 darwin/amd64"
+	BuildVersion   = "Filled in by build"
+	BuildCommitSha = "Filled in by build"
+	BuildDate      = "Filled in by build"
+	GoVersion      = "Filled in by build"
 )

--- a/tools/pika_exporter/version.go
+++ b/tools/pika_exporter/version.go
@@ -1,8 +1,9 @@
 package main
 
 const (
-	BuildVersion   = "Filled in by build"
-	BuildCommitSha = "Filled in by build"
-	BuildDate      = "Filled in by build"
-	GoVersion      = "Filled in by build"
+	PikaExporterVersion = "3.5.4"
+	BuildVersion        = "fix_codis"
+	BuildCommitSha      = "61a9b5a6737759459a50684b8c018338ebe5808e"
+	BuildDate           = "2025-03-21 17:15:41 CST"
+	GoVersion           = "go1.23.4 darwin/amd64"
 )


### PR DESCRIPTION
1. 将 Pika 的编译时间由全球时区改为本地时区
```cpp
string(TIMESTAMP TS "%Y-%m-%d %H:%M:%S")
```
2. 修改 Version 信息
```cpp
[mixficsol@Mixficsol codis (fix_codis ✗)]$ ./bin/codis-dashboard --version
-----------Codis Dashboard----------
codis_version: 3.5.4
codis_git_sha: 61a9b5a6737759459a50684b8c018338ebe5808e
codis_build_compile_date: 2025-03-21 17:26:57 CST
go version: go1.23.4 darwin/amd64

[mixficsol@Mixficsol codis (fix_codis ✗)]$ ./bin/codis-proxy --version
-----------Codis Proxy----------
codis_version: 3.5.4
codis_git_sha: 61a9b5a6737759459a50684b8c018338ebe5808e
codis_build_compile_date: 2025-03-21 17:26:57 CST
go version: go1.23.4 darwin/amd64
[mixficsol@Mixficsol codis (fix_codis ✗)]$ ./bin/codis-fe --version
-----------Codis FE----------
codis_version: 3.5.4
codis_git_sha: 61a9b5a6737759459a50684b8c018338ebe5808e
codis_build_compile_date: 2025-03-21 17:26:57 CST
go version: go1.23.4 darwin/amd64
[mixficsol@Mixficsol codis (fix_codis ✗)]$ ./bin/codis-ha --version
-----------Codis HA----------
codis_version: 3.5.4
codis_git_sha: 61a9b5a6737759459a50684b8c018338ebe5808e
codis_build_compile_date: 2025-03-21 17:26:57 CST
go version: go1.23.4 darwin/amd64

[mixficsol@Mixficsol pika_exporter (fix_codis ✗)]$ ./bin/pika_exporter --version
INFO[0000] Pika Metrics Exporter                        
INFO[0000] Pika Exporter Version:  3.5.5      
INFO[0000] Build Date:  2025-03-21 17:15:41 CST         
INFO[0000] Commit SHA:  61a9b5a6737759459a50684b8c018338ebe5808e 
INFO[0000] Go Version:  go1.23.4 darwin/amd64    

[mixficsol@Mixficsol local_pika (fix_codis ✗)]$ ./output/pika -v
-----------Pika server----------
pika_version: 3.5.5
pika_git_sha:61a9b5a6737759459a50684b8c018338ebe5808e
pika_build_compile_date: 2025-03-21 17:07:00
redis_version: 3.5.5
```