### PR TITLE
fix: the error bugs in getrange and setrange in pika 3.5 version

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -86,6 +86,11 @@ db-path : ./db/
 # Supported Units [K|M|G], write-buffer-size default unit is in [bytes].
 write-buffer-size : 256M
 
+# The maximum size of a single bulk string in Pika protocol.
+# This value is used to limit the size of a single bulk string in Pika protocol.
+# The default value is 512M.
+proto-max-bulk-len : 512M
+
 # The size of one block in arena memory allocation.
 # If <= 0, a proper value is automatically calculated.
 # (usually 1/8 of writer-buffer-size, rounded up to a multiple of 4KB)

--- a/include/pika_cache.h
+++ b/include/pika_cache.h
@@ -133,7 +133,7 @@ class PikaCache : public pstd::noncopyable, public std::enable_shared_from_this<
   rocksdb::Status RPushnx(std::string& key, std::vector<std::string> &values, int64_t ttl);
   rocksdb::Status RPushnxWithoutTTL(std::string& key, std::vector<std::string> &values);
   rocksdb::Status LPushIfKeyExist(std::string& key, std::vector<std::string> &values);
-  
+
   // Set Commands
   rocksdb::Status SAdd(std::string& key, std::vector<std::string>& members);
   rocksdb::Status SAddIfKeyExist(std::string& key, std::vector<std::string>& members);

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -124,6 +124,10 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return write_buffer_size_;
   }
