### PR TITLE
fix:bug in time statistics format

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -45,11 +45,11 @@ static std::string ConstructPinginPubSubResp(const PikaCmdArgsType& argv) {
 }
 
 static double MethodofCommandStatistics(const uint64_t time_consuming, const uint64_t frequency) {
-  return (static_cast<double>(time_consuming) / 1000.0) / static_cast<double>(frequency);
+  return static_cast<double>(time_consuming) / static_cast<double>(frequency);
 }
 
 static double MethodofTotalTimeCalculation(const uint64_t time_consuming) {
-  return static_cast<double>(time_consuming) / 1000.0;
+  return static_cast<double>(time_consuming);
 }
 
 enum AuthResult {


### PR DESCRIPTION
#3131 
## pika3.5中该bug复现
<img width="613" height="296" alt="image" src="https://github.com/user-attachments/assets/ff466a3c-1835-42a5-8041-abc63aab0f37" />

## 原因分析
慢日志明确给出了 210 µs 的耗时，而 info all # Commandstats 对应的 usec_per_call 只有 0.21，这一千倍的差距说明统计值在输出前被 /1000 误换算成了毫秒，因此当前版本的 Commandstats 单位实际上是毫秒，符合 issue #3131 的描述。

## 修改位置
在 src/pika_admin.cc 中将 MethodofCommandStatistics 与 MethodofTotalTimeCalculation 里把 time_consuming / 1000.0 直接改为 static_cast<double>(time_consuming)，去掉这一步除法即可恢复为真正的微秒单位，重新编译后 info all 中的 usec 与 usec_per_call 将与 slowlog 完全一致。

## 修复后截图
<img width="623" height="294" alt="image" src="https://github.com/user-attachments/assets/2404e76d-30a8-41b6-a99d-5921fdae974e" />
