### PR TITLE
fix: connections overflow when command processing takes too long and clients close connection

### DIFF
--- a/src/net/include/net_define.h
+++ b/src/net/include/net_define.h
@@ -48,7 +48,8 @@ enum EventStatus {
   kNone = 0,
   kReadable = 0x1,
   kWritable = 0x1 << 1,
-  kErrorEvent = 0x1 << 2,
+  kPeerClose = 0x1 << 2,
+  kErrorEvent = 0x1 << 3,
 };
 
 enum ConnStatus {

--- a/src/net/src/net_epoll.cc
+++ b/src/net/src/net_epoll.cc
@@ -14,6 +14,10 @@
 #include "net/include/net_define.h"
 #include "pstd/include/xdebug.h"
 
+#ifndef EPOLLRDHUP
+#define EPOLLRDHUP 0x2000
+#endif
+
 namespace net {
 
 NetMultiplexer* CreateNetMultiplexer(int limit) { return new NetEpoll(limit); }
@@ -45,7 +49,7 @@ int NetEpoll::NetAddEvent(int fd, int mask) {
   }
   if (mask & kWritable) {
     ee.events |= EPOLLOUT;
-    }
+  }
 
   return epoll_ctl(multiplexer_, EPOLL_CTL_ADD, fd, &ee);
 }
@@ -61,6 +65,10 @@ int NetEpoll::NetModEvent(int fd, int old_mask, int mask) {
   }
   if ((old_mask | mask) & kWritable) {
     ee.events |= EPOLLOUT;
+  }
+
+  if ((old_mask | mask) & kPeerClose) {
+    ee.events |= EPOLLRDHUP;
   }
   return epoll_ctl(multiplexer_, EPOLL_CTL_MOD, fd, &ee);
 }
@@ -91,6 +99,10 @@ int NetEpoll::NetPoll(int timeout) {
 
     if (events_[i].events & EPOLLOUT) {
       ev.mask |= kWritable;
+    }
+
+    if (events_[i].events & EPOLLRDHUP) {
+      ev.mask |= kPeerClose;
     }
 
     if (events_[i].events & (EPOLLERR | EPOLLHUP)) {

--- a/src/net/src/worker_thread.cc
+++ b/src/net/src/worker_thread.cc
@@ -189,7 +189,7 @@ void* WorkerThread::ThreadMain() {
           ReadStatus read_status = in_conn->GetRequest();
           in_conn->set_last_interaction(now);
           if (read_status == kReadAll) {
-            net_multiplexer_->NetModEvent(pfe->fd, 0, 0);
+            net_multiplexer_->NetModEvent(pfe->fd, 0, kPeerClose);
             // Wait for the conn complete asynchronous task and
             // Mod Event to kWritable
           } else if (read_status == kReadHalf) {
@@ -199,8 +199,15 @@ void* WorkerThread::ThreadMain() {
           }
         }
 
+        if ((should_close == 0) && ((pfe->mask & kPeerClose) != 0)) {
+          should_close = 1;
+        }
+
         if (((pfe->mask & kErrorEvent) != 0) || (should_close != 0)) {
           net_multiplexer_->NetDelEvent(pfe->fd, 0);
+          // TODO: in_conn may live longer than fd.
+          // eg. in_conn are being transferred to net_pubsub
+          // while peer client closing this connection
           CloseFd(in_conn);
           in_conn = nullptr;
           {

--- a/tests/integration/pubsub_test.go
+++ b/tests/integration/pubsub_test.go
@@ -39,7 +39,10 @@ var _ = Describe("PubSub", func() {
 
 	It("implements Stringer", func() {
 		pubsub := client.PSubscribe(ctx, "mychannel*")
-		defer pubsub.Close()
+		defer func() {
+                    time.Sleep(100 * time.Millisecond)
+                    pubsub.Close()
+                }()
 
 		Expect(pubsub.String()).To(Equal("PubSub(mychannel*)"))
 	})


### PR DESCRIPTION
pika服务端在收到一个完整的redis请求之后会关闭可读事件的唤醒。
特殊情况下，比如存量数据很多，用户使用了scan接口导致请求在服务端处理耗时达到了几十秒，此时如果用户代码中设置了超时，那么连接会被客户端关闭，但服务端直到命令处理完才会再次注册connfd相关事件，所以导致服务端积累了大量的close_wait连接，最终可能会达到pika设定的连接数上线从而停止接收新的建连请求。