### PR TITLE
fix: write-buffer-size overflow

### DIFF
--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -675,7 +675,7 @@ class PikaConf : public pstd::BaseConf {
     TryPushDiffCommands("max-background-jobs", std::to_string(value));
     max_background_jobs_ = value;
   }
-  void SetWriteBufferSize(const int& value) {
+  void SetWriteBufferSize(int64_t value) {
     std::lock_guard l(rwlock_);
     TryPushDiffCommands("write-buffer-size", std::to_string(value));
     write_buffer_size_ = value;

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2692,7 +2692,7 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
       res_.AppendStringRaw("-ERR Set write-buffer-size wrong: " + s.ToString() + "\r\n");
       return;
     }
-    g_pika_conf->SetWriteBufferSize(static_cast<int>(ival));
+    g_pika_conf->SetWriteBufferSize(ival);
     res_.AppendStringRaw("+OK\r\n");
   } else if (set_item == "max-write-buffer-num") {
     if (pstd::string2int(value.data(), value.size(), &ival) == 0) {

--- a/tests/integration/server_test.go
+++ b/tests/integration/server_test.go
@@ -321,6 +321,18 @@ var _ = Describe("Server", func() {
 			Expect(r.Val()).To(Equal("OK"))
 		})
 
+		FIt("should ConfigSet write-buffer-size large value", func() {
+			// Test for fix: when setting write-buffer-size value larger than 2147483647,
+			// the value should not become negative
+			configSet := client.ConfigSet(ctx, "write-buffer-size", "3000000000")
+			Expect(configSet.Err()).NotTo(HaveOccurred())
+			Expect(configSet.Val()).To(Equal("OK"))
+			
+			configGet := client.ConfigGet(ctx, "write-buffer-size")
+			Expect(configGet.Err()).NotTo(HaveOccurred())
+			Expect(configGet.Val()).To(Equal(map[string]string{"write-buffer-size": "3000000000"}))
+		})
+
 		It("should ConfigSet maxmemory", func() {
 			configGet := client.ConfigGet(ctx, "maxmemory")
 			Expect(configGet.Err()).NotTo(HaveOccurred())

--- a/tests/integration/server_test.go
+++ b/tests/integration/server_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Server", func() {
 			Expect(r.Val()).To(Equal("OK"))
 		})
 
-		FIt("should ConfigSet write-buffer-size large value", func() {
+		It("should ConfigSet write-buffer-size large value", func() {
 			// Test for fix: when setting write-buffer-size value larger than 2147483647,
 			// the value should not become negative
 			configSet := client.ConfigSet(ctx, "write-buffer-size", "3000000000")


### PR DESCRIPTION
fix #3183
修复在 pika v3.5.5中设置 write-buffer-size 值大于 2147483647时，write-buffer-size 会变成负数的问题