### PR TITLE
fix: fix ci

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Cleanup
         run: |
-          rm -rf  ./deps
           rm -rf ./buildtrees
 
       - uses: actions/upload-artifact@v4
@@ -194,7 +193,6 @@ jobs:
 
       - name: Cleanup
         run: |
-          rm -rf  ./deps
           rm -rf ./buildtrees
 
       - name: Test
@@ -258,8 +256,7 @@ jobs:
         run: |
           cp deps/lib/libz.1.dylib .
           cp deps/lib/libz.1.dylib tests/integration/
-          rm -rf ./deps 
-          rm -rf ./buildtree
+          rm -rf ./buildtrees
 
       - name: Unit Test
         working-directory: ${{ github.workspace }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ ExternalProject_Add(gtest
   LOG_INSTALL
   1
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   BUILD_ALWAYS
@@ -191,6 +193,8 @@ ExternalProject_Add(gflags
   BUILD_ALWAYS
   1
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   -DGFLAGS_NAMESPACE=gflags
@@ -265,6 +269,8 @@ ExternalProject_Add(glog
   BUILD_ALWAYS
   1
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   -DWITH_GFLAGS=ON
@@ -306,6 +312,8 @@ ExternalProject_Add(snappy
   LOG_INSTALL
   1
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   -DSNAPPY_BUILD_TESTS=OFF
@@ -344,6 +352,8 @@ ExternalProject_Add(zstd
   SOURCE_SUBDIR
   build/cmake
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   -DBUILD_TESTING=OFF
@@ -380,6 +390,8 @@ ExternalProject_Add(fmt
   LOG_INSTALL
   1
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   BUILD_ALWAYS
@@ -421,6 +433,8 @@ ExternalProject_Add(lz4
   SOURCE_SUBDIR
   build/cmake
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   -DBUILD_TESTING=OFF
@@ -457,6 +471,8 @@ ExternalProject_Add(zlib
   LOG_INSTALL
   1
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   -DZLIB_USE_STATIC_LIBS=ON
@@ -488,6 +504,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     LOG_INSTALL
     1
     CMAKE_ARGS
+    # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
     -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
     -DGPERFTOOLS_BUILD_STATIC=ON
@@ -556,6 +574,8 @@ ExternalProject_Add(protobuf
   SOURCE_SUBDIR
   cmake
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
   -DBUILD_SHARED_LIBS=FALSE
@@ -605,6 +625,8 @@ ExternalProject_Add(rocksdb
   BUILD_ALWAYS
   1
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
   -DCMAKE_BUILD_TYPE=${LIB_BUILD_TYPE}
@@ -646,6 +668,8 @@ ExternalProject_Add(rediscache
   SOURCE_SUBDIR
   ""
   CMAKE_ARGS
+  # Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
   -DCMAKE_INSTALL_INCLUDEDIR=${INSTALL_INCLUDEDIR}
   -DCMAKE_INSTALL_LIBDIR=${INSTALL_LIBDIR}


### PR DESCRIPTION
Force CMake to run with the policy behavior of version 3.5 to avoid cases where a higher version of CMake does not compile