+  int64_t proto_max_bulk_len() {
+    std::shared_lock l(rwlock_);
+    return proto_max_bulk_len_;
+  }
   int64_t arena_block_size() {
     std::shared_lock l(rwlock_);
     return arena_block_size_;
@@ -745,6 +749,11 @@ class PikaConf : public pstd::BaseConf {
     rsync_timeout_ms_.store(value);
   }
 
+  void SetProtoMaxBulkLen(const int64_t value) {
+    std::lock_guard l(rwlock_);
+    TryPushDiffCommands("proto-max-bulk-len", std::to_string(value));
+    proto_max_bulk_len_ = value;
+  }
   int RocksDBPerfLevel() const {
     return rocksdb_perf_level_.load();
   }
@@ -907,6 +916,7 @@ class PikaConf : public pstd::BaseConf {
   int64_t least_free_disk_to_resume_ = 268435456; // 256 MB
   double min_check_resume_ratio_ = 0.7;
   int64_t write_buffer_size_ = 0;
+  int64_t proto_max_bulk_len_ = 0;
   int64_t arena_block_size_ = 0;
   int64_t slotmigrate_thread_num_ = 0;
   int64_t thread_migrate_keys_num_ = 0;

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -141,54 +141,69 @@ std::map<storage::DataType, int64_t> PikaCache::TTL(std::string &key, std::map<s
   std::map<storage::DataType, int64_t> ret;
   int64_t timestamp = 0;
 
-  std::string CacheKeyPrefixK = PCacheKeyPrefixK + key;
-  int cache_indexk = CacheIndex(CacheKeyPrefixK);
-  s = caches_[cache_indexk]->TTL(CacheKeyPrefixK, &timestamp);
-  if (s.ok() || s.IsNotFound()) {
-    ret[storage::DataType::kStrings] = timestamp;
-  } else if (!s.IsNotFound()) {
-    ret[storage::DataType::kStrings] = -3;
-    (*type_status)[storage::DataType::kStrings] = s;
+  {
+    std::string CacheKeyPrefixK = PCacheKeyPrefixK + key;
+    int cache_indexk = CacheIndex(CacheKeyPrefixK);
+    std::lock_guard lm(*cache_mutexs_[cache_indexk]);
+    s = caches_[cache_indexk]->TTL(CacheKeyPrefixK, &timestamp);
+    if (s.ok() || s.IsNotFound()) {
+      ret[storage::DataType::kStrings] = timestamp;
+    } else if (!s.IsNotFound()) {
+      ret[storage::DataType::kStrings] = -3;
+      (*type_status)[storage::DataType::kStrings] = s;
+    }
   }
 
-  std::string CacheKeyPrefixH = PCacheKeyPrefixH + key;
-  int cache_indexh = CacheIndex(CacheKeyPrefixH);
-  s = caches_[cache_indexh]->TTL(CacheKeyPrefixH, &timestamp);
-  if (s.ok() || s.IsNotFound()) {
-    ret[storage::DataType::kHashes] = timestamp;
-  } else if (!s.IsNotFound()) {
-    ret[storage::DataType::kHashes] = -3;
-    (*type_status)[storage::DataType::kHashes] = s;
+  {
+    std::string CacheKeyPrefixH = PCacheKeyPrefixH + key;
+    int cache_indexh = CacheIndex(CacheKeyPrefixH);
+    std::lock_guard lm(*cache_mutexs_[cache_indexh]);
+    s = caches_[cache_indexh]->TTL(CacheKeyPrefixH, &timestamp);
+    if (s.ok() || s.IsNotFound()) {
+      ret[storage::DataType::kHashes] = timestamp;
+    } else if (!s.IsNotFound()) {
+      ret[storage::DataType::kHashes] = -3;
+      (*type_status)[storage::DataType::kHashes] = s;
+    }
   }
 
-  std::string CacheKeyPrefixL = PCacheKeyPrefixL + key;
-  int cache_indexl = CacheIndex(CacheKeyPrefixL);
-  s = caches_[cache_indexl]->TTL(CacheKeyPrefixL, &timestamp);
-  if (s.ok() || s.IsNotFound()) {
-    ret[storage::DataType::kLists] = timestamp;
-  } else if (!s.IsNotFound()) {
-    ret[storage::DataType::kLists] = -3;
-    (*type_status)[storage::DataType::kLists] = s;
+  {
+    std::string CacheKeyPrefixL = PCacheKeyPrefixL + key;
+    int cache_indexl = CacheIndex(CacheKeyPrefixL);
+    std::lock_guard lm(*cache_mutexs_[cache_indexl]);
+    s = caches_[cache_indexl]->TTL(CacheKeyPrefixL, &timestamp);
+    if (s.ok() || s.IsNotFound()) {
+      ret[storage::DataType::kLists] = timestamp;
+    } else if (!s.IsNotFound()) {
+      ret[storage::DataType::kLists] = -3;
+      (*type_status)[storage::DataType::kLists] = s;
+    }
   }
 
-  std::string CacheKeyPrefixS = PCacheKeyPrefixS + key;
-  int cache_indexs = CacheIndex(CacheKeyPrefixS);
-  s = caches_[cache_indexs]->TTL(CacheKeyPrefixS, &timestamp);
-  if (s.ok() || s.IsNotFound()) {
-    ret[storage::DataType::kSets] = timestamp;
-  } else if (!s.IsNotFound()) {
-    ret[storage::DataType::kSets] = -3;
-    (*type_status)[storage::DataType::kSets] = s;
+  {
+    std::string CacheKeyPrefixS = PCacheKeyPrefixS + key;
+    int cache_indexs = CacheIndex(CacheKeyPrefixS);
+    std::lock_guard lm(*cache_mutexs_[cache_indexs]);
+    s = caches_[cache_indexs]->TTL(CacheKeyPrefixS, &timestamp);
+    if (s.ok() || s.IsNotFound()) {
+      ret[storage::DataType::kSets] = timestamp;
+    } else if (!s.IsNotFound()) {
+      ret[storage::DataType::kSets] = -3;
+      (*type_status)[storage::DataType::kSets] = s;
+    }
   }
 
-  std::string CacheKeyPrefixZ = PCacheKeyPrefixZ + key;
-  int cache_indexz = CacheIndex(CacheKeyPrefixZ);
-  s = caches_[cache_indexz]->TTL(CacheKeyPrefixZ, &timestamp);
-  if (s.ok() || s.IsNotFound()) {
-    ret[storage::DataType::kZSets] = timestamp;
-  } else if (!s.IsNotFound()) {
-    ret[storage::DataType::kZSets] = -3;
-    (*type_status)[storage::DataType::kZSets] = s;
+  {
+    std::string CacheKeyPrefixZ = PCacheKeyPrefixZ + key;
+    int cache_indexz = CacheIndex(CacheKeyPrefixZ);
+    std::lock_guard lm(*cache_mutexs_[cache_indexz]);
+    s = caches_[cache_indexz]->TTL(CacheKeyPrefixZ, &timestamp);
+    if (s.ok() || s.IsNotFound()) {
+      ret[storage::DataType::kZSets] = timestamp;
+    } else if (!s.IsNotFound()) {
+      ret[storage::DataType::kZSets] = -3;
+      (*type_status)[storage::DataType::kZSets] = s;
+    }
   }
   return ret;
 }
@@ -226,68 +241,83 @@ Status PikaCache::GetType(const std::string& key, bool single, std::vector<std::
 
   Status s;
   std::string value;
-  std::string CacheKeyPrefixK = PCacheKeyPrefixK + key;
-  int cache_indexk = CacheIndex(CacheKeyPrefixK);
-  s = caches_[cache_indexk]->Get(CacheKeyPrefixK, &value);
-  if (s.ok()) {
-    types.emplace_back("string");
-  } else if (!s.IsNotFound()) {
-    return s;
-  }
-  if (single && !types.empty()) {
-    return s;
-  }
-
-  uint64_t hashes_len = 0;
-  std::string CacheKeyPrefixH = PCacheKeyPrefixH + key;
-  int cache_indexh = CacheIndex(CacheKeyPrefixH);
-  s = caches_[cache_indexh]->HLen(CacheKeyPrefixH, &hashes_len);
-  if (s.ok() && hashes_len != 0) {
-    types.emplace_back("hash");
-  } else if (!s.IsNotFound()) {
-    return s;
-  }
-  if (single && !types.empty()) {
-    return s;
+  {
+    std::string CacheKeyPrefixK = PCacheKeyPrefixK + key;
+    int cache_indexk = CacheIndex(CacheKeyPrefixK);
+    std::lock_guard lm(*cache_mutexs_[cache_indexk]);
+    s = caches_[cache_indexk]->Get(CacheKeyPrefixK, &value);
+    if (s.ok()) {
+      types.emplace_back("string");
+    } else if (!s.IsNotFound()) {
+      return s;
+    }
+    if (single && !types.empty()) {
+      return s;
+    }
   }
 
-  uint64_t lists_len = 0;
-  std::string CacheKeyPrefixL = PCacheKeyPrefixL + key;
-  int cache_indexl = CacheIndex(CacheKeyPrefixL);
-  s = caches_[cache_indexl]->LLen(CacheKeyPrefixL, &lists_len);
-  if (s.ok() && lists_len != 0) {
-    types.emplace_back("list");
-  } else if (!s.IsNotFound()) {
-    return s;
-  }
-  if (single && !types.empty()) {
-    return s;
-  }
-
-  uint64_t zsets_size = 0;
-  std::string CacheKeyPrefixZ = PCacheKeyPrefixZ + key;
-  int cache_indexz = CacheIndex(CacheKeyPrefixZ);
-  s = caches_[cache_indexz]->ZCard(CacheKeyPrefixZ, &zsets_size);
-  if (s.ok() && zsets_size != 0) {
-    types.emplace_back("zset");
-  } else if (!s.IsNotFound()) {
-    return s;
-  }
-  if (single && !types.empty()) {
-    return s;
+  {
+    uint64_t hashes_len = 0;
+    std::string CacheKeyPrefixH = PCacheKeyPrefixH + key;
+    int cache_indexh = CacheIndex(CacheKeyPrefixH);
+    std::lock_guard lm(*cache_mutexs_[cache_indexh]);
+    s = caches_[cache_indexh]->HLen(CacheKeyPrefixH, &hashes_len);
+    if (s.ok() && hashes_len != 0) {
+      types.emplace_back("hash");
+    } else if (!s.IsNotFound()) {
+      return s;
+    }
+    if (single && !types.empty()) {
+      return s;
+    }
   }
 
-  uint64_t sets_size = 0;
-  std::string CacheKeyPrefixS = PCacheKeyPrefixS + key;
-  int cache_indexs = CacheIndex(CacheKeyPrefixS);
-  s = caches_[cache_indexs]->SCard(CacheKeyPrefixS, &sets_size);
-  if (s.ok() && sets_size != 0) {
-    types.emplace_back("set");
-  } else if (!s.IsNotFound()) {
-    return s;
+  {
+    uint64_t lists_len = 0;
+    std::string CacheKeyPrefixL = PCacheKeyPrefixL + key;
+    int cache_indexl = CacheIndex(CacheKeyPrefixL);
+    std::lock_guard lm(*cache_mutexs_[cache_indexl]);
+    s = caches_[cache_indexl]->LLen(CacheKeyPrefixL, &lists_len);
+    if (s.ok() && lists_len != 0) {
+      types.emplace_back("list");
+    } else if (!s.IsNotFound()) {
+      return s;
+    }
+    if (single && !types.empty()) {
+      return s;
+    }
   }
-  if (single && types.empty()) {
-    types.emplace_back("none");
+
+  {
+    uint64_t zsets_size = 0;
+    std::string CacheKeyPrefixZ = PCacheKeyPrefixZ + key;
+    int cache_indexz = CacheIndex(CacheKeyPrefixZ);
+    std::lock_guard lm(*cache_mutexs_[cache_indexz]);
+    s = caches_[cache_indexz]->ZCard(CacheKeyPrefixZ, &zsets_size);
+    if (s.ok() && zsets_size != 0) {
+      types.emplace_back("zset");
+    } else if (!s.IsNotFound()) {
+      return s;
+    }
+    if (single && !types.empty()) {
+      return s;
+    }
+  }
+
+  {
+    uint64_t sets_size = 0;
+    std::string CacheKeyPrefixS = PCacheKeyPrefixS + key;
+    int cache_indexs = CacheIndex(CacheKeyPrefixS);
+    std::lock_guard lm(*cache_mutexs_[cache_indexs]);
+    s = caches_[cache_indexs]->SCard(CacheKeyPrefixS, &sets_size);
+    if (s.ok() && sets_size != 0) {
+      types.emplace_back("set");
+    } else if (!s.IsNotFound()) {
+      return s;
+    }
+    if (single && types.empty()) {
+      types.emplace_back("none");
+    }
   }
   return Status::OK();
 }
@@ -410,10 +440,39 @@ Status PikaCache::Appendxx(std::string& key, std::string &value) {
   return Status::NotFound("key not exist");
 }
 
+/*
+  Added boundary checks for start and end parameters to the PikaCache::GetRange function,
+  and used the full_value variable to store the actual length of string type, 
+  avoiding excessive memory allocation by sdsnewlen.
+*/
 Status PikaCache::GetRange(std::string& key, int64_t start, int64_t end, std::string *value) {
   int cache_index = CacheIndex(key);
   std::lock_guard lm(*cache_mutexs_[cache_index]);
-  return caches_[cache_index]->GetRange(key, start, end, value);
+  std::string full_value;
+  auto s = caches_[cache_index]->Get(key, &full_value);
+  if (!s.ok()) {
+    return s;
+  }
+  int64_t strlen = full_value.size();
+
+  if (start < 0) {
+    start = strlen + start;
+  }
+  if (end < 0) {
+    end = strlen + end;
+  }
+
+  if (start < 0) start = 0;
+  if (end < 0) end = 0;
+  if (end >= strlen) end = strlen - 1;
+
+  if (start > end || strlen == 0) {
+    value->clear();
+    return Status::OK();
+  }
+
+  *value = full_value.substr(start, end - start + 1);
+  return Status::OK();
 }
 
 Status PikaCache::SetRangeIfKeyExist(std::string& key, int64_t start, std::string &value) {

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -323,6 +323,10 @@ int PikaConf::Load() {
     write_buffer_size_ = 268435456;  // 256Mb
   }
 
+  GetConfInt64Human("proto-max-bulk-len", &proto_max_bulk_len_);
+  if (proto_max_bulk_len_ <= 0) {
+    proto_max_bulk_len_ = 512 * 1024 * 1024;  // 512MB
+  }
   // arena_block_size
   GetConfInt64Human("arena-block-size", &arena_block_size_);
   if (arena_block_size_ <= 0) {

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -1215,6 +1215,17 @@ void SetrangeCmd::DoInitial() {
     return;
   }
   value_ = argv_[3];
+  // Read the proto-max-bulk-len parameter settings in the pika configuration file pika_conf
+  const int64_t PROTO_MAX_BULK_LEN = g_pika_conf->proto_max_bulk_len();
+  //Handle the overflow issue of offset_
+  if (offset_ < 0) {
+    res_.SetRes(CmdRes::kInvalidInt, "offset is out of range");
+    return;
+  }
+  if (offset_ > PROTO_MAX_BULK_LEN - static_cast<int64_t>(value_.size())) {
+    res_.SetRes(CmdRes::kErrOther, "string exceeds maximum allowed size (proto-max-bulk-len)");
+    return;
+  }
 }
 
 void SetrangeCmd::Do() {

--- a/tests/integration/string_test.go
+++ b/tests/integration/string_test.go
@@ -300,6 +300,24 @@ var _ = Describe("String Commands", func() {
 			Expect(getRange.Val()).To(Equal("string"))
 		})
 
+		//Caiyu's test cases for GETRANGE and SETRANGE to fix bug #3092.
+		It("should not crash on huge GETRANGE", func() {
+			set := client.Set(ctx, "key1", "abc", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+			Expect(set.Val()).To(Equal("OK"))
+			getRange1 := client.GetRange(ctx, "key1", 1, 4294967296)
+    		Expect(getRange1.Val()).To(Equal("bc"))
+    		getRange2 := client.GetRange(ctx, "key1", 1, 4294967296)
+    		Expect(getRange2.Val()).To(Equal("bc"))
+		})
+		It("should not crash on huge SETRANGE", func() {
+			set := client.Set(ctx, "key1", "abc", 0)
+			Expect(set.Err()).NotTo(HaveOccurred())
+			Expect(set.Val()).To(Equal("OK"))
+			setRange := client.SetRange(ctx, "key1", 9223372036854775757, "value2")
+			Expect(setRange.Err()).To(HaveOccurred())
+		})
+
 		It("should GetSet", func() {
 			incr := client.Incr(ctx, "key")
 			Expect(incr.Err()).NotTo(HaveOccurred())


### PR DESCRIPTION
# 修复bug #3092：解决导致pika服务崩溃的错误漏洞
## 执行GETRANGE key1 1 4294967296两次后服务崩溃的原因
- 问题分析:大的end值在传递给Redis缓存层之前没有进行适当的验证；PikaCache::GetRange直接委托给缓存而不进行边界检查；尝试创建超大字符串时内存分配失败。
- 下图是连续执行两次GETRANGE key1 1 4294967296之后pika服务挂掉的堆栈信息:
 
![image](https://github.com/user-attachments/assets/65b1a7ef-f1dd-446b-89f3-7ecaa5578de4)

## 执行SETRANGE key1 9223372036854775757 value2后服务崩溃的原因
- 问题分析:偏移值9223372036854775757接近LLONG_MAX，与值长度计算结合时导致整数溢出和内存损坏。
- 下图是执行SETRANGE key1 9223372036854775757 value2之后pika服务挂掉的堆栈信息:
    
![image](https://github.com/user-attachments/assets/3a4da8f7-d459-4ec1-8fdc-d42ed7199f59)

## 修改文件部分
- 重构了src/pika_cache.cc中的GetRange方法，添加了对start和end参数的边界检查；使用full_value变量存储string类型的实际长度，避免过度内存分配。
- 在conf/pika.conf中新增参数proto_max_bulk_len，即单条数据最大长度限制，其默认大小为512MB（与Redis一致）。
- 在include/pika_conf.h中新增了int64_t proto_max_bulk_len_ = 0;以及函数int64_t proto_max_bulk_len()；和void SetRsyncTimeoutMs(int64_t value)函数。
- 在src/pika_conf.cc中新增了GetConfInt64Human("proto-max-bulk-len",xxx)函数。
- 在src/pika_kv.cc的SetrangeCmd::DoInitial中新增读取配置文件pika_conf中proto-max-bulk-len参数的功能；处理了offset_的溢出问题，当offset_大小超过设定值抛出Error:"string exceeds maximum allowed size (proto-max-bulk-len)"；当offset大小小于0则抛出Error:"offset is out of range"。
- 在string_test.go文件中追加了测试用例并通过了测试。

![image-20250612094248664](https://github.com/user-attachments/assets/9fd0b2c8-623a-4096-87cf-2dd34e12867e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option to set the maximum allowed size for a single bulk string in the protocol.

- **Bug Fixes**
  - Improved error handling for string range commands to prevent crashes and ensure correct behavior with large indices or offsets.
  - Enhanced validation to prevent setting strings that exceed the configured maximum size.
  - Optimized substring retrieval to handle negative indices and avoid excessive memory allocation.

- **Tests**
  - Added integration tests to verify correct handling of edge cases for GETRANGE and SETRANGE commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->