### PR TITLE
fix: resolve incorrect element deletion in zset by ZREMRANGEBYSCORE command

### DIFF
--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -307,12 +307,16 @@ Status RedisZSets::ZAdd(const Slice& key, const std::vector<ScoreMember>& score_
   *ret = 0;
   uint32_t statistic = 0;
   std::unordered_set<std::string> unique;
-  std::vector<ScoreMember> filtered_score_members;
-  for (const auto& sm : score_members) {
-    if (unique.find(sm.member) == unique.end()) {
-      unique.insert(sm.member);
-      filtered_score_members.push_back(sm);
+  std::list<storage::ScoreMember> mid_score_members;
+  for (auto it = score_members.rbegin(); it != score_members.rend(); ++it) {
+    if (unique.find(it->member) == unique.end()) {
+      unique.insert(it->member);
+      mid_score_members.push_front(*it);
     }
+  }
+  std::vector<ScoreMember> filtered_score_members;
+  for (auto &item : mid_score_members) {
+    filtered_score_members.push_back(std::move(item));
   }
 
   char score_buf[8];

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -916,7 +916,7 @@ Status RedisZSets::ZRemrangebyscore(const Slice& key, double min, double max, bo
           del_cnt++;
           statistic++;
         }
-        if (!right_pass) {
+        if (right_pass) {
           break;
         }
       }

--- a/tests/integration/zset_test.go
+++ b/tests/integration/zset_test.go
@@ -1266,7 +1266,31 @@ var _ = Describe("Zset Commands", func() {
 		Expect(zRangeByScore.Err()).NotTo(HaveOccurred())
 		Expect(zRangeByScore.Val()).To(Equal([]string{}))
 	})
-
+	//Caiyu's test: Verify the zset command ZREMRANGEBYSCORE to delete invalid items
+	It("should ZRemRangeByScore with big integer scores", func() {
+		err := client.ZAdd(ctx, "test01", redis.Z{Score: 1749168060267762, Member: "a"}).Err()
+		Expect(err).NotTo(HaveOccurred())
+		err = client.ZAdd(ctx, "test01", redis.Z{Score: 1749168060267760, Member: "b"}).Err()
+		Expect(err).NotTo(HaveOccurred())
+		err = client.ZAdd(ctx, "test01", redis.Z{Score: 1749168060267750, Member: "c"}).Err()
+		Expect(err).NotTo(HaveOccurred())
+		zRangeWithScores := client.ZRangeWithScores(ctx, "test01", 0, 3)
+		Expect(zRangeWithScores.Err()).NotTo(HaveOccurred())
+		Expect(zRangeWithScores.Val()).To(Equal([]redis.Z{
+			{Score: 1749168060267750, Member: "c"},
+			{Score: 1749168060267760, Member: "b"},
+			{Score: 1749168060267762, Member: "a"},
+		}))
+		zRemRangeByScore := client.ZRemRangeByScore(ctx, "test01", "1749168060267750", "1749168060267755")
+		Expect(zRemRangeByScore.Err()).NotTo(HaveOccurred())
+		Expect(zRemRangeByScore.Val()).To(Equal(int64(1)))
+		zRangeWithScores = client.ZRangeWithScores(ctx, "test01", 0, 3)
+		Expect(zRangeWithScores.Err()).NotTo(HaveOccurred())
+		Expect(zRangeWithScores.Val()).To(Equal([]redis.Z{
+			{Score: 1749168060267760, Member: "b"},
+			{Score: 1749168060267762, Member: "a"},
+		}))
+	})
 	It("should ZRangeByLex", func() {
 		err := client.ZAdd(ctx, "zset", redis.Z{
 			Score:  0,

--- a/tests/integration/zset_test.go
+++ b/tests/integration/zset_test.go
@@ -233,7 +233,26 @@ var _ = Describe("Zset Commands", func() {
 			Member: "two",
 		}}))
 	})
-
+	// Caiyu's test: verify that zadd with multiple scores for the same member in 
+	//a single command only keeps the last score, consistent with Redis behavior
+	It("should ZAdd with duplicate member in one command", func() {
+		added, err := client.ZAdd(ctx, "myzset", redis.Z{
+			Score:  100,
+			Member: "one",
+		}, redis.Z{
+			Score:  98,
+			Member: "one",
+		}).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(added).To(Equal(int64(1)))
+	
+		vals, err := client.ZRangeWithScores(ctx, "myzset", 0, -1).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vals).To(Equal([]redis.Z{{
+			Score:  98,
+			Member: "one",
+		}}))
+	})
 	It("should ZAdd bytes", func() {
 		added, err := client.ZAdd(ctx, "zset", redis.Z{
 			Score:  1,


### PR DESCRIPTION
# 修复bug #3101 ：解决导致ZREMRANGEBYSCORE删除失效的bug

## 修改文件部分
- 删除了src/storage/src/redis_zsets.cc中RedisZSets::ZRemrangebyscore函数中的if (!right_pass) {break;}命令。
- 补充了tests/integration/zset_test.go中ZRemRangeByScore处理大值的测试用例，并通过了测试。
![image-20250613185738759](https://github.com/user-attachments/assets/12d09f4e-a917-4a95-b96a-e77c6ac944d4)



