### PR TITLE
feat: Pika Quality

### DIFF
--- a/.github/workflows/pika.yml
+++ b/.github/workflows/pika.yml
@@ -170,24 +170,12 @@ jobs:
 
       - name: Extreme Disk Cleanup
         run: |
-        
-          rm -rf /usr/local/share/* || true
-          rm -rf /usr/share/doc/* || true
-          rm -rf /usr/share/man/* || true
-          rm -rf /var/cache/* || true
-          
-          find ${{ github.workspace }} -name "*.o" -type f -delete || true
-          find ${{ github.workspace }} -name "*.a" -type f -delete || true
-          find ${{ github.workspace }} -name "*.la" -type f -delete || true
-          find ${{ github.workspace }} -name "*.so" -type f -delete || true
-          find ${{ github.workspace }} -name "*.pyc" -type f -delete || true
-          
-          rm -rf ${{ github.workspace }}/.git || true
-          
+          rm -rf /__w/pikiwidb/pikiwidb/buildtrees 2>/dev/null || true
+          rm -rf /__w/pikiwidb/pikiwidb/deps 2>/dev/null || true 
+          find /__w/pikiwidb/pikiwidb -type f \( -name "librocksdb.a" -o -name "libprotoc.a" -o -name "libprotobuf.a" \) -delete 2>/dev/null || true
+          find /__w/pikiwidb/pikiwidb -type f \( -name "*.o" -o -name "*.a" -o -name "*.la" -o -name "*.so" -o -name "*_test" \) ! -path "*/build/pika" -delete 2>/dev/null || true
+          rm -rf /__w/pikiwidb/pikiwidb/.git 2>/dev/null || true
           df -h
-          
-          echo "Largest directories:"
-          du -h --max-depth=2 / 2>/dev/null | sort -hr | head -20
 
       - name: Create Log Directories
         run: |

