### PR TITLE
fix: After connecting to Pika via telnet and pressing Enter, it causes Pika core dump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,9 +458,9 @@ set(LZ4_INCLUDE_DIR ${INSTALL_INCLUDEDIR})
 ExternalProject_Add(zlib
   DEPENDS
   URL
-  https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz
+  https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz 
   URL_HASH
-  MD5=9b8aa094c4e5765dabf4da391f00d15c
+  MD5=9855b6d802d7fe5b7bd5b196a2271655
   DOWNLOAD_NO_PROGRESS
   1
   UPDATE_COMMAND

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -286,6 +286,10 @@ bool PikaClientConn::IsInterceptedByRTC(std::string& opt) {
 void PikaClientConn::ProcessRedisCmds(const std::vector<net::RedisCmdArgsType>& argvs, bool async,
                                       std::string* response) {
   time_stat_->Reset();
+  if (argvs.empty()) {
+    NotifyEpoll(true);
+    return;
+  }
   if (async) {
     auto arg = new BgTaskArg();
     arg->cache_miss_in_rtc_ = false;


### PR DESCRIPTION
使用 telnet 连上 Pika 之后直接回车，会让 Pika 接受到一个 "\r\n" 的包，最终会导致 Pika Core 在了 std::string opt = argvs[0][0]; 这里，PR 增加了对空命令包判断，测试后发现没有之前 core 的问题
#3095
