### PR TITLE
fix:SETEX replication does not work

### DIFF
--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -887,7 +887,7 @@ std::string SetexCmd::ToRedisProtocol() {
   RedisAppendContent(content, key_);
   // time_stamp
   char buf[100];
-  auto time_stamp = time(nullptr) + ttl_sec_;
+  int64_t time_stamp  = static_cast<int64_t>(::time(nullptr)) + ttl_sec_;
   pstd::ll2string(buf, 100, time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");
@@ -945,8 +945,9 @@ std::string PsetexCmd::ToRedisProtocol() {
   RedisAppendLenUint64(content, key_.size(), "$");
   RedisAppendContent(content, key_);
   // time_stamp
+  int64_t expire_at_ms = pstd::NowMillis() + ttl_millsec;
+  int64_t time_stamp = expire_at_ms / 1000;
   char buf[100];
-  auto time_stamp = pstd::NowMillis() + ttl_millsec;
   pstd::ll2string(buf, 100, time_stamp);
   std::string at(buf);
   RedisAppendLenUint64(content, at.size(), "$");
@@ -1770,7 +1771,9 @@ void PKSetexAtCmd::DoInitial() {
 }
 
 void PKSetexAtCmd::Do() {
-  s_ = db_->storage()->PKSetexAt(key_, value_, static_cast<int32_t>(time_stamp_sec_ * 1000));
+  // Use int64_t to avoid overflow
+  int64_t time_stamp_ms = static_cast<int64_t>(time_stamp_sec_) * 1000;
+  s_ = db_->storage()->PKSetexAt(key_, value_, time_stamp_ms);
   if (s_.ok()) {
     res_.SetRes(CmdRes::kOk);
   } else if (s_.IsInvalidArgument()) {


### PR DESCRIPTION
# 修复了pika4.0中setex在主从上不同步的bug #3117 
## 修改的代码部分
### 1.过期时间计算错误：
此次修改将 SETEX/PSETEX 写入 binlog 时统一转换为接受绝对秒级时间戳的 pksetexat 指令，先在主库把 “当前时间 + TTL” 换算成过期时间点后落库，保证从库收到后与主库在同一时刻过期；同时把 PKSetexAtCmd::Do() 中时间戳乘 1000 的结果改用 int64_t 传递，避免 32 位溢溢出导致过期时间为负数，键立即失效，从而彻底解决主从过期不一致的问题。
## 修改后的运行截图
![image-20250709201539889-1752063341461-4](https://github.com/user-attachments/assets/e77a26ad-b53b-4ee3-9725-99e45644e00b)

![image-20250709201845060-1752063526769-6](https://github.com/user-attachments/assets/ebed4cca-9ece-4bb6-8d9f-dedb6bd6f301)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expiration times for key-setting commands to prevent potential overflow and ensure accurate timestamp calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->