### PR TITLE
feat:add RTC command

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -273,13 +273,26 @@ void PikaClientConn::ProcessMonitor(const PikaCmdArgsType& argv) {
 }
 
 bool PikaClientConn::IsInterceptedByRTC(std::string& opt) {
-  // currently we only Intercept: Get, HGet
-  if (opt == kCmdNameGet && g_pika_conf->GetCacheString()) {
+
+  static const std::unordered_set<std::string> intercepted_string_cmds = {
+      kCmdNameGet, kCmdNameStrlen, kCmdNameTtl
+  };
+
+  static const std::unordered_set<std::string> intercepted_hash_cmds = {
+      kCmdNameHGet, kCmdNameHMget, kCmdNameHExists, kCmdNameHVals, kCmdNameHStrlen
+  };
+
+  static const std::unordered_set<std::string> intercepted_list_cmds = {
+      kCmdNameLLen
+  };
+
+  if (intercepted_string_cmds.count(opt) && g_pika_conf->GetCacheString()) {
     return true;
   }
-  if (opt == kCmdNameHGet && g_pika_conf->GetCacheHash()) {
+  if (intercepted_hash_cmds.count(opt) && g_pika_conf->GetCacheHash()) {
     return true;
   }
+
   return false;
 }
 

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -282,17 +282,10 @@ bool PikaClientConn::IsInterceptedByRTC(std::string& opt) {
       kCmdNameHGet, kCmdNameHMget, kCmdNameHExists, kCmdNameHVals, kCmdNameHStrlen
   };
 
-  static const std::unordered_set<std::string> intercepted_list_cmds = {
-      kCmdNameLLen
-  };
-
   if (intercepted_string_cmds.count(opt) && g_pika_conf->GetCacheString()) {
     return true;
   }
   if (intercepted_hash_cmds.count(opt) && g_pika_conf->GetCacheHash()) {
-    return true;
-  }
-  if (intercepted_list_cmds.count(opt) && g_pika_conf->GetCacheList()) {
     return true;
   }
 

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -273,13 +273,29 @@ void PikaClientConn::ProcessMonitor(const PikaCmdArgsType& argv) {
 }
 
 bool PikaClientConn::IsInterceptedByRTC(std::string& opt) {
-  // currently we only Intercept: Get, HGet
-  if (opt == kCmdNameGet && g_pika_conf->GetCacheString()) {
+
+  static const std::unordered_set<std::string> intercepted_string_cmds = {
+      kCmdNameGet, kCmdNameStrlen, kCmdNameTtl
+  };
+
+  static const std::unordered_set<std::string> intercepted_hash_cmds = {
+      kCmdNameHGet, kCmdNameHMget, kCmdNameHExists, kCmdNameHVals, kCmdNameHStrlen
+  };
+
+  static const std::unordered_set<std::string> intercepted_list_cmds = {
+      kCmdNameLLen
+  };
+
+  if (intercepted_string_cmds.count(opt) && g_pika_conf->GetCacheString()) {
     return true;
   }
-  if (opt == kCmdNameHGet && g_pika_conf->GetCacheHash()) {
+  if (intercepted_hash_cmds.count(opt) && g_pika_conf->GetCacheHash()) {
     return true;
   }
+  if (intercepted_list_cmds.count(opt) && g_pika_conf->GetCacheList()) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
const std::string kCmdNameGet = "get"; //1
const std::string kCmdNameStrlen = "strlen";//1

// Hash

const std::string kCmdNameHGet = "hget";  //1
const std::string kCmdNameHGetall = "hgetall";  //1
const std::string kCmdNameHExists = "hexists"; //1
const std::string kCmdNameHKeys = "hkeys";//1
const std::string kCmdNameHLen = "hlen";//1
const std::string kCmdNameHMget = "hmget";//1
const std::string kCmdNameHStrlen = "hstrlen";//1
const std::string kCmdNameHVals = "hvals";//1

// List

const std::string kCmdNameLLen = "llen";//1

// BitMap
const std::string kCmdNameBitCount = "bitcount";//1

// Zset
const std::string kCmdNameZCount = "zcount";//1


// Set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded cache interception to include additional string and hash commands, respecting existing cache toggles for those types.
  * Simplified, consistent interception behavior across related string/hash operations for more reliable caching.
  * Note: list-command interception path was removed in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->