### PR TITLE
fix: After connecting to Pika via telnet and pressing Enter, it causes Pika core dump

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -288,6 +288,10 @@ bool PikaClientConn::IsInterceptedByRTC(std::string& opt) {
 void PikaClientConn::ProcessRedisCmds(const std::vector<net::RedisCmdArgsType>& argvs, bool async,
                                       std::string* response) {
   time_stat_->Reset();
+  if (argvs.empty()) {
+    NotifyEpoll(true);
+    return;
+  }
   if (async) {
     auto arg = new BgTaskArg();
     arg->cache_miss_in_rtc_ = false;


### PR DESCRIPTION
使用 telnet 连上 Pika 之后直接回车，会让 Pika 接受到一个 "\r\n" 的包，最终会导致 Pika Core 在了 std::string opt = argvs[0][0]; 这里，PR 增加了对空命令包判断，测试后发现没有之前 core 的问题
#3095
