### PR TITLE
fix: requirepass allows connection with any non-empty password (unstable)

### DIFF
--- a/src/acl.cc
+++ b/src/acl.cc
@@ -497,6 +497,10 @@ void Acl::InitLimitUser(const std::string& bl, bool limit_exist) {
     }
     if (!pass.empty()) {
       u->SetUser(">" + pass);
+    } else {
+      //If the userpass password is empty, 
+      //disable the limit user to prevent password-free access
+      u->SetUser("off");
     }
   } else {
     if (pass.empty()) {


### PR DESCRIPTION
# 修复bug #3085 ：解决requirepass是非空的但可通过任意密码连接(unstable版本)
## requirepass 为非空时填写任意字符串即可连接的原因
![image](https://github.com/user-attachments/assets/f7717082-0088-46ac-8a4e-dbfe99fd8880)

因为src/acl.cc文件中的Acl::InitLimitUser()函数的没有设置else分支，若 userpass 为空且requirepass不为空，limit 用户就会被设置为 nopass（免密），任何密码都能通过；若userpass 和 requirepass 都为空，所有用户都是管理员；若userpass 不为空且requirepass为空就会报(error) ERR Client sent AUTH, but no password is set的错误。
## 修改后的运行截图
![image](https://github.com/user-attachments/assets/014d3f6b-3472-426b-8232-b5ac498d27e1)

![image](https://github.com/user-attachments/assets/b1b7b5a0-8aaa-4d0d-96c2-6abc33ec1636)
