### PR TITLE
fix: ensure ZADD keeps the last score for duplicate members in a single command to align with Redis behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,9 +458,9 @@ set(LZ4_INCLUDE_DIR ${INSTALL_INCLUDEDIR})
 ExternalProject_Add(zlib
   DEPENDS
   URL
-  https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz
+  https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz 
   URL_HASH
-  MD5=9b8aa094c4e5765dabf4da391f00d15c
+  MD5=9855b6d802d7fe5b7bd5b196a2271655
   DOWNLOAD_NO_PROGRESS
   1
   UPDATE_COMMAND

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -46,11 +46,11 @@ static std::string ConstructPinginPubSubResp(const PikaCmdArgsType& argv) {
 }
 
 static double MethodofCommandStatistics(const uint64_t time_consuming, const uint64_t frequency) {
-  return (static_cast<double>(time_consuming) / 1000.0) / static_cast<double>(frequency);
+  return static_cast<double>(time_consuming) / static_cast<double>(frequency);
 }
 
 static double MethodofTotalTimeCalculation(const uint64_t time_consuming) {
-  return static_cast<double>(time_consuming) / 1000.0;
+  return static_cast<double>(time_consuming);
 }
 
 enum AuthResult {

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -183,12 +183,16 @@ Status Redis::ZAdd(const Slice& key, const std::vector<ScoreMember>& score_membe
   *ret = 0;
   uint32_t statistic = 0;
   std::unordered_set<std::string> unique;
-  std::vector<ScoreMember> filtered_score_members;
-  for (const auto& sm : score_members) {
-    if (unique.find(sm.member) == unique.end()) {
-      unique.insert(sm.member);
-      filtered_score_members.push_back(sm);
+  std::list<storage::ScoreMember> mid_score_members;
+  for (auto it = score_members.rbegin(); it != score_members.rend(); ++it) {
+    if (unique.find(it->member) == unique.end()) {
+      unique.insert(it->member);
+      mid_score_members.push_front(*it);
     }
+  }
+  std::vector<ScoreMember> filtered_score_members;
+  for (auto &item : mid_score_members) {
+    filtered_score_members.push_back(std::move(item));
   }
 
   char score_buf[8];


### PR DESCRIPTION
# 修复bug #3078 : 修正 pika 中 zadd 命令在单行多次添加同一 member 时与 Redis 行为不一致的问题
## 问题重现
![image-20250612165250717](https://github.com/user-attachments/assets/e225a486-2bb7-4d75-bcae-d04de84dcd7d)

## 执行zadd key score1 member1 score2 member1返回score1的原因

![image](https://github.com/user-attachments/assets/c242334b-41fc-4b9b-a75f-9caefd05f0c7)

在 src/storage/src/redis_zsets.cc 文件中，RedisZSets::ZAdd 函数存在问题：源代码在这里是从前往后读取score_members数组的，导致与src/pika_cache.cc中的PikaCache::ZAddIfKeyExist函数的从后往前读取score_members数组冲突，程序未能读取到正确的缓存数据。
## 修改文件部分
- 在src/storage/src/redis_zsets.cc 文件中修改了对score_members数组的从后往前读取方式，与PikaCache::ZAddIfKeyExist中的unordered_set+list的方式一致。
- 在zset_test.go文件中追加了测试用例并通过了测试。

![image-20250613112526622](https://github.com/user-attachments/assets/40c9fdf3-cda7-455a-820b-04024a661431)
