### PR TITLE
fix: block-cache config bug

### DIFF
--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -681,7 +681,7 @@ int PikaConf::Load() {
   if (blob_garbage_collection_force_threshold_ <= 0) {
     blob_garbage_collection_force_threshold_ = 1.0;
   }
-  GetConfInt64("blob-cache", &block_cache_);
+  GetConfInt64("blob-cache", &blob_cache_);
   GetConfInt64("blob-num-shard-bits", &blob_num_shard_bits_);
 
   // throttle-bytes-per-second


### PR DESCRIPTION
about: https://github.com/OpenAtomFoundation/pikiwidb/pull/1802
之前修复有遗漏，此处修复3.5分支。4.0分支同理存在问题