### PR TITLE
fix: Divide the auth command into the command thread pool in pipeling mode

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -305,6 +305,13 @@ void PikaClientConn::ProcessRedisCmds(const std::vector<net::RedisCmdArgsType>& 
     bool is_slow_cmd = g_pika_conf->is_slow_cmd(opt);
     bool is_admin_cmd = g_pika_conf->is_admin_cmd(opt);
 
+
+    // Special handling for auth command in pipeline
+    if (is_admin_cmd && opt == kCmdNameAuth && argvs.size() > 1) {
+      // This is a pipeline with auth as first command
+      // Force it to use client processor pool
+      is_admin_cmd = false;
+    }
     // we don't intercept pipeline batch (argvs.size() > 1)
     if (g_pika_conf->rtc_cache_read_enabled() && argvs.size() == 1 && IsInterceptedByRTC(opt) &&
         PIKA_CACHE_NONE != g_pika_conf->cache_mode() && !IsInTxn()) {


### PR DESCRIPTION
在 pipeling模式下将 auth 命令和后续在 Pipeline 中的命令划分到命令线程池

测试方法：
将 Pika 配置文件中的 admin-pool-size 设置成 1 个，然后执行以下压测命令
```bash
 redis-benchmark -t set -p 9221 -n 2 -P 2 -a 123360
```

可以发现在 Pipeling 模式下的命令会被成功划分到命令线程池，而不是管理命令线程池 (PID 73583)
<img width="2056" alt="截屏2025-06-09 11 12 04" src="https://github.com/user-attachments/assets/abadd935-0f1f-4e12-8a92-b6a83a14726e" />
