### PR TITLE
fix:SETEX replication does not work(pika-unstable)

### DIFF
--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -888,16 +888,16 @@ std::string SetexCmd::ToRedisProtocol() {
   content.reserve(RAW_ARGS_LEN);
   RedisAppendLen(content, 4, "*");
 
-  // to pksetexat cmd
-  std::string pksetexat_cmd("pksetexat");
-  RedisAppendLenUint64(content, pksetexat_cmd.size(), "$");
-  RedisAppendContent(content, pksetexat_cmd);
+  // to setex cmd
+  std::string setex_cmd("setex");
+  RedisAppendLenUint64(content, setex_cmd.size(), "$");
+  RedisAppendContent(content, setex_cmd);
   // key
   RedisAppendLenUint64(content, key_.size(), "$");
   RedisAppendContent(content, key_);
   // time_stamp
   char buf[100];
-  auto time_stamp = time(nullptr) + ttl_sec_;
+  auto time_stamp = ttl_sec_;
   pstd::ll2string(buf, 100, time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");
@@ -947,16 +947,16 @@ std::string PsetexCmd::ToRedisProtocol() {
   content.reserve(RAW_ARGS_LEN);
   RedisAppendLen(content, 4, "*");
 
-  // to pksetexat cmd
-  std::string pksetexat_cmd("pksetexat");
-  RedisAppendLenUint64(content, pksetexat_cmd.size(), "$");
-  RedisAppendContent(content, pksetexat_cmd);
+  // to psetex cmd
+  std::string psetex_cmd("psetex");
+  RedisAppendLenUint64(content, psetex_cmd.size(), "$");
+  RedisAppendContent(content, psetex_cmd);
   // key
   RedisAppendLenUint64(content, key_.size(), "$");
   RedisAppendContent(content, key_);
   // time_stamp
   char buf[100];
-  auto time_stamp = pstd::NowMillis() + ttl_millsec;
+  auto time_stamp = ttl_millsec;
   pstd::ll2string(buf, 100, time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");


### PR DESCRIPTION
# 修复了pika unstable版本中setex在主从上不同步的bug #3117 
## 修改的代码部分
### 1.命令名称错误：
修改了SetexCmd::ToRedisProtocol()和PsetexCmd::ToRedisProtocol()方法。原代码中，SetexCmd::ToRedisProtocol()方法生成的是pksetexat命令，而不是标准的setex命令。同样，PsetexCmd::ToRedisProtocol()也生成了错误的命令名称。在主从复制过程中，主节点会将命令转换为二进制日志(binlog)发送给从节点，所以从节点无法正确识别和执行这些非标准命令。
### 2.过期时间计算错误：
原代码中计算过期时间使用了time(nullptr) + ttl_sec_（对于SETEX）和pstd::NowMillis() + ttl_millsec（对于PSETEX）。这意味着主节点计算的是"当前时间+过期秒数"作为绝对过期时间点。当从节点接收到这个命令时，它会直接使用这个绝对时间，而不是重新计算。由于主从之间可能存在时间差或者命令传输延迟，这会导致从节点上的实际过期时间与主节点不一致。
## 修改后的运行截图
![image-20250709201539889-1752063341461-4](https://github.com/user-attachments/assets/e77a26ad-b53b-4ee3-9725-99e45644e00b)

![image-20250709201845060-1752063526769-6](https://github.com/user-attachments/assets/ebed4cca-9ece-4bb6-8d9f-dedb6bd6f301)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated command formatting for improved compatibility with standard Redis clients by using standard command names and TTL handling in protocol output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->