### PR TITLE
fix: Specia Redis directives can cause pika service to crash

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -90,6 +90,11 @@ db-path : ./db/
 # Supported Units [K|M|G], write-buffer-size default unit is in [bytes].
 write-buffer-size : 256M
 
+# The maximum size of a single bulk string in Pika protocol.
+# This value is used to limit the size of a single bulk string in Pika protocol.
+# The default value is 512M.
+proto-max-bulk-len : 512M
+
 # The size of one block in arena memory allocation.
 # If <= 0, a proper value is automatically calculated.
 # (usually 1/8 of writer-buffer-size, rounded up to a multiple of 4KB)

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -862,6 +862,11 @@ class PikaConf : public pstd::BaseConf {
     TryPushDiffCommands("rsync-timeout-ms", std::to_string(value));
     rsync_timeout_ms_.store(value);
   }
+  void SetProtoMaxBulkLen(const int64_t value) {
+    std::lock_guard l(rwlock_);
+    TryPushDiffCommands("proto-max-bulk-len", std::to_string(value));
+    proto_max_bulk_len_ = value;
+  }
 
   int RocksDBPerfLevel() const {
     return rocksdb_perf_level_.load();

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -167,6 +167,10 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return write_buffer_size_;
   }
+  int64_t proto_max_bulk_len() {
+    std::shared_lock l(rwlock_);
+    return proto_max_bulk_len_;
+  }
   int min_write_buffer_number_to_merge() {
     std::shared_lock l(rwlock_);
     return min_write_buffer_number_to_merge_;
@@ -1035,6 +1039,7 @@ class PikaConf : public pstd::BaseConf {
   int64_t least_free_disk_to_resume_ = 268435456; // 256 MB
   double min_check_resume_ratio_ = 0.7;
   int64_t write_buffer_size_ = 0;
+  int64_t proto_max_bulk_len_ = 0;
   int64_t arena_block_size_ = 0;
   int64_t slotmigrate_thread_num_ = 0;
   int64_t thread_migrate_keys_num_ = 0;

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -364,12 +364,46 @@ Status PikaCache::Appendxx(std::string& key, std::string &value) {
   return Status::NotFound("key not exist");
 }
 
+// Status PikaCache::GetRange(std::string& key, int64_t start, int64_t end, std::string *value) {
+//   int cache_index = CacheIndex(key);
+//   std::lock_guard lm(*cache_mutexs_[cache_index]);
+//   return caches_[cache_index]->GetRange(key, start, end, value);
+// }
+
+//6.9号新增
 Status PikaCache::GetRange(std::string& key, int64_t start, int64_t end, std::string *value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  return caches_[cache_index]->GetRange(key, start, end, value);
-}
 
+  std::string full_value;
+  auto s = caches_[cache_index]->Get(key, &full_value);
+  if (!s.ok()) {
+    return s;
+  }
+  int64_t strlen = full_value.size();
+  
+  if (start < 0) {
+    start = strlen + start;
+  }
+  if (end < 0) {
+    end = strlen + end;
+  }
+  
+  if (start < 0) start = 0;
+  if (end < 0) {
+    value->clear();
+    return Status::OK();
+  }
+  if (end >= strlen) end = strlen - 1;
+  
+  if (start > end) {
+    value->clear();
+    return Status::OK();
+  }
+  
+  *value = full_value.substr(start, end - start + 1);
+  return Status::OK();
+}
 Status PikaCache::SetRangeIfKeyExist(std::string& key, int64_t start, std::string &value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -388,13 +388,10 @@ Status PikaCache::GetRange(std::string& key, int64_t start, int64_t end, std::st
   }
   
   if (start < 0) start = 0;
-  if (end < 0) {
-    value->clear();
-    return Status::OK();
-  }
+  if (end < 0) end = 0;
   if (end >= strlen) end = strlen - 1;
-  
-  if (start > end) {
+
+  if (start > end || strlen == 0) {
     value->clear();
     return Status::OK();
   }

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -364,13 +364,11 @@ Status PikaCache::Appendxx(std::string& key, std::string &value) {
   return Status::NotFound("key not exist");
 }
 
-// Status PikaCache::GetRange(std::string& key, int64_t start, int64_t end, std::string *value) {
-//   int cache_index = CacheIndex(key);
-//   std::lock_guard lm(*cache_mutexs_[cache_index]);
-//   return caches_[cache_index]->GetRange(key, start, end, value);
-// }
-
-//6.9号新增
+/*
+  Added boundary checks for start and end parameters to the PikaCache::GetRange function,
+  and used the full_value variable to store the actual length of string type, 
+  avoiding excessive memory allocation by sdsnewlen.
+*/
 Status PikaCache::GetRange(std::string& key, int64_t start, int64_t end, std::string *value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -366,7 +366,10 @@ int PikaConf::Load() {
   if (write_buffer_size_ <= 0) {
     write_buffer_size_ = 268435456;  // 256Mb
   }
-
+  GetConfInt64Human("proto-max-bulk-len", &proto_max_bulk_len_);
+  if (proto_max_bulk_len_ <= 0) {
+    proto_max_bulk_len_ = 512 * 1024 * 1024;  // 512MB
+  }
   GetConfInt("level0-stop-writes-trigger", &level0_stop_writes_trigger_);
   if (level0_stop_writes_trigger_ < 36) {
     level0_stop_writes_trigger_ = 36;

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1140,15 +1140,6 @@ void GetrangeCmd::DoInitial() {
     res_.SetRes(CmdRes::kInvalidInt);
     return;
   }
-  //6.6号新增
-  // 添加最大值限制
-  // const int64_t MAX_RANGE_SIZE = 512 * 1024 * 1024; // 512MB
-  // if (start_ < -MAX_RANGE_SIZE || start_ > MAX_RANGE_SIZE ||
-  //   end_ < -MAX_RANGE_SIZE || end_ > MAX_RANGE_SIZE) {
-  //   res_.SetRes(CmdRes::kInvalidInt, "Range index out of bounds");
-  //   return;
-  // }
-
 }
 
 void GetrangeCmd::Do() {
@@ -1157,13 +1148,6 @@ void GetrangeCmd::Do() {
   s_= db_->storage()->Getrange(key_, start_, end_, &substr);
   
   if (s_.ok() || s_.IsNotFound()) {
-    //6.9号新增的
-    const size_t MAX_RESPONSE_SIZE = 100 * 1024 * 1024; //100MB
-    if (substr.size() > MAX_RESPONSE_SIZE) {
-      substr.resize(MAX_RESPONSE_SIZE);
-      LOG(WARNING) << "GETRANGE result truncated from " << substr.size() 
-                   << " to " << MAX_RESPONSE_SIZE << " bytes";
-    }
     res_.AppendStringLenUint64(substr.size());
     res_.AppendContent(substr);
   } else if (s_.IsInvalidArgument()) {
@@ -1216,7 +1200,7 @@ void SetrangeCmd::DoInitial() {
     res_.SetRes(CmdRes::kInvalidInt);
     return;
   }
-  //6.9号新增
+  //Handle the overflow issue of offset_
   if (offset_ < 0) {
     res_.SetRes(CmdRes::kInvalidInt, "offset is out of range");
     return;

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1140,13 +1140,30 @@ void GetrangeCmd::DoInitial() {
     res_.SetRes(CmdRes::kInvalidInt);
     return;
   }
+  //6.6号新增
+  // 添加最大值限制
+  // const int64_t MAX_RANGE_SIZE = 512 * 1024 * 1024; // 512MB
+  // if (start_ < -MAX_RANGE_SIZE || start_ > MAX_RANGE_SIZE ||
+  //   end_ < -MAX_RANGE_SIZE || end_ > MAX_RANGE_SIZE) {
+  //   res_.SetRes(CmdRes::kInvalidInt, "Range index out of bounds");
+  //   return;
+  // }
+
 }
 
 void GetrangeCmd::Do() {
   std::string substr;
   STAGE_TIMER_GUARD(storage_duration_ms, true);
   s_= db_->storage()->Getrange(key_, start_, end_, &substr);
+  
   if (s_.ok() || s_.IsNotFound()) {
+    //6.9号新增的
+    const size_t MAX_RESPONSE_SIZE = 100 * 1024 * 1024; //100MB
+    if (substr.size() > MAX_RESPONSE_SIZE) {
+      substr.resize(MAX_RESPONSE_SIZE);
+      LOG(WARNING) << "GETRANGE result truncated from " << substr.size() 
+                   << " to " << MAX_RESPONSE_SIZE << " bytes";
+    }
     res_.AppendStringLenUint64(substr.size());
     res_.AppendContent(substr);
   } else if (s_.IsInvalidArgument()) {
@@ -1199,7 +1216,17 @@ void SetrangeCmd::DoInitial() {
     res_.SetRes(CmdRes::kInvalidInt);
     return;
   }
+  //6.9号新增
+  if (offset_ < 0) {
+    res_.SetRes(CmdRes::kInvalidInt, "offset is out of range");
+    return;
+  }
+  const int64_t MAX_STRING_SIZE = 9223372036854775757;
   value_ = argv_[3];
+  if (offset_ > MAX_STRING_SIZE - static_cast<int64_t>(value_.size())) {
+    res_.SetRes(CmdRes::kInvalidInt, "string exceeds maximum allowed size");
+    return;
+  }
 }
 
 void SetrangeCmd::Do() {

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1195,13 +1195,7 @@ void SetrangeCmd::DoInitial() {
     res_.SetRes(CmdRes::kWrongNum, kCmdNameSetrange);
     return;
   }
-  key_ = argv_[1];
-  //If the number of keys exceeds 19, the system is returned
-  if (argv_[2].size() >= 19) {
-    res_.SetRes(CmdRes::kErrOther, "string exceeds maximum allowed size (proto-max-bulk-len)");
-    return;
-  }
-  
+  key_ = argv_[1];  
   if (pstd::string2int(argv_[2].data(), argv_[2].size(), &offset_) == 0) {
     res_.SetRes(CmdRes::kInvalidInt);
     return;
@@ -1209,13 +1203,13 @@ void SetrangeCmd::DoInitial() {
   
   value_ = argv_[3];
   
+  // Read the proto-max-bulk-len parameter settings in the pika configuration file pika_conf
+  const int64_t PROTO_MAX_BULK_LEN = g_pika_conf->proto_max_bulk_len();
   //Handle the overflow issue of offset_
-  const int64_t PROTO_MAX_BULK_LEN = 512 * 1024 * 1024; // 512MB
   if (offset_ < 0) {
     res_.SetRes(CmdRes::kInvalidInt, "offset is out of range");
     return;
   }
-
   if (offset_ > PROTO_MAX_BULK_LEN - static_cast<int64_t>(value_.size())) {
     res_.SetRes(CmdRes::kErrOther, "string exceeds maximum allowed size (proto-max-bulk-len)");
     return;

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1196,19 +1196,28 @@ void SetrangeCmd::DoInitial() {
     return;
   }
   key_ = argv_[1];
+  //If the number of keys exceeds 19, the system is returned
+  if (argv_[2].size() >= 19) {
+    res_.SetRes(CmdRes::kErrOther, "string exceeds maximum allowed size (proto-max-bulk-len)");
+    return;
+  }
+  
   if (pstd::string2int(argv_[2].data(), argv_[2].size(), &offset_) == 0) {
     res_.SetRes(CmdRes::kInvalidInt);
     return;
   }
+  
+  value_ = argv_[3];
+  
   //Handle the overflow issue of offset_
+  const int64_t PROTO_MAX_BULK_LEN = 512 * 1024 * 1024; // 512MB
   if (offset_ < 0) {
     res_.SetRes(CmdRes::kInvalidInt, "offset is out of range");
     return;
   }
-  const int64_t MAX_STRING_SIZE = 9223372036854775757;
-  value_ = argv_[3];
-  if (offset_ > MAX_STRING_SIZE - static_cast<int64_t>(value_.size())) {
-    res_.SetRes(CmdRes::kInvalidInt, "string exceeds maximum allowed size");
+
+  if (offset_ > PROTO_MAX_BULK_LEN - static_cast<int64_t>(value_.size())) {
+    res_.SetRes(CmdRes::kErrOther, "string exceeds maximum allowed size (proto-max-bulk-len)");
     return;
   }
 }

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -277,7 +277,7 @@ var _ = Describe("String Commands", func() {
 			Expect(getBit.Err()).NotTo(HaveOccurred())
 			Expect(getBit.Val()).To(Equal(int64(0)))
 		})
-				
+
 		It("should GetRange", func() {
 			set := client.Set(ctx, "key", "This is a string", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
@@ -298,6 +298,22 @@ var _ = Describe("String Commands", func() {
 			getRange = client.GetRange(ctx, "key", 10, 100)
 			Expect(getRange.Err()).NotTo(HaveOccurred())
 			Expect(getRange.Val()).To(Equal("string"))
+		})
+
+		//Caiyu's test cases for GETRANGE and SETRANGE to fix bug #3092.
+		It("should not crash on huge GETRANGE", func() {
+			set := client.Set(ctx, "key1", "abc", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+			Expect(set.Val()).To(Equal("OK"))
+			getRange := client.GetRange(ctx, "key1", 1, 4294967296)
+			Expect(getRange.Val()).To(Equal("bc"))
+		})
+		It("should not crash on huge SETRANGE", func() {
+			set := client.Set(ctx, "key1", "abc", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+			Expect(set.Val()).To(Equal("OK"))
+			setRange := client.SetRange(ctx, "key1", 9223372036854775757, "value2")
+			Expect(setRange.Err()).To(HaveOccurred())
 		})
 
 		It("should GetSet", func() {
@@ -798,24 +814,24 @@ var _ = Describe("String Commands", func() {
 		})
 
 		It("should SetEX ten seconds", func() {
-			err := client.SetEx(ctx, "x", "y", 10 * time.Second).Err()
+			err := client.SetEx(ctx, "x", "y", 10*time.Second).Err()
 			Expect(err).NotTo(HaveOccurred())
-		
+
 			val, err := client.Get(ctx, "x").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal("y"))
-		
+
 			time.Sleep(11 * time.Second)
 			//sleep 10 second x still exists
-		
+
 			err = client.Do(ctx, "compact").Err()
 			Expect(err).NotTo(HaveOccurred())
-		
+
 			keys, err := client.Keys(ctx, "x").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(BeEmpty())
 		})
-		
+
 		It("should SetNX", func() {
 			_, err := client.Del(ctx, "key").Result()
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -305,8 +305,10 @@ var _ = Describe("String Commands", func() {
 			set := client.Set(ctx, "key1", "abc", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
-			getRange := client.GetRange(ctx, "key1", 1, 4294967296)
-			Expect(getRange.Val()).To(Equal("bc"))
+			getRange1 := client.GetRange(ctx, "key1", 1, 4294967296)
+    		Expect(getRange1.Val()).To(Equal("bc"))
+    		getRange2 := client.GetRange(ctx, "key1", 1, 4294967296)
+    		Expect(getRange2.Val()).To(Equal("bc"))
 		})
 		It("should not crash on huge SETRANGE", func() {
 			set := client.Set(ctx, "key1", "abc", 0)


### PR DESCRIPTION
# 修复bug #3092：解决导致pika服务崩溃的错误漏洞
## 执行GETRANGE key1 1 4294967296两次后服务崩溃的原因
- 问题分析:大的end值在传递给Redis缓存层之前没有进行适当的验证；PikaCache::GetRange直接委托给缓存而不进行边界检查；尝试创建超大字符串时内存分配失败。
- 下图是连续执行两次GETRANGE key1 1 4294967296之后pika服务挂掉的堆栈信息:
 
![image](https://github.com/user-attachments/assets/65b1a7ef-f1dd-446b-89f3-7ecaa5578de4)

## 执行SETRANGE key1 9223372036854775757 value2后服务崩溃的原因
- 问题分析:偏移值9223372036854775757接近LLONG_MAX，与值长度计算结合时导致整数溢出和内存损坏。
- 下图是执行SETRANGE key1 9223372036854775757 value2之后pika服务挂掉的堆栈信息:
    
![image](https://github.com/user-attachments/assets/3a4da8f7-d459-4ec1-8fdc-d42ed7199f59)

## 修改文件部分
- 重构了src/pika_cache.cc中的GetRange方法，添加了对start和end参数的边界检查；使用full_value变量存储string类型的实际长度，避免过度内存分配。
- 在conf/pika.conf中新增参数proto_max_bulk_len，即单条数据最大长度限制，其默认大小为512MB（与Redis一致）。
- 在include/pika_conf.h中新增了int64_t proto_max_bulk_len_ = 0;以及函数int64_t proto_max_bulk_len()；和void SetRsyncTimeoutMs(int64_t value)函数。
- 在src/pika_conf.cc中新增了GetConfInt64Human("proto-max-bulk-len",xxx)函数。
- 在src/pika_kv.cc的SetrangeCmd::DoInitial中新增读取配置文件pika_conf中proto-max-bulk-len参数的功能；处理了offset_的溢出问题，当offset_大小超过设定值抛出Error:"string exceeds maximum allowed size (proto-max-bulk-len)"；当offset大小小于0则抛出Error:"offset is out of range"。
- 在string_test.go文件中追加了测试用例并通过了测试。

![image-20250612094248664](https://github.com/user-attachments/assets/9fd0b2c8-623a-4096-87cf-2dd34e12867e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option to set the maximum allowed size for a single bulk string in the protocol.

- **Bug Fixes**
  - Improved error handling for string range commands to prevent crashes and ensure correct behavior with large indices or offsets.
  - Enhanced validation to prevent setting strings that exceed the configured maximum size.
  - Optimized substring retrieval to handle negative indices and avoid excessive memory allocation.

- **Tests**
  - Added integration tests to verify correct handling of edge cases for GETRANGE and SETRANGE commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->