### PR TITLE
fix: when enable rate limiter auto tune, bandwidth should be higher a…

### DIFF
--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -422,6 +422,10 @@ int PikaConf::Load() {
   std::string at;
   GetConfStr("rate-limiter-auto-tuned", &at);
   rate_limiter_auto_tuned_ = at == "yes" || at.empty();
+  // if rate limiter autotune enable, `rate_limiter_bandwidth_` will still be respected as an upper-bound.
+  if (rate_limiter_auto_tuned_) {
+    rate_limiter_bandwidth_ = 10 * 1024 * 1024 * 1024; // 10GB/s
+  }
 
   // max_write_buffer_num
   max_write_buffer_num_ = 2;


### PR DESCRIPTION
…s upper bound. fix #3084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When rate limiter autotuning is enabled, bandwidth is now automatically set to 10 GB/s.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->