--- a/tests/integration/network_stability_test.go
+++ b/tests/integration/network_stability_test.go
@@ -1,0 +1,57 @@
+package pika_integration
+
+import (
+	"net"
+	. "github.com/bsm/ginkgo/v2"
+	. "github.com/bsm/gomega"
+)
+
+var _ = Describe("Telnet", func() {
+	Describe("core dump fix", func() {
+		It("should handle empty commands without crashing (telnet core dump fix)", func() {
+			conn, err := net.Dial("tcp", SINGLEADDR)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close()
+
+			_, err = conn.Write([]byte("\n"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = conn.Write([]byte("*1\r\n$4\r\nPING\r\n"))
+			Expect(err).NotTo(HaveOccurred())
+
+			buf := make([]byte, 1024)
+			n, err := conn.Read(buf)
+			Expect(err).NotTo(HaveOccurred())
+			response := string(buf[:n])
+			Expect(response).To(ContainSubstring("+PONG"))
+
+			_, err = conn.Write([]byte("*2\r\n$4\r\nECHO\r\n$4\r\nTEST\r\n"))
+			Expect(err).NotTo(HaveOccurred())
+
+			n, err = conn.Read(buf)
+			Expect(err).NotTo(HaveOccurred())
+			response = string(buf[:n])
+			Expect(response).To(ContainSubstring("$4\r\nTEST"))
+		})
+
+		It("should handle multiple empty commands without crashing", func() {
+			conn, err := net.Dial("tcp", SINGLEADDR)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close()
+
+			for i := 0; i < 5; i++ {
+				_, err = conn.Write([]byte("\r\n"))
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			_, err = conn.Write([]byte("*1\r\n$4\r\nPING\r\n"))
+			Expect(err).NotTo(HaveOccurred())
+
+			buf := make([]byte, 1024)
+			n, err := conn.Read(buf)
+			Expect(err).NotTo(HaveOccurred())
+			response := string(buf[:n])
+			Expect(response).To(ContainSubstring("+PONG"))
+		})
+	})
+})

--- a/tests/integration/server_test.go
+++ b/tests/integration/server_test.go
@@ -434,6 +434,31 @@ var _ = Describe("Server", func() {
 			Expect(configRewrite.Err()).NotTo(HaveOccurred())
 			Expect(configRewrite.Val()).To(Equal("OK"))
 		})
+
+		// Test for cache-value-item-max-size & max-key-size-in-cache
+		It("should handle cache size configurations correctly", func() {
+			configGet := client.ConfigGet(ctx, "cache-value-item-max-size")
+			Expect(configGet.Err()).NotTo(HaveOccurred())
+			Expect(configGet.Val()).To(HaveKey("cache-value-item-max-size"))
+			
+			configGet2 := client.ConfigGet(ctx, "max-key-size-in-cache")
+			Expect(configGet2.Err()).NotTo(HaveOccurred())
+			Expect(configGet2.Val()).To(HaveKey("max-key-size-in-cache"))
+			
+			configSet1 := client.ConfigSet(ctx, "cache-value-item-max-size", "1024")
+			Expect(configSet1.Err()).NotTo(HaveOccurred())
+			Expect(configSet1.Val()).To(Equal("OK"))
+			
+			configSet2 := client.ConfigSet(ctx, "max-key-size-in-cache", "1048576")
+			Expect(configSet2.Err()).NotTo(HaveOccurred())
+			Expect(configSet2.Val()).To(Equal("OK"))
+			
+			configGet3 := client.ConfigGet(ctx, "cache-value-item-max-size")
+			Expect(configGet3.Val()["cache-value-item-max-size"]).To(Equal("1024"))
+			
+			configGet4 := client.ConfigGet(ctx, "max-key-size-in-cache")
+			Expect(configGet4.Val()["max-key-size-in-cache"]).To(Equal("1048576"))
+		})
 		//It("should DBSize", func() {
 		//	Expect(client.Set(ctx, "key", "value", 0).Val()).To(Equal("OK"))
 		//	Expect(client.Do(ctx, "info", "keyspace", "1").Err()).NotTo(HaveOccurred())
@@ -793,6 +818,28 @@ var _ = Describe("Server", func() {
 			Expect(client.Exists(ctx, "foo").Val()).To(Equal(int64(0)))
 			Expect(client.Get(ctx, "foo").Err()).To(MatchError(redis.Nil))
 			Expect(client.Get(ctx, "key1").Err()).To(MatchError(redis.Nil))
+		})
+		
+		//fix: added the correct loading of admin-cmd-list in the configuration file
+		It("should load admin-cmd-list from config correctly", func() {
+			configGet := client.ConfigGet(ctx, "admin-cmd-list")
+			Expect(configGet.Err()).NotTo(HaveOccurred())
+			Expect(configGet.Val()).To(HaveLen(1))
+			
+			adminCmdList, ok := configGet.Val()["admin-cmd-list"]
+			Expect(ok).To(BeTrue())
+			
+			Expect(adminCmdList).To(ContainSubstring("auth"))
+			Expect(adminCmdList).To(ContainSubstring("config"))
+			Expect(adminCmdList).To(ContainSubstring("info"))
+			Expect(adminCmdList).To(ContainSubstring("ping"))
+			Expect(adminCmdList).To(ContainSubstring("monitor"))
+		})
+
+		// fix add auth command to admin-thread-pool
+		It("should process auth command in admin thread pool", func() {
+			auth := client.Do(ctx, "auth", "wrongpassword")
+			Expect(auth.Err()).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
https://github.com/OpenAtomFoundation/pikiwidb/pull/3043 https://github.com/OpenAtomFoundation/pikiwidb/pull/3047
这两处修复都涉及到了参数cache-value-item-max-size 和 max-key-size-in-cache
添加测试点：
● 验证配置项的存在性：通过ConfigGet命令确认cache-value-item-max-size 和max-key-size-in-cache 配置项存在
● 验证配置可以被设置：通过ConfigSet命令尝试设置配置值
https://github.com/OpenAtomFoundation/pikiwidb/pull/3048
用例验证配置项 admin-cmd-list 中是否包含 "auth" 命令，确保配置被正确设置。
https://github.com/OpenAtomFoundation/pikiwidb/issues/3095
测试了两种情况：
● 使用原始 TCP 连接来模拟 telnet 客户端行为
● 验证服务器不会崩溃并能继续处理正常命令

测试结果如下：
<img width="627" height="157" alt="5a4555475dd95f35c8ff2e00e7553111" src="https://github.com/user-attachments/assets/88660296-79a3-4956-a213-30f7c9464864" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced network stability testing with Telnet interactions, empty/multiline command handling, and response assertions.
  * Added tests for cache configuration updates and verification of retrieved values.
  * Added tests validating admin command loading and execution behavior.

* **Chores**
  * CI cleanup steps refined to target workspace build artifacts and specific libraries; minor Docker build label formatting adjusted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->