### PR TITLE
fix:Type Command Expired Key Consistency

### DIFF
--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1671,14 +1671,14 @@ rocksdb::Status Redis::GetType(const storage::Slice& key, enum DataType& type) {
   BaseMetaKey base_meta_key(key);
   rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
-    // 检查键是否已过期
+    // Check if key has expired
     if (ExpectedStale(meta_value)) {
-      type = DataType::kNones;  // 如果键已过期，返回"none"类型
+      type = DataType::kNones;  // If key has expired, return "none" type
     } else {
       type = static_cast<enum DataType>(static_cast<uint8_t>(meta_value[0]));
     }
   } else {
-    type = DataType::kNones;  // 如果键不存在，返回"none"类型
+    type = DataType::kNones;  // If key doesn't exist, return "none" type
   }
   return Status::OK();
 }

--- a/src/storage/src/redis_strings.cc
+++ b/src/storage/src/redis_strings.cc
@@ -1671,7 +1671,14 @@ rocksdb::Status Redis::GetType(const storage::Slice& key, enum DataType& type) {
   BaseMetaKey base_meta_key(key);
   rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
-    type = static_cast<enum DataType>(static_cast<uint8_t>(meta_value[0]));
+    // 检查键是否已过期
+    if (ExpectedStale(meta_value)) {
+      type = DataType::kNones;  // 如果键已过期，返回"none"类型
+    } else {
+      type = static_cast<enum DataType>(static_cast<uint8_t>(meta_value[0]));
+    }
+  } else {
+    type = DataType::kNones;  // 如果键不存在，返回"none"类型
   }
   return Status::OK();
 }

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1514,16 +1514,6 @@ Status Storage::GetType(const std::string& key, enum DataType& type) {
   return Status::OK();
 }
 
-Status Storage::Type(const std::string& key, std::vector<std::string>& types) {
-  types.clear();
-  DataType type;
-  Status s = GetType(key, type);
-  if (s.ok()) {
-    types.push_back(DataTypeToString(type));
-  }
-  return s;
-}
-
 Status Storage::Keys(const DataType& data_type, const std::string& pattern, std::vector<std::string>* keys) {
   keys->clear();
   std::vector<DataType> types;

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1514,6 +1514,16 @@ Status Storage::GetType(const std::string& key, enum DataType& type) {
   return Status::OK();
 }
 
+Status Storage::Type(const std::string& key, std::vector<std::string>& types) {
+  types.clear();
+  DataType type;
+  Status s = GetType(key, type);
+  if (s.ok()) {
+    types.push_back(DataTypeToString(type));
+  }
+  return s;
+}
+
 Status Storage::Keys(const DataType& data_type, const std::string& pattern, std::vector<std::string>* keys) {
   keys->clear();
   std::vector<DataType> types;


### PR DESCRIPTION
#3130 
在PikiwiDB v4中，当哈希类型的键过期时，在使用类似HLEN等命令时会返回0或空结果，表示键不存在。但当使用TYPE命令时，仍然会返回"hash"而不是"none"，这与v355版本的行为不一致。
## 问题原因：
在Redis::GetType方法中，即使键已过期，也没有检查过期状态，而是直接返回键的类型。元数据中记录了键的类型，即使键过期，这个元数据仍然存在，只是被标记为过期(stale)。
## 解决方案：
   1.修改了Redis::GetType方法，添加了对键是否过期的检查。
   2.实现了Storage::Type方法以确保TYPE命令能正确处理过期键。
## 修复后的效果：
1.现在当哈希键过期时，TYPE命令会返回"none"而不是"hash"
2.这与v355版本的行为一致，避免了在应用程序中使用TYPE命令判断键类型时的混淆
3.解决方案保持了PikiwiDB内部代码的一致性，确保所有命令对过期键的处理逻辑相同

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key type retrieval to correctly handle expired or non-existent keys, ensuring expired keys are now reported as non-existent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->