### PR TITLE
fix: ensure ZADD keeps the last score for duplicate members in a single command to align with Redis behavior

### DIFF
--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -307,12 +307,16 @@ Status RedisZSets::ZAdd(const Slice& key, const std::vector<ScoreMember>& score_
   *ret = 0;
   uint32_t statistic = 0;
   std::unordered_set<std::string> unique;
-  std::vector<ScoreMember> filtered_score_members;
-  for (const auto& sm : score_members) {
-    if (unique.find(sm.member) == unique.end()) {
-      unique.insert(sm.member);
-      filtered_score_members.push_back(sm);
+  std::list<storage::ScoreMember> mid_score_members;
+  for (auto it = score_members.rbegin(); it != score_members.rend(); ++it) {
+    if (unique.find(it->member) == unique.end()) {
+      unique.insert(it->member);
+      mid_score_members.push_front(*it);
     }
+  }
+  std::vector<ScoreMember> filtered_score_members;
+  for (auto &item : mid_score_members) {
+    filtered_score_members.push_back(std::move(item));
   }
 
   char score_buf[8];

--- a/tests/integration/zset_test.go
+++ b/tests/integration/zset_test.go
@@ -233,7 +233,26 @@ var _ = Describe("Zset Commands", func() {
 			Member: "two",
 		}}))
 	})
-
+	// Caiyu's test: verify that zadd with multiple scores for the same member in 
+	//a single command only keeps the last score, consistent with Redis behavior
+	It("should ZAdd with duplicate member in one command", func() {
+		added, err := client.ZAdd(ctx, "myzset", redis.Z{
+			Score:  100,
+			Member: "one",
+		}, redis.Z{
+			Score:  98,
+			Member: "one",
+		}).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(added).To(Equal(int64(1)))
+	
+		vals, err := client.ZRangeWithScores(ctx, "myzset", 0, -1).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vals).To(Equal([]redis.Z{{
+			Score:  98,
+			Member: "one",
+		}}))
+	})
 	It("should ZAdd bytes", func() {
 		added, err := client.ZAdd(ctx, "zset", redis.Z{
 			Score:  1,


### PR DESCRIPTION
# 修复bug #3078 : 修正 pika 中 zadd 命令在单行多次添加同一 member 时与 Redis 行为不一致的问题
## 问题重现
![image-20250612165250717](https://github.com/user-attachments/assets/e225a486-2bb7-4d75-bcae-d04de84dcd7d)

## 执行zadd key score1 member1 score2 member1返回score1的原因

![image](https://github.com/user-attachments/assets/c242334b-41fc-4b9b-a75f-9caefd05f0c7)

在 src/storage/src/redis_zsets.cc 文件中，RedisZSets::ZAdd 函数存在问题：源代码在这里是从前往后读取score_members数组的，导致与src/pika_cache.cc中的PikaCache::ZAddIfKeyExist函数的从后往前读取score_members数组冲突，程序未能读取到正确的缓存数据。
## 修改文件部分
- 在src/storage/src/redis_zsets.cc 文件中修改了对score_members数组的从后往前读取方式，与PikaCache::ZAddIfKeyExist中的unordered_set+list的方式一致。
- 在zset_test.go文件中追加了测试用例并通过了测试。

![image-20250613112526622](https://github.com/user-attachments/assets/40c9fdf3-cda7-455a-820b-04024a661431)
