### PR TITLE
Revert "fix:bug in time statistics format"

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -45,11 +45,11 @@ static std::string ConstructPinginPubSubResp(const PikaCmdArgsType& argv) {
 }
 
 static double MethodofCommandStatistics(const uint64_t time_consuming, const uint64_t frequency) {
-  return static_cast<double>(time_consuming) / static_cast<double>(frequency);
+  return (static_cast<double>(time_consuming) / 1000.0) / static_cast<double>(frequency);
 }
 
 static double MethodofTotalTimeCalculation(const uint64_t time_consuming) {
-  return static_cast<double>(time_consuming);
+  return static_cast<double>(time_consuming) / 1000.0;
 }
 
 enum AuthResult {


### PR DESCRIPTION
Reverts OpenAtomFoundation/pikiwidb#3134
会导致pika_exporter不兼容，pika_exporter采集旧版本的pika是以毫秒为单位，新版本的值是以微妙为单位。升级exporter之后保证兼容性了再修改pika这个bug。