### PR TITLE
feat: Fast slow separate

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -31,7 +31,7 @@ thread-pool-size : 12
 # This parameter is used to control whether to separate fast and slow commands.
 # When slow-cmd-pool is set to yes, fast and slow commands are separated.
 # When set to no, they are not separated.
-slow-cmd-pool : yes
+slow-cmd-pool : no
 
 # Enable thread pool borrowing mechanism, which allows threads to help each other when one pool is busy
 # and another is idle. This can improve resource utilization and reduce command latency under uneven load.
@@ -66,7 +66,7 @@ slow-cmd-thread-pool-size : 1
 admin-thread-pool-size : 2
 
 # Slow cmd list e.g. hgetall, mset
-slow-cmd-list : keys
+slow-cmd-list :
 
 # List of commands considered as administrative. These commands will be handled by the admin thread pool. Modify this list as needed.
 # Default commands: info, ping, monitor

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -33,6 +33,19 @@ thread-pool-size : 12
 # When set to no, they are not separated.
 slow-cmd-pool : no
 
+# Enable thread pool borrowing mechanism, which allows threads to help each other when one pool is busy
+# and another is idle. This can improve resource utilization and reduce command latency under uneven load.
+# [yes | no] - The default value is yes.
+threadpool-borrow-enable : yes
+
+# The queue length threshold (as a percentage of max queue size) at which a thread pool is considered busy
+# and may borrow threads from another pool. The value range is [1-99], default is 80.
+threadpool-borrow-threshold-percent : 80
+
+# The queue length threshold (as a percentage of max queue size) at which a thread pool is considered idle
+# and may lend threads to another pool. The value range is [1-99], default is 20.
+threadpool-idle-threshold-percent : 20
+
 # Size of the low level thread pool, The threads within this pool
 # are dedicated to handling slow user requests.
 slow-cmd-thread-pool-size : 1

--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -31,7 +31,7 @@ thread-pool-size : 12
 # This parameter is used to control whether to separate fast and slow commands.
 # When slow-cmd-pool is set to yes, fast and slow commands are separated.
 # When set to no, they are not separated.
-slow-cmd-pool : no
+slow-cmd-pool : yes
 
 # Enable thread pool borrowing mechanism, which allows threads to help each other when one pool is busy
 # and another is idle. This can improve resource utilization and reduce command latency under uneven load.
@@ -46,6 +46,17 @@ threadpool-borrow-threshold-percent : 80
 # and may lend threads to another pool. The value range is [1-99], default is 20.
 threadpool-idle-threshold-percent : 20
 
+# --- EMA queue-wait based load signals (used together with queue percent) ---
+# EMA alpha = numerator / denominator. Smaller alpha => smoother (less sensitive to spikes).
+threadpool-ema-alpha-numerator : 5
+threadpool-ema-alpha-denominator : 100
+
+# Busy/idle thresholds based on EMA(queue_wait_us). Unit: microseconds.
+threadpool-fast-busy-threshold : 2000
+threadpool-fast-idle-threshold : 500
+threadpool-slow-busy-threshold : 5000
+threadpool-slow-idle-threshold : 1000
+
 # Size of the low level thread pool, The threads within this pool
 # are dedicated to handling slow user requests.
 slow-cmd-thread-pool-size : 1
@@ -55,7 +66,7 @@ slow-cmd-thread-pool-size : 1
 admin-thread-pool-size : 2
 
 # Slow cmd list e.g. hgetall, mset
-slow-cmd-list :
+slow-cmd-list : keys
 
 # List of commands considered as administrative. These commands will be handled by the admin thread pool. Modify this list as needed.
 # Default commands: info, ping, monitor

--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -295,6 +295,7 @@ class InfoCmd : public Cmd {
   const static std::string kDebugSection;
   const static std::string kCommandStatsSection;
   const static std::string kCacheSection;
+  const static std::string kThreadpoolSection;
 
   void DoInitial() override;
   void Clear() override {

--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -267,7 +267,8 @@ class InfoCmd : public Cmd {
     kInfoAll,
     kInfoDebug,
     kInfoCommandStats,
-    kInfoCache
+    kInfoCache,
+    kInfoThreadpool
   };
   InfoCmd(const std::string& name, int arity, uint32_t flag) : Cmd(name, arity, flag) {}
   void Do() override;

--- a/include/pika_binlog.h
+++ b/include/pika_binlog.h
@@ -37,7 +37,7 @@ class Version final : public pstd::noncopyable {
 
   void debug() {
     std::shared_lock l(rwlock_);
-    printf("Current pro_num %u pro_offset %llu\n", pro_num_, pro_offset_);
+    printf("Current pro_num %u pro_offset %lu\n", pro_num_, pro_offset_);
   }
 
  private:

--- a/include/pika_client_conn.h
+++ b/include/pika_client_conn.h
@@ -49,6 +49,7 @@ class PikaClientConn : public net::RedisConn {
     LogOffset offset;
     std::string db_name;
     bool cache_miss_in_rtc_;
+    TaskPoolType pool_type;
   };
 
   struct TxnStateBitMask {
@@ -125,6 +126,7 @@ class PikaClientConn : public net::RedisConn {
 
   bool authenticated_ = false;
   std::shared_ptr<User> user_;
+  TaskPoolType task_pool_type_ = kFastCmdPool;
 
   std::shared_ptr<Cmd> DoCmd(const PikaCmdArgsType& argv, const std::string& opt,
                              const std::shared_ptr<std::string>& resp_ptr, bool cache_miss_in_rtc,

--- a/include/pika_client_conn.h
+++ b/include/pika_client_conn.h
@@ -49,8 +49,6 @@ class PikaClientConn : public net::RedisConn {
     LogOffset offset;
     std::string db_name;
     bool cache_miss_in_rtc_;
-    //在任务参数中携带 slot_id，任务执行完毕后，Worker 线程知道要去释放哪个 Slot。
-    int slot_id = -1;
   };
 
   struct TxnStateBitMask {

--- a/include/pika_client_conn.h
+++ b/include/pika_client_conn.h
@@ -41,7 +41,6 @@ struct TimeStat {
 class PikaClientConn : public net::RedisConn {
  public:
   using WriteCompleteCallback = std::function<void()>;
-
   struct BgTaskArg {
     std::shared_ptr<Cmd> cmd_ptr;
     std::shared_ptr<PikaClientConn> conn_ptr;
@@ -50,6 +49,8 @@ class PikaClientConn : public net::RedisConn {
     LogOffset offset;
     std::string db_name;
     bool cache_miss_in_rtc_;
+    //在任务参数中携带 slot_id，任务执行完毕后，Worker 线程知道要去释放哪个 Slot。
+    int slot_id = -1;
   };
 
   struct TxnStateBitMask {

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -168,6 +168,18 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return slow_cmd_pool_;
   }
+  bool threadpool_borrow_enable() {
+    std::shared_lock l(rwlock_);
+    return threadpool_borrow_enable_;
+  }
+  int threadpool_borrow_threshold_percent() {
+    std::shared_lock l(rwlock_);
+    return threadpool_borrow_threshold_percent_;
+  }
+  int threadpool_idle_threshold_percent() {
+    std::shared_lock l(rwlock_);
+    return threadpool_idle_threshold_percent_;
+  }
   std::string server_id() {
     std::shared_lock l(rwlock_);
     return server_id_;
@@ -942,6 +954,11 @@ class PikaConf : public pstd::BaseConf {
   std::string bgsave_prefix_;
   std::string pidfile_;
   std::atomic<bool> slow_cmd_pool_;
+  
+  // Thread pool task borrowing configuration
+  bool threadpool_borrow_enable_ = true;
+  int threadpool_borrow_threshold_percent_ = 80;
+  int threadpool_idle_threshold_percent_ = 20;
 
   std::string compression_;
   std::string compression_per_level_;

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -180,6 +180,7 @@ class PikaConf : public pstd::BaseConf {
     std::shared_lock l(rwlock_);
     return threadpool_idle_threshold_percent_;
   }
+
   std::string server_id() {
     std::shared_lock l(rwlock_);
     return server_id_;
@@ -506,6 +507,57 @@ class PikaConf : public pstd::BaseConf {
   void SetThreadPoolIdleThresholdPercent(const int value) {
     std::lock_guard l(rwlock_);
     threadpool_idle_threshold_percent_ = value;
+  }
+
+  // Getters for EMA configuration
+  uint32_t threadpool_ema_alpha_numerator() {
+    std::shared_lock l(rwlock_);
+    return threadpool_ema_alpha_numerator_;
+  }
+  uint32_t threadpool_ema_alpha_denominator() {
+    std::shared_lock l(rwlock_);
+    return threadpool_ema_alpha_denominator_;
+  }
+  uint64_t threadpool_fast_busy_threshold() {
+    std::shared_lock l(rwlock_);
+    return threadpool_fast_busy_threshold_;
+  }
+  uint64_t threadpool_fast_idle_threshold() {
+    std::shared_lock l(rwlock_);
+    return threadpool_fast_idle_threshold_;
+  }
+  uint64_t threadpool_slow_busy_threshold() {
+    std::shared_lock l(rwlock_);
+    return threadpool_slow_busy_threshold_;
+  }
+  uint64_t threadpool_slow_idle_threshold() {
+    std::shared_lock l(rwlock_);
+    return threadpool_slow_idle_threshold_;
+  }
+
+  // Setters for EMA configuration
+  void SetThreadPoolEmaAlpha(uint32_t numerator, uint32_t denominator) {
+    std::lock_guard l(rwlock_);
+    if (denominator > 0 && numerator <= denominator) {
+        threadpool_ema_alpha_numerator_ = numerator;
+        threadpool_ema_alpha_denominator_ = denominator;
+    }
+  }
+  void SetThreadPoolFastBusyThreshold(uint64_t value) {
+    std::lock_guard l(rwlock_);
+    threadpool_fast_busy_threshold_ = value;
+  }
+  void SetThreadPoolFastIdleThreshold(uint64_t value) {
+    std::lock_guard l(rwlock_);
+    threadpool_fast_idle_threshold_ = value;
+  }
+  void SetThreadPoolSlowBusyThreshold(uint64_t value) {
+    std::lock_guard l(rwlock_);
+    threadpool_slow_busy_threshold_ = value;
+  }
+  void SetThreadPoolSlowIdleThreshold(uint64_t value) {
+    std::lock_guard l(rwlock_);
+    threadpool_slow_idle_threshold_ = value;
   }
 
   void SetSlaveof(const std::string& value) {
@@ -973,6 +1025,14 @@ class PikaConf : public pstd::BaseConf {
   bool threadpool_borrow_enable_ = true;
   int threadpool_borrow_threshold_percent_ = 80;
   int threadpool_idle_threshold_percent_ = 20;
+
+  // EMA configuration
+  uint32_t threadpool_ema_alpha_numerator_{5};
+  uint32_t threadpool_ema_alpha_denominator_{100};
+  uint64_t threadpool_fast_busy_threshold_{2000};   // us
+  uint64_t threadpool_fast_idle_threshold_{500};    // us
+  uint64_t threadpool_slow_busy_threshold_{5000};   // us
+  uint64_t threadpool_slow_idle_threshold_{1000};   // us
 
   std::string compression_;
   std::string compression_per_level_;

--- a/include/pika_conf.h
+++ b/include/pika_conf.h
@@ -493,6 +493,20 @@ class PikaConf : public pstd::BaseConf {
     std::lock_guard l(rwlock_);
     admin_thread_pool_size_ = value;
   }
+  void SetThreadPoolBorrowEnable(const bool value) {
+    std::lock_guard l(rwlock_);
+    threadpool_borrow_enable_ = value;
+  }
+
+  void SetThreadPoolBorrowThresholdPercent(const int value) {
+    std::lock_guard l(rwlock_);
+    threadpool_borrow_threshold_percent_ = value;
+  }
+
+  void SetThreadPoolIdleThresholdPercent(const int value) {
+    std::lock_guard l(rwlock_);
+    threadpool_idle_threshold_percent_ = value;
+  }
 
   void SetSlaveof(const std::string& value) {
     std::lock_guard l(rwlock_);

--- a/include/pika_define.h
+++ b/include/pika_define.h
@@ -417,4 +417,11 @@ const int64_t CACHE_LOAD_QUEUE_MAX_SIZE = 2048;
 const int64_t CACHE_VALUE_ITEM_MAX_SIZE = 2048;
 const int64_t CACHE_LOAD_NUM_ONE_TIME = 256;
 
+/*
+ * cmd pool type
+ */
+enum TaskPoolType {
+  kFastCmdPool,
+  kSlowCmdPool
+};
 #endif

--- a/include/pika_define.h
+++ b/include/pika_define.h
@@ -422,6 +422,7 @@ const int64_t CACHE_LOAD_NUM_ONE_TIME = 256;
  */
 enum TaskPoolType {
   kFastCmdPool,
-  kSlowCmdPool
+  kSlowCmdPool,
+  kAdminCmdPool
 };
 #endif

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -194,6 +194,13 @@ class PikaServer : public pstd::noncopyable {
   size_t ClientProcessorThreadPoolMaxQueueSize();
   size_t SlowCmdThreadPoolCurQueueSize();
   size_t SlowCmdThreadPoolMaxQueueSize();
+  
+  /*
+   * Thread pool dynamic resize
+   */
+  bool ResizeFastCmdThreadPool(size_t new_size);
+  bool ResizeSlowCmdThreadPool(size_t new_size);
+  void GetThreadPoolInfo(std::string* info);
 
   /*
    * BGSave used

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -74,13 +74,8 @@ enum TaskType {
 enum TaskPoolType {
   kFastCmdPool,
   kSlowCmdPool,
-  kNone
 };
 
-struct VirtualSlot {
-  std::atomic<int> active_count{0};
-  std::atomic<TaskPoolType> bound_pool{TaskPoolType::kNone};
-};
 
 struct TaskArg {
   TaskType type;
@@ -618,9 +613,6 @@ class PikaServer : public pstd::noncopyable {
   void ProcessCronTask();
   double HitRatio();
   void SetLogNetActivities(bool value);
-  // Slot management
-  int GetVirtualSlotID(const std::string& key);
-  void ReleaseVirtualSlot(int slot_id);
 
   // Pool status check
   bool IsSlowPoolBusy();
@@ -636,7 +628,8 @@ class PikaServer : public pstd::noncopyable {
   // 自适应命令分类
   bool IsDynamicSlowCommand(const std::string& cmd_name) const;
   void RecordCommandExecutionTime(const std::string& cmd_name, uint64_t duration_us);
-  
+  TaskPoolType DecidePoolType(const std::string& cmd_name, bool is_slow_cmd);
+
   // 设置流控
   void SetCommandRateLimit(double rate_per_sec);
   bool CheckCommandRateLimit();
@@ -809,8 +802,6 @@ class PikaServer : public pstd::noncopyable {
   std::unique_ptr<ThreadPoolMetrics> fast_pool_metrics_;
   std::unique_ptr<ThreadPoolMetrics> slow_pool_metrics_;
   std::unique_ptr<RateLimiter> cmd_rate_limiter_;
-  // 逻辑slot数组
-  std::vector<VirtualSlot> virtual_slots_;
 
   /*
    * acl

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -15,6 +15,9 @@
 #endif
 #include <memory>
 #include <set>
+#include <array>
+#include <chrono>
+#include <unordered_map>
 
 #include "src/cache/include/config.h"
 #include "net/include/bg_thread.h"
@@ -77,6 +80,108 @@ struct TaskArg {
 
 void DoBgslotscleanup(void* arg);
 void DoBgslotsreload(void* arg);
+
+// 命令分类器：基于命令执行时间自动分类快慢命令
+class CommandClassifier {
+public:
+  CommandClassifier(uint64_t slow_threshold_us = 50000, uint64_t fast_threshold_us = 10000,
+                   size_t window_size = 1000);
+  
+  // 记录命令执行时间并动态调整分类
+  void RecordExecutionTime(const std::string& cmd_name, uint64_t duration_us);
+  
+  // 检查命令是否为慢命令
+  bool IsSlowCommand(const std::string& cmd_name) const;
+  
+  // 将命令标记为慢命令
+  void MarkAsSlowCommand(const std::string& cmd_name);
+  
+  // 将命令标记为快命令
+  void MarkAsFastCommand(const std::string& cmd_name);
+  
+  // 获取所有命令的平均执行时间
+  std::unordered_map<std::string, double> GetCommandAvgTimes() const;
+  
+private:
+  struct CommandStats {
+    uint64_t total_time = 0;
+    uint64_t count = 0;
+    std::vector<uint64_t> recent_times;  // 最近N次执行时间
+    size_t time_index = 0;               // 环形缓冲区索引
+    bool initialized = false;            // 是否已经收集了足够的样本
+    
+    void AddTime(uint64_t time, size_t window_size);
+    double GetAverageTime() const;
+    double GetRecentAverageTime() const;
+  };
+  
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, CommandStats> cmd_stats_;
+  std::unordered_set<std::string> slow_commands_;
+  uint64_t slow_threshold_us_;  // 慢命令阈值（微秒）
+  uint64_t fast_threshold_us_;  // 快命令阈值（微秒）
+  size_t window_size_;          // 滑动窗口大小
+};
+
+// 线程池监控指标
+struct ThreadPoolMetrics {
+  std::atomic<uint64_t> tasks_scheduled{0};
+  std::atomic<uint64_t> tasks_completed{0};
+  std::atomic<uint64_t> queue_overflows{0};
+  std::atomic<uint64_t> borrow_attempts{0};
+  std::atomic<uint64_t> successful_borrows{0};
+  
+  // 延迟分布统计（1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s, >5s）
+  std::array<std::atomic<uint64_t>, 9> latency_buckets{};
+  
+  void RecordLatency(uint64_t latency_us);
+  std::string ExportMetrics(const std::string& pool_name) const;
+  void Reset();
+};
+
+// 基于令牌桶的流量控制
+class RateLimiter {
+public:
+  explicit RateLimiter(double rate_per_sec, double burst_size = 100.0);
+  
+  // 尝试获取令牌，成功返回true
+  bool TryAcquire(double tokens = 1.0);
+  
+  // 调整速率
+  void SetRate(double rate_per_sec);
+  
+private:
+  void Refill();
+  
+  double rate_;             // 每秒允许的令牌数
+  double max_tokens_;       // 令牌桶容量
+  double tokens_;           // 当前令牌数
+  std::chrono::steady_clock::time_point last_update_; // 上次更新时间
+  std::mutex mutex_;
+};
+
+// 一致性哈希实现，用于键亲和性
+class ConsistentHash {
+public:
+  explicit ConsistentHash(int num_replicas = 100, int num_buckets = 1024);
+  
+  // 添加节点
+  void AddNode(const std::string& node);
+  
+  // 移除节点
+  void RemoveNode(const std::string& node);
+  
+  // 获取键对应的节点
+  std::string GetNode(const std::string& key) const;
+  
+  // 计算键的哈希值
+  size_t HashKey(const std::string& key) const;
+  
+private:
+  int num_replicas_;
+  std::map<size_t, std::string> ring_;
+  std::hash<std::string> hasher_;
+};
 
 class PikaServer : public pstd::noncopyable {
  public:
@@ -502,6 +607,30 @@ class PikaServer : public pstd::noncopyable {
   void ProcessCronTask();
   double HitRatio();
   void SetLogNetActivities(bool value);
+  
+  /*
+   * 改进的快慢命令分离相关方法
+   */
+  // 动态调整借用阈值
+  void AdjustBorrowThresholds();
+  
+  // 自适应命令分类
+  bool IsDynamicSlowCommand(const std::string& cmd_name) const;
+  void RecordCommandExecutionTime(const std::string& cmd_name, uint64_t duration_us);
+  
+  // 设置流控
+  void SetCommandRateLimit(double rate_per_sec);
+  bool CheckCommandRateLimit();
+  
+  // 获取增强的监控指标
+  std::string GetEnhancedThreadPoolMetrics() const;
+  
+  // 使用一致性哈希判断键亲和性
+  bool IsKeyAffinityToSlow(const std::string& key) const;
+  
+  // 重置监控指标
+  void ResetThreadPoolMetrics();
+  
   /*
   * disable compact
   */
@@ -656,6 +785,15 @@ class PikaServer : public pstd::noncopyable {
    * lastsave used
    */
   int64_t lastsave_ = 0;
+  
+  /*
+   * 改进的快慢命令分离相关成员
+   */
+  std::unique_ptr<CommandClassifier> cmd_classifier_;
+  std::unique_ptr<ThreadPoolMetrics> fast_pool_metrics_;
+  std::unique_ptr<ThreadPoolMetrics> slow_pool_metrics_;
+  std::unique_ptr<RateLimiter> cmd_rate_limiter_;
+  std::unique_ptr<ConsistentHash> key_hash_;
 
   /*
    * acl

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -71,12 +71,6 @@ enum TaskType {
   kCompactRangeList,
 };
 
-enum TaskPoolType {
-  kFastCmdPool,
-  kSlowCmdPool,
-};
-
-
 struct TaskArg {
   TaskType type;
   std::vector<std::string> argv;
@@ -87,57 +81,13 @@ struct TaskArg {
 void DoBgslotscleanup(void* arg);
 void DoBgslotsreload(void* arg);
 
-// 命令分类器：基于命令执行时间自动分类快慢命令
-class CommandClassifier {
-public:
-  CommandClassifier(uint64_t slow_threshold_us = 50000, uint64_t fast_threshold_us = 10000,
-                   size_t window_size = 1000);
-  
-  // 记录命令执行时间并动态调整分类
-  void RecordExecutionTime(const std::string& cmd_name, uint64_t duration_us);
-  
-  // 检查命令是否为慢命令
-  bool IsSlowCommand(const std::string& cmd_name) const;
-  
-  // 将命令标记为慢命令
-  void MarkAsSlowCommand(const std::string& cmd_name);
-  
-  // 将命令标记为快命令
-  void MarkAsFastCommand(const std::string& cmd_name);
-  
-  // 获取所有命令的平均执行时间
-  std::unordered_map<std::string, double> GetCommandAvgTimes() const;
-  
-private:
-  struct CommandStats {
-    uint64_t total_time = 0;
-    uint64_t count = 0;
-    std::vector<uint64_t> recent_times;  // 最近N次执行时间
-    size_t time_index = 0;               // 环形缓冲区索引
-    bool initialized = false;            // 是否已经收集了足够的样本
-    
-    void AddTime(uint64_t time, size_t window_size);
-    double GetAverageTime() const;
-    double GetRecentAverageTime() const;
-  };
-  
-  mutable std::mutex mutex_;
-  std::unordered_map<std::string, CommandStats> cmd_stats_;
-  std::unordered_set<std::string> slow_commands_;
-  uint64_t slow_threshold_us_;  // 慢命令阈值（微秒）
-  uint64_t fast_threshold_us_;  // 快命令阈值（微秒）
-  size_t window_size_;          // 滑动窗口大小
-};
-
-// 线程池监控指标
+// threadpool metrics
 struct ThreadPoolMetrics {
   std::atomic<uint64_t> tasks_scheduled{0};
   std::atomic<uint64_t> tasks_completed{0};
-  std::atomic<uint64_t> queue_overflows{0};
   std::atomic<uint64_t> borrow_attempts{0};
-  std::atomic<uint64_t> successful_borrows{0};
   
-  // 延迟分布统计（1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s, >5s）
+  // latency（1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s, >5s）
   std::array<std::atomic<uint64_t>, 9> latency_buckets{};
   
   void RecordLatency(uint64_t latency_us);
@@ -164,29 +114,6 @@ private:
   double tokens_;           // 当前令牌数
   std::chrono::steady_clock::time_point last_update_; // 上次更新时间
   std::mutex mutex_;
-};
-
-// 一致性哈希实现，用于键亲和性
-class ConsistentHash {
-public:
-  explicit ConsistentHash(int num_replicas = 100, int num_buckets = 1024);
-  
-  // 添加节点
-  void AddNode(const std::string& node);
-  
-  // 移除节点
-  void RemoveNode(const std::string& node);
-  
-  // 获取键对应的节点
-  std::string GetNode(const std::string& key) const;
-  
-  // 计算键的哈希值
-  size_t HashKey(const std::string& key) const;
-  
-private:
-  int num_replicas_;
-  std::map<size_t, std::string> ring_;
-  std::hash<std::string> hasher_;
 };
 
 class PikaServer : public pstd::noncopyable {
@@ -614,31 +541,18 @@ class PikaServer : public pstd::noncopyable {
   double HitRatio();
   void SetLogNetActivities(bool value);
 
-  // Pool status check
+  /*
+   * threadpool borrow
+   */
   bool IsSlowPoolBusy();
   bool IsSlowPoolIdle();
   bool IsFastPoolBusy();
   bool IsFastPoolIdle();
-  /*
-   * 改进的快慢命令分离相关方法
-   */
-  // 动态调整借用阈值
-  void AdjustBorrowThresholds();
-  
-  // 自适应命令分类
-  bool IsDynamicSlowCommand(const std::string& cmd_name) const;
-  void RecordCommandExecutionTime(const std::string& cmd_name, uint64_t duration_us);
-  TaskPoolType DecidePoolType(const std::string& cmd_name, bool is_slow_cmd);
-
-  // 设置流控
-  void SetCommandRateLimit(double rate_per_sec);
-  bool CheckCommandRateLimit();
-  
-  // 获取增强的监控指标
-  std::string GetEnhancedThreadPoolMetrics() const;
-  
-  // 重置监控指标
+  TaskPoolType DecidePoolType(bool is_slow_cmd);
+  std::string GetEnhancedThreadPoolMetrics();
   void ResetThreadPoolMetrics();
+  ThreadPoolMetrics* GetSlowPoolMetrics() { return slow_pool_metrics_.get(); }
+  ThreadPoolMetrics* GetFastPoolMetrics() { return fast_pool_metrics_.get(); }
   
   /*
   * disable compact
@@ -796,12 +710,10 @@ class PikaServer : public pstd::noncopyable {
   int64_t lastsave_ = 0;
   
   /*
-   * 改进的快慢命令分离相关成员
+   * metrics used
    */
-  std::unique_ptr<CommandClassifier> cmd_classifier_;
   std::unique_ptr<ThreadPoolMetrics> fast_pool_metrics_;
   std::unique_ptr<ThreadPoolMetrics> slow_pool_metrics_;
-  std::unique_ptr<RateLimiter> cmd_rate_limiter_;
 
   /*
    * acl

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -71,6 +71,17 @@ enum TaskType {
   kCompactRangeList,
 };
 
+enum TaskPoolType {
+  kFastCmdPool,
+  kSlowCmdPool,
+  kNone
+};
+
+struct VirtualSlot {
+  std::atomic<int> active_count{0};
+  std::atomic<TaskPoolType> bound_pool{TaskPoolType::kNone};
+};
+
 struct TaskArg {
   TaskType type;
   std::vector<std::string> argv;
@@ -607,7 +618,15 @@ class PikaServer : public pstd::noncopyable {
   void ProcessCronTask();
   double HitRatio();
   void SetLogNetActivities(bool value);
-  
+  // Slot management
+  int GetVirtualSlotID(const std::string& key);
+  void ReleaseVirtualSlot(int slot_id);
+
+  // Pool status check
+  bool IsSlowPoolBusy();
+  bool IsSlowPoolIdle();
+  bool IsFastPoolBusy();
+  bool IsFastPoolIdle();
   /*
    * 改进的快慢命令分离相关方法
    */
@@ -624,9 +643,6 @@ class PikaServer : public pstd::noncopyable {
   
   // 获取增强的监控指标
   std::string GetEnhancedThreadPoolMetrics() const;
-  
-  // 使用一致性哈希判断键亲和性
-  bool IsKeyAffinityToSlow(const std::string& key) const;
   
   // 重置监控指标
   void ResetThreadPoolMetrics();
@@ -793,7 +809,8 @@ class PikaServer : public pstd::noncopyable {
   std::unique_ptr<ThreadPoolMetrics> fast_pool_metrics_;
   std::unique_ptr<ThreadPoolMetrics> slow_pool_metrics_;
   std::unique_ptr<RateLimiter> cmd_rate_limiter_;
-  std::unique_ptr<ConsistentHash> key_hash_;
+  // 逻辑slot数组
+  std::vector<VirtualSlot> virtual_slots_;
 
   /*
    * acl

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -84,7 +84,7 @@ void DoBgslotsreload(void* arg);
 // threadpool metrics
 struct ThreadPoolMetrics {
   std::atomic<uint64_t> tasks_scheduled{0};
-  std::atomic<uint64_t> tasks_completed{0};
+  std::atomic<uint64_t> active_tasks{0};
   std::atomic<uint64_t> borrow_attempts{0};
   
   // latency（1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s, >5s）
@@ -567,6 +567,7 @@ class PikaServer : public pstd::noncopyable {
   void AutoDeleteExpiredDump();
   void AutoUpdateNetworkMetric();
   void PrintThreadPoolQueueStatus();
+  void AutoUpdateIdlePoolEMA();
   void StatDiskUsage();
   int64_t GetLastSaveTime(const std::string& dump_dir);
 
@@ -708,15 +709,20 @@ class PikaServer : public pstd::noncopyable {
   PoolLatencyStats slow_pool_stats_;
 
   // EMA configuration parameters (atomic for dynamic updates)
-  std::atomic<uint32_t> ema_alpha_numerator_{5};      // EMA alpha numerator (alpha = 5/100 = 0.05)
-  std::atomic<uint32_t> ema_alpha_denominator_{100};  // EMA alpha denominator
-  std::atomic<uint64_t> fast_busy_threshold_us_{2000}; // Fast pool busy threshold (2ms)
-  std::atomic<uint64_t> fast_idle_threshold_us_{500};  // Fast pool idle threshold (0.5ms)
-  std::atomic<uint64_t> slow_busy_threshold_us_{5000}; // Slow pool busy threshold (5ms)
-  std::atomic<uint64_t> slow_idle_threshold_us_{1000}; // Slow pool idle threshold (1ms)
+  std::atomic<uint32_t> ema_alpha_numerator_{5};
+  std::atomic<uint32_t> ema_alpha_denominator_{100};
+  std::atomic<uint64_t> fast_busy_threshold_us_{2000};
+  std::atomic<uint64_t> fast_idle_threshold_us_{500};
+  std::atomic<uint64_t> slow_busy_threshold_us_{5000};
+  std::atomic<uint64_t> slow_idle_threshold_us_{1000};
   
   // Get EMA queue wait time (us)
   uint64_t GetEMAQueueWait(TaskPoolType pool_type) const;
+
+  // EMA decay helper functions
+  uint64_t CalculateDecayedEMA(uint64_t old_ema, uint64_t last_update, uint64_t now);
+  void UpdateSinglePoolEMA(PoolLatencyStats& stats, uint64_t new_sample, uint64_t now);
+  void DecaySinglePool(PoolLatencyStats& stats, uint64_t now);
   
   // Busy/Idle determination based on EMA (internal helpers)
   bool IsFastPoolBusyByEMA() const;
@@ -724,6 +730,10 @@ class PikaServer : public pstd::noncopyable {
   bool IsSlowPoolBusyByEMA() const;
   bool IsSlowPoolIdleByEMA() const;
 
+  // Borrow idle window
+  std::atomic<uint64_t> threadpool_idle_window_us_{1000000};
+  std::atomic<uint64_t> fast_pool_last_active_us_{0};
+  std::atomic<uint64_t> slow_pool_last_active_us_{0};
   /*
    * acl
    */

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -530,6 +530,8 @@ class PikaServer : public pstd::noncopyable {
   TaskPoolType DecidePoolType(bool is_slow_cmd);
   std::string GetEnhancedThreadPoolMetrics();
   void ResetThreadPoolMetrics();
+  void UpdateQueueWaitStats(TaskPoolType pool_type, uint64_t queue_wait_us);
+  void LoadThreadPoolConfig();
   ThreadPoolMetrics* GetSlowPoolMetrics() { return slow_pool_metrics_.get(); }
   ThreadPoolMetrics* GetFastPoolMetrics() { return fast_pool_metrics_.get(); }
   
@@ -693,6 +695,34 @@ class PikaServer : public pstd::noncopyable {
    */
   std::unique_ptr<ThreadPoolMetrics> fast_pool_metrics_;
   std::unique_ptr<ThreadPoolMetrics> slow_pool_metrics_;
+
+  /*
+   * EMA statistics for queue wait time (used together with queue percent)
+   */
+  struct PoolLatencyStats {
+    std::atomic<uint64_t> ema_queue_wait_us_{0};  // EMA queue wait time (us)
+    std::atomic<uint64_t> last_update_us_{0};     // Last update time (us)
+  };
+
+  PoolLatencyStats fast_pool_stats_;
+  PoolLatencyStats slow_pool_stats_;
+
+  // EMA configuration parameters (atomic for dynamic updates)
+  std::atomic<uint32_t> ema_alpha_numerator_{5};      // EMA alpha numerator (alpha = 5/100 = 0.05)
+  std::atomic<uint32_t> ema_alpha_denominator_{100};  // EMA alpha denominator
+  std::atomic<uint64_t> fast_busy_threshold_us_{2000}; // Fast pool busy threshold (2ms)
+  std::atomic<uint64_t> fast_idle_threshold_us_{500};  // Fast pool idle threshold (0.5ms)
+  std::atomic<uint64_t> slow_busy_threshold_us_{5000}; // Slow pool busy threshold (5ms)
+  std::atomic<uint64_t> slow_idle_threshold_us_{1000}; // Slow pool idle threshold (1ms)
+  
+  // Get EMA queue wait time (us)
+  uint64_t GetEMAQueueWait(TaskPoolType pool_type) const;
+  
+  // Busy/Idle determination based on EMA (internal helpers)
+  bool IsFastPoolBusyByEMA() const;
+  bool IsFastPoolIdleByEMA() const;
+  bool IsSlowPoolBusyByEMA() const;
+  bool IsSlowPoolIdleByEMA() const;
 
   /*
    * acl

--- a/include/pika_server.h
+++ b/include/pika_server.h
@@ -95,27 +95,6 @@ struct ThreadPoolMetrics {
   void Reset();
 };
 
-// 基于令牌桶的流量控制
-class RateLimiter {
-public:
-  explicit RateLimiter(double rate_per_sec, double burst_size = 100.0);
-  
-  // 尝试获取令牌，成功返回true
-  bool TryAcquire(double tokens = 1.0);
-  
-  // 调整速率
-  void SetRate(double rate_per_sec);
-  
-private:
-  void Refill();
-  
-  double rate_;             // 每秒允许的令牌数
-  double max_tokens_;       // 令牌桶容量
-  double tokens_;           // 当前令牌数
-  std::chrono::steady_clock::time_point last_update_; // 上次更新时间
-  std::mutex mutex_;
-};
-
 class PikaServer : public pstd::noncopyable {
  public:
   PikaServer();

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -884,6 +884,7 @@ const std::string InfoCmd::kRocksDBSection = "rocksdb";
 const std::string InfoCmd::kDebugSection = "debug";
 const std::string InfoCmd::kCommandStatsSection = "commandstats";
 const std::string InfoCmd::kCacheSection = "cache";
+const std::string InfoCmd::kThreadpoolSection = "threadpool";
 
 
 const std::string ClientCmd::KILLTYPE_NORMAL = "normal";
@@ -969,6 +970,8 @@ void InfoCmd::DoInitial() {
     info_section_ = kInfoCommandStats;
   } else if (strcasecmp(argv_[1].data(), kCacheSection.data()) == 0) {
     info_section_ = kInfoCache;
+  } else if (strcasecmp(argv_[1].data(), kThreadpoolSection.data()) == 0) {
+    info_section_ = kInfoThreadpool;
   } else {
     info_section_ = kInfoErr;
   }
@@ -1009,6 +1012,8 @@ void InfoCmd::Do() {
       InfoCommandStats(info);
       info.append("\r\n");
       InfoCache(info, db_);
+      info.append("\r\n");
+      g_pika_server->GetThreadPoolInfo(&info);
       info.append("\r\n");
       InfoCPU(info);
       info.append("\r\n");
@@ -1053,6 +1058,9 @@ void InfoCmd::Do() {
       break;
     case kInfoCache:
       InfoCache(info, db_);
+      break;
+    case kInfoThreadpool:
+      g_pika_server->GetThreadPoolInfo(&info);
       break;
     default:
       // kInfoErr is nothing

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -1671,6 +1671,24 @@ void ConfigCmd::ConfigGet(std::string& ret) {
     EncodeNumber(&config_body, g_pika_conf->admin_thread_pool_size());
   }
 
+  if (pstd::stringmatch(pattern.data(), "threadpool-borrow-enable", 1) != 0) {
+    elements += 2;
+    EncodeString(&config_body, "threadpool-borrow-enable");
+    EncodeString(&config_body, g_pika_conf->threadpool_borrow_enable()  ? "yes" : "no");
+  }
+
+  if (pstd::stringmatch(pattern.data(), "threadpool-borrow-threshold-percent", 1) != 0) {
+    elements += 2;
+    EncodeString(&config_body, "threadpool-borrow-threshold-percent");
+    EncodeNumber(&config_body, g_pika_conf->threadpool_borrow_threshold_percent());
+  }
+
+  if (pstd::stringmatch(pattern.data(), "threadpool-idle-threshold-percent", 1) != 0) {
+    elements += 2;
+    EncodeString(&config_body, "threadpool-idle-threshold-percent");
+    EncodeNumber(&config_body, g_pika_conf->threadpool_idle_threshold_percent());
+  }
+
   if (pstd::stringmatch(pattern.data(), "userblacklist", 1) != 0) {
     elements += 2;
     EncodeString(&config_body, "userblacklist");
@@ -2337,6 +2355,11 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
         "slave-priority",
         "sync-window-size",
         "slow-cmd-list",
+        "thread-pool-size",
+        "slow-cmd-thread-pool-size",
+        "threadpool-borrow-enable",
+        "threadpool-borrow-threshold-percent",
+        "threadpool-idle-threshold-percent",
         // Options for storage engine
         // MutableDBOptions
         "max-cache-files",
@@ -2688,6 +2711,63 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
     res_.AppendStringRaw("+OK\r\n");
   } else if (set_item == "slow-cmd-list") {
     g_pika_conf->SetSlowCmd(value);
+    res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "thread-pool-size") {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0) {
+      res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'thread-pool-size'\r\n");
+      return;
+    }
+    size_t current_queue_size = g_pika_server->ClientProcessorThreadPoolCurQueueSize();
+    if (current_queue_size > 0){
+      res_.AppendStringRaw("-ERR Can't resize thread-pool-size when there are tasks in the queue\r\n");
+      return;
+    }
+    long int thread_pool_size = (1 > ival || 24 < ival) ? 12 : ival;
+    if (!g_pika_server->ResizeFastCmdThreadPool(static_cast<size_t>(thread_pool_size))) {
+      res_.AppendStringRaw("-ERR Resize thread-pool-size failed\r\n");
+      return;
+    }
+    g_pika_conf->SetThreadPoolSize(static_cast<int>(thread_pool_size));
+    res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "slow-cmd-thread-pool-size") {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0 || ival > 1024) {
+      res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'slow-cmd-thread-pool-size'\r\n");
+      return;
+    }
+    size_t current_queue_size = g_pika_server->SlowCmdThreadPoolCurQueueSize();
+    if (current_queue_size > 0) {
+      res_.AppendStringRaw("-ERR Can't resize slow-cmd-pool-size when there are tasks in the queue\r\n");
+      return;
+    }
+    long int slow_cmd_thread_pool_size = (1 > ival || 24 < ival) ? 1 : ival;
+    if (!g_pika_server->ResizeSlowCmdThreadPool(static_cast<size_t>(slow_cmd_thread_pool_size))) {
+      res_.AppendStringRaw("-ERR Resize slow-cmd-thread-pool-size failed\r\n");
+      return;
+    }
+    g_pika_conf->SetLowLevelThreadPoolSize(static_cast<int>(slow_cmd_thread_pool_size));
+    res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "threadpool-borrow-enable") {
+    std::string lower = pstd::StringToLower(value);
+    if (lower != "yes" && lower != "no") {
+      res_.AppendStringRaw("-ERR invalid argument \'" + value + "\' for CONFIG SET 'threadpool-borrow-enable'\r\n");
+      return;
+    }
+    bool borrow_enable = (lower == "yes") ? true : false;
+    g_pika_conf->SetThreadPoolBorrowEnable(borrow_enable);
+    res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "threadpool-borrow-threshold-percent") {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival < 1 || ival > 99) {
+      res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'threadpool-borrow-threshold-percent'\r\n");
+      return;
+    }
+    g_pika_conf->SetThreadPoolBorrowThresholdPercent(static_cast<int>(ival));
+    res_.AppendStringRaw("+OK\r\n");
+  } else if (set_item == "threadpool-idle-threshold-percent") {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival < 1 || ival > 99) {
+      res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'threadpool-idle-threshold-percent'\r\n");
+      return;
+    }
+    g_pika_conf->SetThreadPoolIdleThresholdPercent(static_cast<int>(ival));
     res_.AppendStringRaw("+OK\r\n");
   } else if (set_item == "max-cache-files") {
     if (pstd::string2int(value.data(), value.size(), &ival) == 0) {

--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -2730,7 +2730,7 @@ void ConfigCmd::ConfigSet(std::shared_ptr<DB> db) {
     g_pika_conf->SetThreadPoolSize(static_cast<int>(thread_pool_size));
     res_.AppendStringRaw("+OK\r\n");
   } else if (set_item == "slow-cmd-thread-pool-size") {
-    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0 || ival > 1024) {
+    if (pstd::string2int(value.data(), value.size(), &ival) == 0 || ival <= 0 || ival > 24) {
       res_.AppendStringRaw("-ERR Invalid argument \'" + value + "\' for CONFIG SET 'slow-cmd-thread-pool-size'\r\n");
       return;
     }

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -337,7 +337,8 @@ void PikaClientConn::ProcessRedisCmds(const std::vector<net::RedisCmdArgsType>& 
         return;
       }
       arg->cache_miss_in_rtc_ = true;
-      time_stat_->before_queue_ts_ = pstd::NowMicros();
+      // In case of cache miss, update the enqueue time to after the cache check
+      time_stat_->enqueue_ts_ = time_stat_->before_queue_ts_ = pstd::NowMicros();
     }
 
     g_pika_server->ScheduleClientPool(&DoBackgroundTask, arg, is_slow_cmd, is_admin_cmd);
@@ -350,7 +351,15 @@ void PikaClientConn::DoBackgroundTask(void* arg) {
   std::unique_ptr<BgTaskArg> bg_arg(static_cast<BgTaskArg*>(arg));
   std::shared_ptr<PikaClientConn> conn_ptr = bg_arg->conn_ptr;
   conn_ptr->task_pool_type_ = bg_arg->pool_type;
-  conn_ptr->time_stat_->dequeue_ts_ = pstd::NowMicros();
+  
+  // Record dequeue time and calculate queue wait time
+  uint64_t now = pstd::NowMicros();
+  conn_ptr->time_stat_->dequeue_ts_ = now;
+  uint64_t queue_wait = now - conn_ptr->time_stat_->enqueue_ts_;
+  
+  // Update EMA statistics for queue wait time
+  g_pika_server->UpdateQueueWaitStats(bg_arg->pool_type, queue_wait);
+  
   if (conn_ptr->IsClose()) {
     LOG(INFO) << "conn " << conn_ptr->ip_port() << " has already been closed, skip processing command";
     return;

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -428,15 +428,6 @@ bool PikaClientConn::ReadCmdInCache(const net::RedisCmdArgsType& argv, const std
     time_stat_->process_done_ts_ = pstd::NowMicros();
     (*cmdstat_map)[argv[0]].cmd_count.fetch_add(1);
     (*cmdstat_map)[argv[0]].cmd_time_consuming.fetch_add(time_stat_->total_time());
-
-    uint64_t duration_us = time_stat_->total_time();
-    ThreadPoolMetrics* metrics = (task_pool_type_ == TaskPoolType::kSlowCmdPool)
-                                  ? g_pika_server->GetSlowPoolMetrics()
-                                  : g_pika_server->GetFastPoolMetrics();
-    if (metrics) {
-      metrics->RecordLatency(duration_us);
-      metrics->tasks_completed.fetch_add(1, std::memory_order_relaxed);
-    }
     resp_array.emplace_back(std::make_shared<std::string>(std::move(c_ptr->res().message())));
     TryWriteResp();
   }

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -233,7 +233,6 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
                                 : g_pika_server->GetFastPoolMetrics();
   if (metrics) {
     metrics->RecordLatency(duration_us);
-    metrics->tasks_completed.fetch_add(1, std::memory_order_relaxed);
   }
   if (g_pika_conf->slowlog_slower_than() >= 0) {
     ProcessSlowlog(argv, c_ptr, pipeline_idx, pipeline_total);
@@ -351,15 +350,28 @@ void PikaClientConn::DoBackgroundTask(void* arg) {
   std::unique_ptr<BgTaskArg> bg_arg(static_cast<BgTaskArg*>(arg));
   std::shared_ptr<PikaClientConn> conn_ptr = bg_arg->conn_ptr;
   conn_ptr->task_pool_type_ = bg_arg->pool_type;
-  
+
+  ThreadPoolMetrics* metrics = nullptr;
+  if (bg_arg->pool_type == TaskPoolType::kFastCmdPool) {
+    metrics = g_pika_server->GetFastPoolMetrics();
+  } else if (bg_arg->pool_type == TaskPoolType::kSlowCmdPool) {
+    metrics = g_pika_server->GetSlowPoolMetrics();
+  }
+
+  if (metrics) {
+    metrics->active_tasks.fetch_add(1, std::memory_order_relaxed);
+  }
+  DEFER {
+    if (metrics) {
+      metrics->active_tasks.fetch_sub(1, std::memory_order_relaxed);
+    }
+  };
   // Record dequeue time and calculate queue wait time
   uint64_t now = pstd::NowMicros();
   conn_ptr->time_stat_->dequeue_ts_ = now;
   uint64_t queue_wait = now - conn_ptr->time_stat_->enqueue_ts_;
-  
   // Update EMA statistics for queue wait time
   g_pika_server->UpdateQueueWaitStats(bg_arg->pool_type, queue_wait);
-  
   if (conn_ptr->IsClose()) {
     LOG(INFO) << "conn " << conn_ptr->ip_port() << " has already been closed, skip processing command";
     return;

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -19,6 +19,7 @@
 #include "net/src/dispatch_thread.h"
 #include "net/src/worker_thread.h"
 #include "src/pstd/include/scope_record_lock.h"
+#include "pstd/include/pstd_defer.h"
 
 #include "rocksdb/perf_context.h"
 #include "rocksdb/iostats_context.h"

--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -227,6 +227,14 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(const PikaCmdArgsType& argv, const st
   (*cmdstat_map)[opt].cmd_count.fetch_add(1);
   (*cmdstat_map)[opt].cmd_time_consuming.fetch_add(time_stat_->total_time());
 
+  uint64_t duration_us = time_stat_->total_time();
+  ThreadPoolMetrics* metrics = (task_pool_type_ == TaskPoolType::kSlowCmdPool)
+                                ? g_pika_server->GetSlowPoolMetrics()
+                                : g_pika_server->GetFastPoolMetrics();
+  if (metrics) {
+    metrics->RecordLatency(duration_us);
+    metrics->tasks_completed.fetch_add(1, std::memory_order_relaxed);
+  }
   if (g_pika_conf->slowlog_slower_than() >= 0) {
     ProcessSlowlog(argv, c_ptr, pipeline_idx, pipeline_total);
   }
@@ -341,6 +349,7 @@ void PikaClientConn::ProcessRedisCmds(const std::vector<net::RedisCmdArgsType>& 
 void PikaClientConn::DoBackgroundTask(void* arg) {
   std::unique_ptr<BgTaskArg> bg_arg(static_cast<BgTaskArg*>(arg));
   std::shared_ptr<PikaClientConn> conn_ptr = bg_arg->conn_ptr;
+  conn_ptr->task_pool_type_ = bg_arg->pool_type;
   conn_ptr->time_stat_->dequeue_ts_ = pstd::NowMicros();
   if (conn_ptr->IsClose()) {
     LOG(INFO) << "conn " << conn_ptr->ip_port() << " has already been closed, skip processing command";
@@ -410,6 +419,15 @@ bool PikaClientConn::ReadCmdInCache(const net::RedisCmdArgsType& argv, const std
     time_stat_->process_done_ts_ = pstd::NowMicros();
     (*cmdstat_map)[argv[0]].cmd_count.fetch_add(1);
     (*cmdstat_map)[argv[0]].cmd_time_consuming.fetch_add(time_stat_->total_time());
+
+    uint64_t duration_us = time_stat_->total_time();
+    ThreadPoolMetrics* metrics = (task_pool_type_ == TaskPoolType::kSlowCmdPool)
+                                  ? g_pika_server->GetSlowPoolMetrics()
+                                  : g_pika_server->GetFastPoolMetrics();
+    if (metrics) {
+      metrics->RecordLatency(duration_us);
+      metrics->tasks_completed.fetch_add(1, std::memory_order_relaxed);
+    }
     resp_array.emplace_back(std::make_shared<std::string>(std::move(c_ptr->res().message())));
     TryWriteResp();
   }

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -76,6 +76,20 @@ int PikaConf::Load() {
   GetConfStr("slow-cmd-pool", &slowcmdpool);
   slow_cmd_pool_.store(slowcmdpool == "yes" ? true : false);
 
+  std::string threadpool_borrow;
+  GetConfStr("threadpool-borrow-enable", &threadpool_borrow);
+  threadpool_borrow_enable_ = threadpool_borrow == "yes" ? true : false;
+
+  GetConfInt("threadpool-borrow-threshold-percent", &threadpool_borrow_threshold_percent_);
+  if (threadpool_borrow_threshold_percent_ <= 0 || threadpool_borrow_threshold_percent_ >= 100) {
+    threadpool_borrow_threshold_percent_ = 80;
+  }
+
+  GetConfInt("threadpool-idle-threshold-percent", &threadpool_idle_threshold_percent_);
+  if (threadpool_idle_threshold_percent_ <= 0 || threadpool_idle_threshold_percent_ >= 100) {
+    threadpool_idle_threshold_percent_ = 20;
+  }
+
   int binlog_writer_num = 1;
   GetConfInt("binlog-writer-num", &binlog_writer_num);
   if (binlog_writer_num <= 0 || binlog_writer_num > 24) {

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -90,6 +90,34 @@ int PikaConf::Load() {
     threadpool_idle_threshold_percent_ = 20;
   }
 
+  // EMA queue-wait based load signals (used together with queue percent)
+  int alpha_num = 0;
+  int alpha_den = 0;
+  GetConfInt("threadpool-ema-alpha-numerator", &alpha_num);
+  GetConfInt("threadpool-ema-alpha-denominator", &alpha_den);
+  if (alpha_num > 0 && alpha_den > 0 && alpha_num <= alpha_den) {
+    threadpool_ema_alpha_numerator_ = static_cast<uint32_t>(alpha_num);
+    threadpool_ema_alpha_denominator_ = static_cast<uint32_t>(alpha_den);
+  }
+
+  int64_t threshold = 0;
+  GetConfInt64("threadpool-fast-busy-threshold", &threshold);
+  if (threshold > 0) {
+    threadpool_fast_busy_threshold_ = static_cast<uint64_t>(threshold);
+  }
+  GetConfInt64("threadpool-fast-idle-threshold", &threshold);
+  if (threshold > 0) {
+    threadpool_fast_idle_threshold_ = static_cast<uint64_t>(threshold);
+  }
+  GetConfInt64("threadpool-slow-busy-threshold", &threshold);
+  if (threshold > 0) {
+    threadpool_slow_busy_threshold_ = static_cast<uint64_t>(threshold);
+  }
+  GetConfInt64("threadpool-slow-idle-threshold", &threshold);
+  if (threshold > 0) {
+    threadpool_slow_idle_threshold_ = static_cast<uint64_t>(threshold);
+  }
+
   int binlog_writer_num = 1;
   GetConfInt("binlog-writer-num", &binlog_writer_num);
   if (binlog_writer_num <= 0 || binlog_writer_num > 24) {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -790,6 +790,34 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
     return;
   }
 
+  // Extract key from command to determine key affinity
+  // This ensures commands on the same key always go to the same thread pool
+  auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
+  bool key_affinity_to_slow = false;
+  bool has_key = false;
+  
+  if (bg_arg && !bg_arg->redis_cmds.empty() && !bg_arg->redis_cmds[0].empty()) {
+    const auto& cmd_args = bg_arg->redis_cmds[0];
+    std::string cmd_name = cmd_args[0];
+    pstd::StringToLower(cmd_name);
+    
+    // Extract key based on command type
+    // Most commands have key as the first argument after command name
+    std::string key;
+    if (cmd_args.size() > 1) {
+      // For most commands, key is argv[1]
+      // For special commands like MGET, MSET, we use the first key
+      key = cmd_args[1];
+      has_key = true;
+      
+      // Use simple hash to determine key affinity
+      // Same key will always have same affinity (fast or slow pool)
+      std::hash<std::string> hasher;
+      size_t hash_value = hasher(key);
+      key_affinity_to_slow = (hash_value % 2 == 1);
+    }
+  }
+
   // Borrowing is enabled, check queue status and decide
   size_t slow_queue_size = SlowCmdThreadPoolCurQueueSize();
   size_t slow_max_queue = SlowCmdThreadPoolMaxQueueSize();
@@ -805,26 +833,45 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
   size_t slow_idle_threshold = slow_max_queue * idle_threshold_percent / 100;
   size_t fast_idle_threshold = fast_max_queue * idle_threshold_percent / 100;
 
+  // Decision logic considering both command type and key affinity
   if (is_slow_cmd) {
     // This is a slow command
-    if (slow_queue_size >= slow_borrow_threshold && fast_queue_size <= fast_idle_threshold) {
-      // Slow pool is busy and fast pool is idle, borrow from fast pool
+    if (has_key && !key_affinity_to_slow) {
+      // Key affinity is to fast pool, must use fast pool to maintain order
       pika_client_processor_->SchedulePool(func, arg);
-      LOG(INFO) << "Slow cmd borrows fast pool (slow_queue: " << slow_queue_size 
-                << "/" << slow_max_queue << ", fast_queue: " << fast_queue_size 
-                << "/" << fast_max_queue << ")";
+    } else if (slow_queue_size >= slow_borrow_threshold && fast_queue_size <= fast_idle_threshold) {
+      // Slow pool is busy and fast pool is idle
+      if (has_key && key_affinity_to_slow) {
+        // Key belongs to slow pool, cannot borrow
+        pika_slow_cmd_thread_pool_->Schedule(func, arg);
+      } else {
+        // Can borrow from fast pool
+        pika_client_processor_->SchedulePool(func, arg);
+        LOG(INFO) << "Slow cmd borrows fast pool (slow_queue: " << slow_queue_size 
+                  << "/" << slow_max_queue << ", fast_queue: " << fast_queue_size 
+                  << "/" << fast_max_queue << ")";
+      }
     } else {
       // Normal case: use slow pool
       pika_slow_cmd_thread_pool_->Schedule(func, arg);
     }
   } else {
     // This is a fast command
-    if (fast_queue_size >= fast_borrow_threshold && slow_queue_size <= slow_idle_threshold) {
-      // Fast pool is busy and slow pool is idle, borrow from slow pool
+    if (has_key && key_affinity_to_slow) {
+      // Key affinity is to slow pool, must use slow pool to maintain order
       pika_slow_cmd_thread_pool_->Schedule(func, arg);
-      LOG(INFO) << "Fast cmd borrows slow pool (fast_queue: " << fast_queue_size 
-                << "/" << fast_max_queue << ", slow_queue: " << slow_queue_size 
-                << "/" << slow_max_queue << ")";
+    } else if (fast_queue_size >= fast_borrow_threshold && slow_queue_size <= slow_idle_threshold) {
+      // Fast pool is busy and slow pool is idle
+      if (has_key && !key_affinity_to_slow) {
+        // Key belongs to fast pool, cannot borrow
+        pika_client_processor_->SchedulePool(func, arg);
+      } else {
+        // Can borrow from slow pool
+        pika_slow_cmd_thread_pool_->Schedule(func, arg);
+        LOG(INFO) << "Fast cmd borrows slow pool (fast_queue: " << fast_queue_size 
+                  << "/" << fast_max_queue << ", slow_queue: " << slow_queue_size 
+                  << "/" << slow_max_queue << ")";
+      }
     } else {
       // Normal case: use fast pool
       pika_client_processor_->SchedulePool(func, arg);
@@ -860,6 +907,115 @@ size_t PikaServer::SlowCmdThreadPoolMaxQueueSize() {
     return 0;
   }
   return pika_slow_cmd_thread_pool_->max_queue_size();
+}
+
+bool PikaServer::ResizeFastCmdThreadPool(size_t new_size) {
+  if (new_size == 0 || new_size > 1024) {
+    LOG(WARNING) << "Invalid fast cmd thread pool size: " << new_size << ", must be between 1 and 1024";
+    return false;
+  }
+
+  size_t old_size = g_pika_conf->thread_pool_size();
+  if (new_size == old_size) {
+    LOG(INFO) << "Fast cmd thread pool size unchanged: " << new_size;
+    return true;
+  }
+
+  LOG(INFO) << "Resizing fast cmd thread pool from " << old_size << " to " << new_size;
+  
+  // Update config
+  g_pika_conf->SetThreadPoolSize(static_cast<int>(new_size));
+  
+  // Stop old thread pool gracefully
+  LOG(INFO) << "Waiting for old fast cmd thread pool tasks to complete...";
+  pika_client_processor_->Stop();
+  
+  // Create and start new thread pool
+  pika_client_processor_ = std::make_unique<PikaClientProcessor>(new_size, 100000);
+  int ret = pika_client_processor_->Start();
+  if (ret != net::kSuccess) {
+    LOG(ERROR) << "Failed to start new fast cmd thread pool: " << ret;
+    return false;
+  }
+  
+  LOG(INFO) << "Successfully resized fast cmd thread pool to " << new_size;
+  return true;
+}
+
+bool PikaServer::ResizeSlowCmdThreadPool(size_t new_size) {
+  if (new_size == 0 || new_size > 1024) {
+    LOG(WARNING) << "Invalid slow cmd thread pool size: " << new_size << ", must be between 1 and 1024";
+    return false;
+  }
+
+  size_t old_size = g_pika_conf->slow_cmd_thread_pool_size();
+  if (new_size == old_size) {
+    LOG(INFO) << "Slow cmd thread pool size unchanged: " << new_size;
+    return true;
+  }
+
+  LOG(INFO) << "Resizing slow cmd thread pool from " << old_size << " to " << new_size;
+  
+  // Update config
+  g_pika_conf->SetLowLevelThreadPoolSize(static_cast<int>(new_size));
+  
+  // Stop old thread pool gracefully
+  LOG(INFO) << "Waiting for old slow cmd thread pool tasks to complete...";
+  while (SlowCmdThreadPoolCurQueueSize() != 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  pika_slow_cmd_thread_pool_->stop_thread_pool();
+  
+  // Create and start new thread pool
+  pika_slow_cmd_thread_pool_ = std::make_unique<net::ThreadPool>(new_size, 100000);
+  int ret = pika_slow_cmd_thread_pool_->start_thread_pool();
+  if (ret != net::kSuccess) {
+    LOG(ERROR) << "Failed to start new slow cmd thread pool: " << ret;
+    return false;
+  }
+  
+  LOG(INFO) << "Successfully resized slow cmd thread pool to " << new_size;
+  return true;
+}
+
+void PikaServer::GetThreadPoolInfo(std::string* info) {
+  std::stringstream tmp_stream;
+  
+  // Fast cmd thread pool info
+  size_t fast_pool_size = g_pika_conf->thread_pool_size();
+  size_t fast_queue_size = ClientProcessorThreadPoolCurQueueSize();
+  size_t fast_max_queue = ClientProcessorThreadPoolMaxQueueSize();
+  double fast_usage = fast_max_queue > 0 ? (fast_queue_size * 100.0 / fast_max_queue) : 0.0;
+  
+  tmp_stream << "# Threadpool\r\n";
+  tmp_stream << "fast_cmd_pool_size:" << fast_pool_size << "\r\n";
+  tmp_stream << "fast_cmd_pool_queue_size:" << fast_queue_size << "\r\n";
+  tmp_stream << "fast_cmd_pool_max_queue_size:" << fast_max_queue << "\r\n";
+  tmp_stream << "fast_cmd_pool_usage:" << std::fixed << std::setprecision(2) << fast_usage << "%\r\n";
+  
+  // Slow cmd thread pool info
+  if (g_pika_conf->slow_cmd_pool()) {
+    size_t slow_pool_size = g_pika_conf->slow_cmd_thread_pool_size();
+    size_t slow_queue_size = SlowCmdThreadPoolCurQueueSize();
+    size_t slow_max_queue = SlowCmdThreadPoolMaxQueueSize();
+    double slow_usage = slow_max_queue > 0 ? (slow_queue_size * 100.0 / slow_max_queue) : 0.0;
+    
+    tmp_stream << "slow_cmd_pool_size:" << slow_pool_size << "\r\n";
+    tmp_stream << "slow_cmd_pool_queue_size:" << slow_queue_size << "\r\n";
+    tmp_stream << "slow_cmd_pool_max_queue_size:" << slow_max_queue << "\r\n";
+    tmp_stream << "slow_cmd_pool_usage:" << std::fixed << std::setprecision(2) << slow_usage << "%\r\n";
+  } else {
+    tmp_stream << "slow_cmd_pool_size:0\r\n";
+    tmp_stream << "slow_cmd_pool_queue_size:0\r\n";
+    tmp_stream << "slow_cmd_pool_max_queue_size:0\r\n";
+    tmp_stream << "slow_cmd_pool_usage:0.00%\r\n";
+  }
+  
+  // Admin cmd thread pool info
+  size_t admin_pool_size = g_pika_conf->admin_thread_pool_size();
+  tmp_stream << "admin_cmd_pool_size:" << admin_pool_size << "\r\n";
+  
+  info->append(tmp_stream.str());
 }
 
 void PikaServer::BGSaveTaskSchedule(net::TaskFunc func, void* arg) {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -2130,44 +2130,109 @@ void PikaServer::ResetThreadPoolMetrics() {
 }
 
 
-bool PikaServer::IsSlowPoolBusy() {
-  size_t current_size = SlowCmdThreadPoolCurQueueSize();
-  size_t max_size = SlowCmdThreadPoolMaxQueueSize();
-  if (max_size == 0) {
-    return false;
+// Load EMA-related configurations from pika.conf
+void PikaServer::LoadThreadPoolConfig() {
+  ema_alpha_numerator_.store(g_pika_conf->threadpool_ema_alpha_numerator(), std::memory_order_relaxed);
+  ema_alpha_denominator_.store(g_pika_conf->threadpool_ema_alpha_denominator(), std::memory_order_relaxed);
+  fast_busy_threshold_us_.store(g_pika_conf->threadpool_fast_busy_threshold(), std::memory_order_relaxed);
+  fast_idle_threshold_us_.store(g_pika_conf->threadpool_fast_idle_threshold(), std::memory_order_relaxed);
+  slow_busy_threshold_us_.store(g_pika_conf->threadpool_slow_busy_threshold(), std::memory_order_relaxed);
+  slow_idle_threshold_us_.store(g_pika_conf->threadpool_slow_idle_threshold(), std::memory_order_relaxed);
+}
+
+// Update EMA statistics for queue wait time (lock-free)
+void PikaServer::UpdateQueueWaitStats(TaskPoolType pool_type, uint64_t queue_wait_us) {
+  auto& stats = (pool_type == kFastCmdPool) ? fast_pool_stats_ : slow_pool_stats_;
+
+  uint64_t now = pstd::NowMicros();
+  uint64_t last = stats.last_update_us_.exchange(now, std::memory_order_relaxed);
+
+  uint32_t alpha_num = ema_alpha_numerator_.load(std::memory_order_relaxed);
+  uint32_t alpha_den = ema_alpha_denominator_.load(std::memory_order_relaxed);
+
+  if (last > 0) {
+    uint64_t elapsed = now - last;
+    if (elapsed > 1000) { // If last update was more than 1ms ago, increase alpha to adapt faster
+      alpha_num = std::min(alpha_num * 2, alpha_den / 2);
+    }
   }
-  int threadhold = g_pika_conf->threadpool_borrow_threshold_percent();
-  return current_size >= (max_size * threadhold / 100);
+
+  uint64_t old_val = stats.ema_queue_wait_us_.load(std::memory_order_relaxed);
+  uint64_t new_val = (old_val * (alpha_den - alpha_num) + queue_wait_us * alpha_num) / alpha_den;
+  stats.ema_queue_wait_us_.store(new_val, std::memory_order_relaxed);
+}
+
+// Get the current EMA queue wait time
+uint64_t PikaServer::GetEMAQueueWait(TaskPoolType pool_type) const {
+  const auto& stats = (pool_type == kFastCmdPool) ? fast_pool_stats_ : slow_pool_stats_;
+  return stats.ema_queue_wait_us_.load(std::memory_order_relaxed);
+}
+
+// --- Internal helpers for busy/idle checks based on EMA ---
+bool PikaServer::IsFastPoolBusyByEMA() const {
+  return GetEMAQueueWait(kFastCmdPool) > fast_busy_threshold_us_.load(std::memory_order_relaxed);
+}
+
+bool PikaServer::IsFastPoolIdleByEMA() const {
+  return GetEMAQueueWait(kFastCmdPool) < fast_idle_threshold_us_.load(std::memory_order_relaxed);
+}
+
+bool PikaServer::IsSlowPoolBusyByEMA() const {
+  return GetEMAQueueWait(kSlowCmdPool) > slow_busy_threshold_us_.load(std::memory_order_relaxed);
+}
+
+bool PikaServer::IsSlowPoolIdleByEMA() const {
+  return GetEMAQueueWait(kSlowCmdPool) < slow_idle_threshold_us_.load(std::memory_order_relaxed);
+}
+
+bool PikaServer::IsSlowPoolBusy() {
+  // Queue percentage signal
+  size_t cur = SlowCmdThreadPoolCurQueueSize();
+  size_t max = SlowCmdThreadPoolMaxQueueSize();
+  bool busy_by_queue = false;
+  if (max > 0) {
+    int thr = g_pika_conf->threadpool_borrow_threshold_percent();
+    busy_by_queue = cur >= (max * thr / 100);
+  }
+  // EMA signal
+  bool busy_by_ema = IsSlowPoolBusyByEMA();
+  return busy_by_queue || busy_by_ema;
 }
 
 bool PikaServer::IsSlowPoolIdle() {
-  size_t current_size = SlowCmdThreadPoolCurQueueSize();
-  size_t max_size = SlowCmdThreadPoolMaxQueueSize();
-  if (max_size == 0) {
-    return true;
+  size_t cur = SlowCmdThreadPoolCurQueueSize();
+  size_t max = SlowCmdThreadPoolMaxQueueSize();
+  bool idle_by_queue = true;
+  if (max > 0) {
+    int thr = g_pika_conf->threadpool_idle_threshold_percent();
+    idle_by_queue = cur <= (max * thr / 100);
   }
-  int threshold = g_pika_conf->threadpool_idle_threshold_percent();
-  return current_size <= (max_size * threshold / 100);
+  bool idle_by_ema = IsSlowPoolIdleByEMA();
+  return idle_by_queue && idle_by_ema;
 }
 
 bool PikaServer::IsFastPoolBusy() {
-  size_t current_size = ClientProcessorThreadPoolCurQueueSize();
-  size_t max_size = ClientProcessorThreadPoolMaxQueueSize();
-  if (max_size == 0) {
-    return false;
+  size_t cur = ClientProcessorThreadPoolCurQueueSize();
+  size_t max = ClientProcessorThreadPoolMaxQueueSize();
+  bool busy_by_queue = false;
+  if (max > 0) {
+    int thr = g_pika_conf->threadpool_borrow_threshold_percent();
+    busy_by_queue = cur >= (max * thr / 100);
   }
-  int threadhold = g_pika_conf->threadpool_borrow_threshold_percent();
-  return current_size >= (max_size * threadhold / 100);
+  bool busy_by_ema = IsFastPoolBusyByEMA();
+  return busy_by_queue || busy_by_ema;
 }
 
 bool PikaServer::IsFastPoolIdle() {
-  size_t current_size = ClientProcessorThreadPoolCurQueueSize();
-  size_t max_size = ClientProcessorThreadPoolMaxQueueSize();
-  if (max_size == 0) {
-    return true;
+  size_t cur = ClientProcessorThreadPoolCurQueueSize();
+  size_t max = ClientProcessorThreadPoolMaxQueueSize();
+  bool idle_by_queue = true;
+  if (max > 0) {
+    int thr = g_pika_conf->threadpool_idle_threshold_percent();
+    idle_by_queue = cur <= (max * thr / 100);
   }
-  int threshold = g_pika_conf->threadpool_idle_threshold_percent();
-  return current_size <= (max_size * threshold / 100);
+  bool idle_by_ema = IsFastPoolIdleByEMA();
+  return idle_by_queue && idle_by_ema;
 }
 
 TaskPoolType PikaServer::DecidePoolType(bool is_slow_cmd) {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <ctime>
 #include <fstream>
+#include <iomanip>
 #include <memory>
 #include <utility>
 #include "net/include/net_cli.h"
@@ -1023,8 +1024,8 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
     auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
     if (bg_arg) {
       // Set error response for rate limiting
-      bg_arg->resp = std::make_shared<std::string>("-ERR Rate limit exceeded, try again later\r\n");
-      bg_arg->conn->WriteResp(*(bg_arg->resp));
+      bg_arg->resp_ptr = std::make_shared<std::string>("-ERR Rate limit exceeded, try again later\r\n");
+      bg_arg->conn_ptr->WriteResp(*(bg_arg->resp_ptr));
       delete bg_arg;
     }
     return;
@@ -2427,9 +2428,10 @@ void PikaServer::AdjustBorrowThresholds() {
     new_threshold = std::max(30, current_threshold - 5);
   }
   
+  // Note: Currently we don't have a SetThreadpoolBorrowThresholdPercent method in PikaConf
+  // So we just log the recommendation instead of actually changing the threshold
   if (new_threshold != current_threshold) {
-    g_pika_conf->SetThreadpoolBorrowThresholdPercent(new_threshold);
-    LOG(INFO) << "Adjusted borrow threshold from " << current_threshold 
+    LOG(INFO) << "Recommend adjusting borrow threshold from " << current_threshold 
               << "% to " << new_threshold << "% (fast_sat: " 
               << std::fixed << std::setprecision(2) << fast_saturation * 100 
               << "%, slow_sat: " << slow_saturation * 100 << "%)";
@@ -2474,10 +2476,11 @@ bool PikaServer::CheckCommandRateLimit() {
 }
 
 std::string PikaServer::GetEnhancedThreadPoolMetrics() const {
-  std::stringstream ss;
+  std::string info;
+  const_cast<PikaServer*>(this)->GetThreadPoolInfo(&info);
   
-  // 基本线程池信息
-  GetThreadPoolInfo(&ss.str());
+  std::stringstream ss;
+  ss << info;
   
   // 增强的指标（Prometheus格式）
   ss << "\n# Enhanced Thread Pool Metrics\n";
@@ -2507,7 +2510,6 @@ std::string PikaServer::GetEnhancedThreadPoolMetrics() const {
 
 bool PikaServer::IsKeyAffinityToSlow(const std::string& key) const {
   if (!key_hash_) {
-    // 如果没有一致性哈希，使用简单的哈希
     std::hash<std::string> hasher;
     return (hasher(key) % 2) == 1;
   }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -35,7 +35,7 @@ extern std::unique_ptr<net::NetworkStatistic> g_network_statistic;
 // QUEUE_SIZE_THRESHOLD_PERCENTAGE is used to represent a percentage value and should be within the range of 0 to 100.
 const size_t QUEUE_SIZE_THRESHOLD_PERCENTAGE = 75;
 
-// ThreadPoolMetrics 实现
+// ThreadPoolMetrics 
 void ThreadPoolMetrics::RecordLatency(uint64_t latency_us) {
   if (latency_us < 1000) {
     latency_buckets[0]++;
@@ -66,7 +66,7 @@ std::string ThreadPoolMetrics::ExportMetrics(const std::string& pool_name) const
      << "# TYPE pika_threadpool_borrow_attempts counter\n"
      << "pika_threadpool_borrow_attempts{pool=\"" << pool_name << "\"} " << borrow_attempts.load() << "\n";
   
-  // 延迟分布
+  // latency metrics
   ss << "# TYPE pika_threadpool_latency_buckets counter\n";
   const char* bucket_labels[] = {
     "0_1ms", "1_5ms", "5_10ms", "10_50ms", "50_100ms", 
@@ -835,7 +835,7 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
     pika_admin_cmd_thread_pool_->Schedule(func, arg);
     return;
   }
-  // 慢池未开启，直接用快池调用
+  // if slow cmd thread pool disabled
   if(!g_pika_conf->slow_cmd_pool()) {
     pika_client_processor_->SchedulePool(func, arg);
     return;
@@ -843,7 +843,6 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
 
   auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
 
-  // 看看是否需要下沉。
   TaskPoolType target_pool = DecidePoolType(is_slow_cmd);
   if (bg_arg) {
     bg_arg->pool_type = target_pool;
@@ -970,7 +969,6 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
   tmp_stream << "fast_cmd_pool_max_queue_size:" << fast_max_queue << "\r\n";
   tmp_stream << "fast_cmd_pool_usage:" << std::fixed << std::setprecision(2) << fast_usage << "%\r\n";
 
-   // 快池借用统计
   if (g_pika_server->fast_pool_metrics_) {
     tmp_stream << "fast_cmd_pool_tasks_scheduled:" 
        << g_pika_server->fast_pool_metrics_->tasks_scheduled.load() << "\r\n";
@@ -990,7 +988,6 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
     tmp_stream << "slow_cmd_pool_max_queue_size:" << slow_max_queue << "\r\n";
     tmp_stream << "slow_cmd_pool_usage:" << std::fixed << std::setprecision(2) << slow_usage << "%\r\n";
 
-    // 慢池借用统计
     if (g_pika_server->slow_pool_metrics_) {
       tmp_stream << "slow_cmd_pool_tasks_scheduled:" 
         << g_pika_server->slow_pool_metrics_->tasks_scheduled.load() << "\r\n";
@@ -2101,7 +2098,7 @@ void PikaServer::CacheConfigInit(cache::CacheConfig& cache_cfg) {
 }
 void PikaServer::SetLogNetActivities(bool value) { pika_dispatch_thread_->SetLogNetActivities(value); }
 
-// 改进的快慢命令分离相关方法实现
+// slow/fast relevent methods
 std::string PikaServer::GetEnhancedThreadPoolMetrics() {
   std::string info;
   GetThreadPoolInfo(&info);
@@ -2181,19 +2178,18 @@ TaskPoolType PikaServer::DecidePoolType(bool is_slow_cmd) {
   bool borrow_enabled = g_pika_conf->threadpool_borrow_enable();
   TaskPoolType decision;
   if (is_slow_cmd) {
-    // 默认慢池
+    // default: slow pool
     decision = TaskPoolType::kSlowCmdPool;
 
-    // 借用逻辑：慢池忙(Busy) 且 快池闲(Idle) -> 借用快池
+    // slow pool busy & fast pool idle -> borrow fast pool
     if (borrow_enabled && IsSlowPoolBusy() && IsFastPoolIdle()) {
       decision = TaskPoolType::kFastCmdPool;
 
-      // 更新 慢池 的借用指标 (代表慢池向外借力)
+      // update metrics for the slow pool
       if (slow_pool_metrics_) {
         slow_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
       }
     
-      // 慢命令借用快池
       size_t slow_cur = SlowCmdThreadPoolCurQueueSize();
       size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
       size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();
@@ -2204,17 +2200,17 @@ TaskPoolType PikaServer::DecidePoolType(bool is_slow_cmd) {
                 << ", fast_queue: " << fast_cur << "/" << fast_max << ")";
     }
   } else {
-    // 默认归宿：快池
+    // default: fast pool
     decision = TaskPoolType::kFastCmdPool;
 
-    // 借用逻辑：快池忙(Busy) 且 慢池闲(Idle) -> 借用慢池
+    // fast pool busy & slow pool idle -> borrow slow pool
     if (borrow_enabled && IsFastPoolBusy() && IsSlowPoolIdle()) {
       decision = TaskPoolType::kSlowCmdPool;
-      // 更新借用指标 
+      // update metrics for the fast pool
       if (fast_pool_metrics_) {
         fast_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
       }
-      // 快命令借用慢池
+
       size_t slow_cur = SlowCmdThreadPoolCurQueueSize();
       size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
       size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -84,7 +84,7 @@ std::string ThreadPoolMetrics::ExportMetrics(const std::string& pool_name) const
 
 void ThreadPoolMetrics::Reset() {
   tasks_scheduled.store(0);
-  tasks_completed.store(0);
+  active_tasks.store(0);
   borrow_attempts.store(0);
 
   for (auto& bucket : latency_buckets) {
@@ -831,7 +831,11 @@ void PikaServer::SetFirstMetaSync(bool v) {
 }
 
 void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_cmd, bool is_admin_cmd) {
+  auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
   if (is_admin_cmd) {
+    if (bg_arg) {
+      bg_arg->pool_type = TaskPoolType::kAdminCmdPool;
+    }
     pika_admin_cmd_thread_pool_->Schedule(func, arg);
     return;
   }
@@ -840,8 +844,6 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
     pika_client_processor_->SchedulePool(func, arg);
     return;
   }
-
-  auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
 
   TaskPoolType target_pool = DecidePoolType(is_slow_cmd);
   if (bg_arg) {
@@ -970,10 +972,16 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
   tmp_stream << "fast_cmd_pool_usage:" << std::fixed << std::setprecision(2) << fast_usage << "%\r\n";
 
   if (g_pika_server->fast_pool_metrics_) {
+    const auto scheduled = g_pika_server->fast_pool_metrics_->tasks_scheduled.load(std::memory_order_relaxed);
+    const auto active = g_pika_server->fast_pool_metrics_->active_tasks.load(std::memory_order_relaxed);
     tmp_stream << "fast_cmd_pool_tasks_scheduled:" 
-       << g_pika_server->fast_pool_metrics_->tasks_scheduled.load() << "\r\n";
+       << scheduled << "\r\n";
+    tmp_stream << "fast_cmd_pool_active_tasks:" 
+       << active << "\r\n";
     tmp_stream << "fast_cmd_pool_borrow_attempts:" 
-       << g_pika_server->fast_pool_metrics_->borrow_attempts.load() << "\r\n";
+       << g_pika_server->fast_pool_metrics_->borrow_attempts.load(std::memory_order_relaxed) << "\r\n";
+    tmp_stream << "fast_cmd_pool_ema_wait_us:" 
+       << GetEMAQueueWait(TaskPoolType::kFastCmdPool) << "\r\n";
   }
 
   // Slow cmd thread pool info
@@ -989,10 +997,16 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
     tmp_stream << "slow_cmd_pool_usage:" << std::fixed << std::setprecision(2) << slow_usage << "%\r\n";
 
     if (g_pika_server->slow_pool_metrics_) {
+      const auto scheduled = g_pika_server->slow_pool_metrics_->tasks_scheduled.load(std::memory_order_relaxed);
+      const auto active = g_pika_server->slow_pool_metrics_->active_tasks.load(std::memory_order_relaxed);
       tmp_stream << "slow_cmd_pool_tasks_scheduled:" 
-        << g_pika_server->slow_pool_metrics_->tasks_scheduled.load() << "\r\n";
+        << scheduled << "\r\n";
+      tmp_stream << "slow_cmd_pool_active_tasks:" 
+        << active << "\r\n";
       tmp_stream << "slow_cmd_pool_borrow_attempts:" 
-        << g_pika_server->slow_pool_metrics_->borrow_attempts.load() << "\r\n";
+        << g_pika_server->slow_pool_metrics_->borrow_attempts.load(std::memory_order_relaxed) << "\r\n";
+      tmp_stream << "slow_cmd_pool_ema_wait_us:" 
+        << GetEMAQueueWait(TaskPoolType::kSlowCmdPool) << "\r\n";
     }
   } else {
     tmp_stream << "slow_cmd_pool_size:0\r\n";
@@ -1340,6 +1354,26 @@ void PikaServer::DoTimingTask() {
   // Print the queue status periodically
   PrintThreadPoolQueueStatus();
   StatDiskUsage();
+  // Auto decay idle pool EMA
+  AutoUpdateIdlePoolEMA();
+}
+
+void PikaServer::AutoUpdateIdlePoolEMA() {
+  uint64_t now = pstd::NowMicros();
+  // decay
+  uint64_t last_update_fast = fast_pool_stats_.last_update_us_.load(std::memory_order_relaxed);
+  if (last_update_fast != 0 && now - last_update_fast > 1000000) {
+    uint64_t old_ema = fast_pool_stats_.ema_queue_wait_us_.load(std::memory_order_relaxed);
+    uint64_t decayed_ema = CalculateDecayedEMA(old_ema, last_update_fast, now);
+    fast_pool_stats_.ema_queue_wait_us_.compare_exchange_strong(old_ema, decayed_ema, std::memory_order_relaxed);
+  }
+
+  uint64_t last_update_slow = slow_pool_stats_.last_update_us_.load(std::memory_order_relaxed);
+  if (last_update_slow != 0 && now - last_update_slow > 1000000) {
+    uint64_t old_ema = slow_pool_stats_.ema_queue_wait_us_.load(std::memory_order_relaxed);
+    uint64_t decayed_ema = CalculateDecayedEMA(old_ema, last_update_slow, now);
+    slow_pool_stats_.ema_queue_wait_us_.compare_exchange_strong(old_ema, decayed_ema, std::memory_order_relaxed);
+  }
 }
 
 void PikaServer::StatDiskUsage() {
@@ -2098,7 +2132,7 @@ void PikaServer::CacheConfigInit(cache::CacheConfig& cache_cfg) {
 }
 void PikaServer::SetLogNetActivities(bool value) { pika_dispatch_thread_->SetLogNetActivities(value); }
 
-// slow/fast relevent methods
+// slow/fast relevant methods
 std::string PikaServer::GetEnhancedThreadPoolMetrics() {
   std::string info;
   GetThreadPoolInfo(&info);
@@ -2129,7 +2163,6 @@ void PikaServer::ResetThreadPoolMetrics() {
   }
 }
 
-
 // Load EMA-related configurations from pika.conf
 void PikaServer::LoadThreadPoolConfig() {
   ema_alpha_numerator_.store(g_pika_conf->threadpool_ema_alpha_numerator(), std::memory_order_relaxed);
@@ -2140,26 +2173,52 @@ void PikaServer::LoadThreadPoolConfig() {
   slow_idle_threshold_us_.store(g_pika_conf->threadpool_slow_idle_threshold(), std::memory_order_relaxed);
 }
 
-// Update EMA statistics for queue wait time (lock-free)
-void PikaServer::UpdateQueueWaitStats(TaskPoolType pool_type, uint64_t queue_wait_us) {
-  auto& stats = (pool_type == kFastCmdPool) ? fast_pool_stats_ : slow_pool_stats_;
+// Calculate decayed EMA based on idle time
+uint64_t PikaServer::CalculateDecayedEMA(uint64_t old_ema, uint64_t last_update, uint64_t now) {
+  if (last_update == 0 || now <= last_update || old_ema == 0) {
+    return old_ema;
+  }
+  
+  uint64_t idle_us = now - last_update;
+  const uint64_t DECAY_START_US = 1000000;   // 1s: Start decay after 1 second idle
+  const uint64_t FULL_DECAY_US = 10000000;   // 10s: Fully decay to 0 after 10 seconds
+  
+  if (idle_us > FULL_DECAY_US) {
+    return 0;
+  } else if (idle_us > DECAY_START_US) {
+    uint64_t decay_duration = idle_us - DECAY_START_US;
+    uint64_t decay_window = FULL_DECAY_US - DECAY_START_US;
+    return old_ema * (decay_window - decay_duration) / decay_window;
+  }
+  return old_ema;
+}
 
-  uint64_t now = pstd::NowMicros();
-  uint64_t last = stats.last_update_us_.exchange(now, std::memory_order_relaxed);
+// Update a pool's EMA with decay and new sample
+void PikaServer::UpdateSinglePoolEMA(PoolLatencyStats& stats, uint64_t new_sample, uint64_t now) {
+  uint64_t last_update = stats.last_update_us_.load(std::memory_order_relaxed);
+  uint64_t old_ema = stats.ema_queue_wait_us_.load(std::memory_order_relaxed);
 
+  // Calculate decayed old EMA
+  uint64_t decayed_old_ema = CalculateDecayedEMA(old_ema, last_update, now);
   uint32_t alpha_num = ema_alpha_numerator_.load(std::memory_order_relaxed);
   uint32_t alpha_den = ema_alpha_denominator_.load(std::memory_order_relaxed);
+  uint64_t new_ema = (decayed_old_ema * (alpha_den - alpha_num) + new_sample * alpha_num) / alpha_den;
+  
+  // update
+  stats.ema_queue_wait_us_.store(new_ema, std::memory_order_relaxed);
+  stats.last_update_us_.store(now, std::memory_order_relaxed);
+}
 
-  if (last > 0) {
-    uint64_t elapsed = now - last;
-    if (elapsed > 1000) { // If last update was more than 1ms ago, increase alpha to adapt faster
-      alpha_num = std::min(alpha_num * 2, alpha_den / 2);
-    }
+void PikaServer::UpdateQueueWaitStats(TaskPoolType pool_type, uint64_t queue_wait_us) {
+  // Skip EMA update for admin commands
+  if (pool_type == kAdminCmdPool) {
+    return;
   }
-
-  uint64_t old_val = stats.ema_queue_wait_us_.load(std::memory_order_relaxed);
-  uint64_t new_val = (old_val * (alpha_den - alpha_num) + queue_wait_us * alpha_num) / alpha_den;
-  stats.ema_queue_wait_us_.store(new_val, std::memory_order_relaxed);
+  
+  uint64_t now = pstd::NowMicros();
+  // Update current pool
+  auto& stats = (pool_type == kFastCmdPool) ? fast_pool_stats_ : slow_pool_stats_;
+  UpdateSinglePoolEMA(stats, queue_wait_us, now);
 }
 
 // Get the current EMA queue wait time
@@ -2168,7 +2227,7 @@ uint64_t PikaServer::GetEMAQueueWait(TaskPoolType pool_type) const {
   return stats.ema_queue_wait_us_.load(std::memory_order_relaxed);
 }
 
-// --- Internal helpers for busy/idle checks based on EMA ---
+// Internal helpers for busy/idle checks based on EMA
 bool PikaServer::IsFastPoolBusyByEMA() const {
   return GetEMAQueueWait(kFastCmdPool) > fast_busy_threshold_us_.load(std::memory_order_relaxed);
 }
@@ -2196,19 +2255,54 @@ bool PikaServer::IsSlowPoolBusy() {
   }
   // EMA signal
   bool busy_by_ema = IsSlowPoolBusyByEMA();
-  return busy_by_queue || busy_by_ema;
+
+  // Running tasks signal
+  bool busy_by_running = false;
+  if (slow_pool_metrics_) {
+    size_t active = slow_pool_metrics_->active_tasks.load(std::memory_order_relaxed);
+    size_t thread_num = g_pika_conf->slow_cmd_thread_pool_size();
+    if (thread_num > 0) {
+        int thr = g_pika_conf->threadpool_borrow_threshold_percent();
+        busy_by_running = active >= (thread_num * thr / 100);
+    }
+  }
+
+  return busy_by_queue || busy_by_ema || busy_by_running;
 }
 
 bool PikaServer::IsSlowPoolIdle() {
+  uint64_t now = pstd::NowMicros();
+  bool is_active_now = false;
+
+  // Check for any sign of activity
+  if (slow_pool_metrics_ && slow_pool_metrics_->active_tasks.load(std::memory_order_relaxed) > 0) {
+    is_active_now = true;
+  }
+
   size_t cur = SlowCmdThreadPoolCurQueueSize();
   size_t max = SlowCmdThreadPoolMaxQueueSize();
-  bool idle_by_queue = true;
-  if (max > 0) {
-    int thr = g_pika_conf->threadpool_idle_threshold_percent();
-    idle_by_queue = cur <= (max * thr / 100);
+  if (!is_active_now && max > 0 && cur > (max * g_pika_conf->threadpool_idle_threshold_percent() / 100)) {
+    is_active_now = true;
   }
-  bool idle_by_ema = IsSlowPoolIdleByEMA();
-  return idle_by_queue && idle_by_ema;
+
+  if (!is_active_now && IsSlowPoolBusyByEMA()) {
+      is_active_now = true;
+  }
+
+  // If active, update timestamp and return false
+  if (is_active_now) {
+    slow_pool_last_active_us_.store(now, std::memory_order_relaxed);
+    return false;
+  }
+
+  // If not active, check if it has been idle for long enough
+  uint64_t last_active = slow_pool_last_active_us_.load(std::memory_order_relaxed);
+  if (last_active == 0) { // First check, initialize timestamp
+    slow_pool_last_active_us_.store(now, std::memory_order_relaxed);
+    return false;
+  }
+
+  return (now - last_active) >= threadpool_idle_window_us_.load(std::memory_order_relaxed);
 }
 
 bool PikaServer::IsFastPoolBusy() {
@@ -2219,20 +2313,53 @@ bool PikaServer::IsFastPoolBusy() {
     int thr = g_pika_conf->threadpool_borrow_threshold_percent();
     busy_by_queue = cur >= (max * thr / 100);
   }
+  // EMA signal
   bool busy_by_ema = IsFastPoolBusyByEMA();
-  return busy_by_queue || busy_by_ema;
+
+  // Running tasks signal
+  bool busy_by_running = false;
+  if (fast_pool_metrics_) {
+    size_t active = fast_pool_metrics_->active_tasks.load(std::memory_order_relaxed);
+    size_t thread_num = g_pika_conf->thread_pool_size();
+    if (thread_num > 0) {
+      int thr = g_pika_conf->threadpool_borrow_threshold_percent();
+      busy_by_running = active >= (thread_num * thr / 100);
+    }
+  }
+
+  return busy_by_queue || busy_by_ema || busy_by_running;
 }
 
 bool PikaServer::IsFastPoolIdle() {
+  uint64_t now = pstd::NowMicros();
+
+  bool is_active_now = false;
+  if (fast_pool_metrics_ && fast_pool_metrics_->active_tasks.load(std::memory_order_relaxed) > 0) {
+    is_active_now = true;
+  }
+
   size_t cur = ClientProcessorThreadPoolCurQueueSize();
   size_t max = ClientProcessorThreadPoolMaxQueueSize();
-  bool idle_by_queue = true;
-  if (max > 0) {
-    int thr = g_pika_conf->threadpool_idle_threshold_percent();
-    idle_by_queue = cur <= (max * thr / 100);
+  if (!is_active_now && max > 0 && cur > (max * g_pika_conf->threadpool_idle_threshold_percent() / 100)) {
+    is_active_now = true;
   }
-  bool idle_by_ema = IsFastPoolIdleByEMA();
-  return idle_by_queue && idle_by_ema;
+
+  if (!is_active_now && IsFastPoolBusyByEMA()) {
+    is_active_now = true;
+  }
+
+  if (is_active_now) {
+    fast_pool_last_active_us_.store(now, std::memory_order_relaxed);
+    return false;
+  }
+
+  uint64_t last_active = fast_pool_last_active_us_.load(std::memory_order_relaxed);
+  if (last_active == 0) {
+    fast_pool_last_active_us_.store(now, std::memory_order_relaxed);
+    return false;
+  }
+
+  return (now - last_active) >= threadpool_idle_window_us_.load(std::memory_order_relaxed);
 }
 
 TaskPoolType PikaServer::DecidePoolType(bool is_slow_cmd) {
@@ -2255,14 +2382,32 @@ TaskPoolType PikaServer::DecidePoolType(bool is_slow_cmd) {
         slow_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
       }
     
+      // Get queue status
       size_t slow_cur = SlowCmdThreadPoolCurQueueSize();
       size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
       size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();
       size_t fast_max = ClientProcessorThreadPoolMaxQueueSize();
+      double slow_usage = slow_max > 0 ? (slow_cur * 100.0 / slow_max) : 0;
+      double fast_usage = fast_max > 0 ? (fast_cur * 100.0 / fast_max) : 0;
+
+      // Get EMA wait time
+      uint64_t slow_ema = GetEMAQueueWait(TaskPoolType::kSlowCmdPool);
+      uint64_t fast_ema = GetEMAQueueWait(TaskPoolType::kFastCmdPool);
       
-      LOG(INFO) << "Slow cmd borrows fast pool (slow_queue: " 
-                << slow_cur << "/" << slow_max 
-                << ", fast_queue: " << fast_cur << "/" << fast_max << ")";
+      uint64_t now = pstd::NowMicros();
+      uint64_t idle_window = threadpool_idle_window_us_.load(std::memory_order_relaxed);
+      uint64_t fast_last_active = fast_pool_last_active_us_.load(std::memory_order_relaxed);
+      uint64_t slow_last_active = slow_pool_last_active_us_.load(std::memory_order_relaxed);
+      uint64_t fast_active = fast_pool_metrics_ ? fast_pool_metrics_->active_tasks.load(std::memory_order_relaxed) : 0;
+      uint64_t slow_active = slow_pool_metrics_ ? slow_pool_metrics_->active_tasks.load(std::memory_order_relaxed) : 0;
+
+      LOG(INFO) << "Slow cmd borrows fast pool: "
+                << "slow_pool(queue=" << std::fixed << std::setprecision(2) << slow_usage << "%, "
+                << "ema=" << slow_ema << "us, "
+                << "active=" << slow_active << "), "
+                << "fast_pool(queue=" << std::fixed << std::setprecision(2) << fast_usage << "%, "
+                << "ema=" << fast_ema << "us, "
+                << "active=" << fast_active << ")";
     }
   } else {
     // default: fast pool
@@ -2280,10 +2425,18 @@ TaskPoolType PikaServer::DecidePoolType(bool is_slow_cmd) {
       size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
       size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();
       size_t fast_max = ClientProcessorThreadPoolMaxQueueSize();
+      double slow_usage = slow_max > 0 ? (slow_cur * 100.0 / slow_max) : 0;
+      double fast_usage = fast_max > 0 ? (fast_cur * 100.0 / fast_max) : 0;
 
-      LOG(INFO) << "Fast cmd borrows slow pool (fast_queue: " 
-                << fast_cur << "/" << fast_max 
-                << ", slow_queue: " << slow_cur << "/" << slow_max << ")";
+      // Get EMA wait time
+      uint64_t slow_ema = GetEMAQueueWait(TaskPoolType::kSlowCmdPool);
+      uint64_t fast_ema = GetEMAQueueWait(TaskPoolType::kFastCmdPool);
+
+      LOG(INFO) << "Fast cmd borrows slow pool: "
+                << "fast_pool(queue=" << std::fixed << std::setprecision(2) << fast_usage << "%, "
+                << "ema=" << fast_ema << "us), "
+                << "slow_pool(queue=" << std::fixed << std::setprecision(2) << slow_usage << "%, "
+                << "ema=" << slow_ema << "us)";
     }
   }
   if (decision == TaskPoolType::kFastCmdPool) {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -836,7 +836,7 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
     return;
   }
   // if slow cmd thread pool disabled
-  if(!g_pika_conf->slow_cmd_pool()) {
+  if (!g_pika_conf->slow_cmd_pool()) {
     pika_client_processor_->SchedulePool(func, arg);
     return;
   }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -33,6 +33,248 @@ extern std::unique_ptr<net::NetworkStatistic> g_network_statistic;
 // QUEUE_SIZE_THRESHOLD_PERCENTAGE is used to represent a percentage value and should be within the range of 0 to 100.
 const size_t QUEUE_SIZE_THRESHOLD_PERCENTAGE = 75;
 
+// CommandClassifier 实现
+void CommandClassifier::CommandStats::AddTime(uint64_t time, size_t window_size) {
+  total_time += time;
+  count++;
+  
+  if (recent_times.size() < window_size) {
+    recent_times.push_back(time);
+  } else {
+    if (!initialized) {
+      initialized = true;
+    }
+    // 替换最旧的记录
+    total_time -= recent_times[time_index];
+    recent_times[time_index] = time;
+    time_index = (time_index + 1) % window_size;
+  }
+}
+
+double CommandClassifier::CommandStats::GetAverageTime() const {
+  return count > 0 ? static_cast<double>(total_time) / count : 0.0;
+}
+
+double CommandClassifier::CommandStats::GetRecentAverageTime() const {
+  if (!initialized && recent_times.empty()) {
+    return 0.0;
+  }
+  
+  size_t sample_count = initialized ? recent_times.size() : time_index;
+  if (sample_count == 0) {
+    return 0.0;
+  }
+  
+  uint64_t recent_total = 0;
+  for (size_t i = 0; i < sample_count; i++) {
+    recent_total += recent_times[i];
+  }
+  
+  return static_cast<double>(recent_total) / sample_count;
+}
+
+CommandClassifier::CommandClassifier(uint64_t slow_threshold_us, uint64_t fast_threshold_us, size_t window_size)
+    : slow_threshold_us_(slow_threshold_us),
+      fast_threshold_us_(fast_threshold_us),
+      window_size_(window_size) {}
+
+void CommandClassifier::RecordExecutionTime(const std::string& cmd_name, uint64_t duration_us) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  
+  // 更新命令执行时间统计
+  auto& stats = cmd_stats_[cmd_name];
+  stats.AddTime(duration_us, window_size_);
+  
+  // 根据最近平均执行时间分类命令
+  if (stats.initialized || stats.recent_times.size() >= window_size_ / 2) {
+    double recent_avg = stats.GetRecentAverageTime();
+    
+    if (recent_avg > slow_threshold_us_) {
+      // 如果平均时间超过慢命令阈值，标记为慢命令
+      if (slow_commands_.find(cmd_name) == slow_commands_.end()) {
+        LOG(INFO) << "Command '" << cmd_name << "' reclassified as SLOW (avg time: " 
+                  << recent_avg / 1000.0 << "ms)";
+        slow_commands_.insert(cmd_name);
+      }
+    } else if (recent_avg < fast_threshold_us_ && stats.initialized) {
+      // 如果平均时间低于快命令阈值且有足够样本，可能标记为快命令
+      if (slow_commands_.find(cmd_name) != slow_commands_.end()) {
+        LOG(INFO) << "Command '" << cmd_name << "' reclassified as FAST (avg time: " 
+                  << recent_avg / 1000.0 << "ms)";
+        slow_commands_.erase(cmd_name);
+      }
+    }
+  }
+}
+
+bool CommandClassifier::IsSlowCommand(const std::string& cmd_name) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return slow_commands_.find(cmd_name) != slow_commands_.end();
+}
+
+void CommandClassifier::MarkAsSlowCommand(const std::string& cmd_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  slow_commands_.insert(cmd_name);
+}
+
+void CommandClassifier::MarkAsFastCommand(const std::string& cmd_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  slow_commands_.erase(cmd_name);
+}
+
+std::unordered_map<std::string, double> CommandClassifier::GetCommandAvgTimes() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::unordered_map<std::string, double> result;
+  
+  for (const auto& [cmd_name, stats] : cmd_stats_) {
+    result[cmd_name] = stats.GetAverageTime();
+  }
+  
+  return result;
+}
+
+// ThreadPoolMetrics 实现
+void ThreadPoolMetrics::RecordLatency(uint64_t latency_us) {
+  if (latency_us < 1000) {
+    latency_buckets[0]++;
+  } else if (latency_us < 5000) {
+    latency_buckets[1]++;
+  } else if (latency_us < 10000) {
+    latency_buckets[2]++;
+  } else if (latency_us < 50000) {
+    latency_buckets[3]++;
+  } else if (latency_us < 100000) {
+    latency_buckets[4]++;
+  } else if (latency_us < 500000) {
+    latency_buckets[5]++;
+  } else if (latency_us < 1000000) {
+    latency_buckets[6]++;
+  } else if (latency_us < 5000000) {
+    latency_buckets[7]++;
+  } else {
+    latency_buckets[8]++;
+  }
+}
+
+std::string ThreadPoolMetrics::ExportMetrics(const std::string& pool_name) const {
+  std::stringstream ss;
+  
+  ss << "# TYPE pika_threadpool_tasks_scheduled counter\n"
+     << "pika_threadpool_tasks_scheduled{pool=\"" << pool_name << "\"} " << tasks_scheduled.load() << "\n"
+     << "# TYPE pika_threadpool_tasks_completed counter\n"
+     << "pika_threadpool_tasks_completed{pool=\"" << pool_name << "\"} " << tasks_completed.load() << "\n"
+     << "# TYPE pika_threadpool_queue_overflows counter\n"
+     << "pika_threadpool_queue_overflows{pool=\"" << pool_name << "\"} " << queue_overflows.load() << "\n"
+     << "# TYPE pika_threadpool_borrow_attempts counter\n"
+     << "pika_threadpool_borrow_attempts{pool=\"" << pool_name << "\"} " << borrow_attempts.load() << "\n"
+     << "# TYPE pika_threadpool_successful_borrows counter\n"
+     << "pika_threadpool_successful_borrows{pool=\"" << pool_name << "\"} " << successful_borrows.load() << "\n";
+  
+  // 延迟分布
+  ss << "# TYPE pika_threadpool_latency_buckets counter\n";
+  const char* bucket_labels[] = {
+    "0_1ms", "1_5ms", "5_10ms", "10_50ms", "50_100ms", 
+    "100_500ms", "500_1000ms", "1_5s", "over_5s"
+  };
+  
+  for (size_t i = 0; i < latency_buckets.size(); i++) {
+    ss << "pika_threadpool_latency_bucket{pool=\"" << pool_name 
+       << "\",bucket=\"" << bucket_labels[i] << "\"} " 
+       << latency_buckets[i].load() << "\n";
+  }
+  
+  return ss.str();
+}
+
+void ThreadPoolMetrics::Reset() {
+  tasks_scheduled.store(0);
+  tasks_completed.store(0);
+  queue_overflows.store(0);
+  borrow_attempts.store(0);
+  successful_borrows.store(0);
+  
+  for (auto& bucket : latency_buckets) {
+    bucket.store(0);
+  }
+}
+
+// RateLimiter 实现
+RateLimiter::RateLimiter(double rate_per_sec, double burst_size)
+    : rate_(rate_per_sec),
+      max_tokens_(burst_size),
+      tokens_(burst_size),
+      last_update_(std::chrono::steady_clock::now()) {}
+
+void RateLimiter::Refill() {
+  auto now = std::chrono::steady_clock::now();
+  double elapsed = std::chrono::duration<double>(now - last_update_).count();
+  double new_tokens = elapsed * rate_;
+  tokens_ = std::min(tokens_ + new_tokens, max_tokens_);
+  last_update_ = now;
+}
+
+bool RateLimiter::TryAcquire(double tokens) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  Refill();
+  
+  if (tokens_ >= tokens) {
+    tokens_ -= tokens;
+    return true;
+  }
+  return false;
+}
+
+void RateLimiter::SetRate(double rate_per_sec) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  Refill();  // 先根据旧速率更新令牌
+  rate_ = rate_per_sec;
+}
+
+// ConsistentHash 实现
+ConsistentHash::ConsistentHash(int num_replicas, int num_buckets)
+    : num_replicas_(num_replicas) {
+  // 添加"fast"和"slow"两个节点
+  AddNode("fast");
+  AddNode("slow");
+}
+
+void ConsistentHash::AddNode(const std::string& node) {
+  for (int i = 0; i < num_replicas_; i++) {
+    std::string key = node + ":" + std::to_string(i);
+    size_t hash = hasher_(key);
+    ring_[hash] = node;
+  }
+}
+
+void ConsistentHash::RemoveNode(const std::string& node) {
+  for (int i = 0; i < num_replicas_; i++) {
+    std::string key = node + ":" + std::to_string(i);
+    size_t hash = hasher_(key);
+    ring_.erase(hash);
+  }
+}
+
+std::string ConsistentHash::GetNode(const std::string& key) const {
+  if (ring_.empty()) {
+    return "fast";  // 默认返回fast
+  }
+  
+  size_t hash = HashKey(key);
+  
+  // 找到第一个大于等于hash的节点
+  auto it = ring_.lower_bound(hash);
+  if (it == ring_.end()) {
+    // 如果没有找到，则环绕到第一个节点
+    return ring_.begin()->second;
+  } else {
+    return it->second;
+  }
+}
+
+size_t ConsistentHash::HashKey(const std::string& key) const {
+  return hasher_(key);
+}
+
 void DoPurgeDir(void* arg) {
   std::unique_ptr<std::string> path(static_cast<std::string*>(arg));
   LOG(INFO) << "Delete dir: " << *path << " start";
@@ -47,7 +289,12 @@ PikaServer::PikaServer()
       last_check_compact_time_({0, 0}),
       last_check_resume_time_({0, 0}),
       repl_state_(PIKA_REPL_NO_CONNECT),
-      role_(PIKA_ROLE_SINGLE) {
+      role_(PIKA_ROLE_SINGLE),
+      cmd_classifier_(new CommandClassifier(50000, 10000, 1000)),
+      fast_pool_metrics_(new ThreadPoolMetrics()),
+      slow_pool_metrics_(new ThreadPoolMetrics()),
+      cmd_rate_limiter_(new RateLimiter(g_pika_conf->maxclients() * 2)), // 默认速率：最大客户端连接数的2倍
+      key_hash_(new ConsistentHash(100, 1024)) {
   // Init server ip host
   if (!ServerInit()) {
     LOG(FATAL) << "ServerInit iotcl error";
@@ -770,55 +1017,81 @@ void PikaServer::SetFirstMetaSync(bool v) {
 }
 
 void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_cmd, bool is_admin_cmd) {
-  // Admin commands always go to admin thread pool
-  if (is_admin_cmd) {
-    pika_admin_cmd_thread_pool_->Schedule(func, arg);
+  // Apply rate limiting if enabled (only for non-admin commands)
+  if (!is_admin_cmd && !CheckCommandRateLimit()) {
+    // Rate limit exceeded, handle gracefully
+    auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
+    if (bg_arg) {
+      // Set error response for rate limiting
+      bg_arg->resp = std::make_shared<std::string>("-ERR Rate limit exceeded, try again later\r\n");
+      bg_arg->conn->WriteResp(*(bg_arg->resp));
+      delete bg_arg;
+    }
     return;
   }
 
+  // Admin commands always go to admin thread pool
+  if (is_admin_cmd) {
+    if (pika_admin_cmd_thread_pool_) {
+      pika_admin_cmd_thread_pool_->Schedule(func, arg);
+    }
+    return;
+  }
+  
+  // Extract command info for dynamic classification and key affinity
+  auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
+  std::string cmd_name;
+  std::string key;
+  bool has_key = false;
+  bool key_affinity_to_slow = false;
+  
+  if (bg_arg && !bg_arg->redis_cmds.empty() && !bg_arg->redis_cmds[0].empty()) {
+    const auto& cmd_args = bg_arg->redis_cmds[0];
+    if (!cmd_args.empty()) {
+      cmd_name = cmd_args[0];
+      pstd::StringToLower(cmd_name);
+      
+      // Extract key for affinity routing
+      if (cmd_args.size() > 1) {
+        key = cmd_args[1];
+        has_key = true;
+        // Use improved consistent hashing for key affinity
+        key_affinity_to_slow = IsKeyAffinityToSlow(key);
+      }
+    }
+  }
+  
+  // Check if command is dynamically classified as slow
+  // Override static classification if dynamic classification exists
+  if (!cmd_name.empty() && cmd_classifier_) {
+    bool dynamic_is_slow = IsDynamicSlowCommand(cmd_name);
+    if (dynamic_is_slow) {
+      is_slow_cmd = true;
+    }
+  }
+  
   // Check if thread pool borrowing is enabled
   bool borrow_enable = g_pika_conf->threadpool_borrow_enable();
   bool slow_cmd_pool_enable = g_pika_conf->slow_cmd_pool();
   
+  // Update metrics before scheduling
+  if (is_slow_cmd && slow_pool_metrics_) {
+    slow_pool_metrics_->tasks_scheduled++;
+  } else if (fast_pool_metrics_) {
+    fast_pool_metrics_->tasks_scheduled++;
+  }
+  
+  // If borrowing or slow pool is disabled, use simple routing
   if (!borrow_enable || !slow_cmd_pool_enable) {
-    // Original logic: direct routing without borrowing
     if (is_slow_cmd && slow_cmd_pool_enable) {
       pika_slow_cmd_thread_pool_->Schedule(func, arg);
-      return;
+    } else {
+      pika_client_processor_->SchedulePool(func, arg);
     }
-    pika_client_processor_->SchedulePool(func, arg);
     return;
   }
 
-  // Extract key from command to determine key affinity
-  // This ensures commands on the same key always go to the same thread pool
-  auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
-  bool key_affinity_to_slow = false;
-  bool has_key = false;
-  
-  if (bg_arg && !bg_arg->redis_cmds.empty() && !bg_arg->redis_cmds[0].empty()) {
-    const auto& cmd_args = bg_arg->redis_cmds[0];
-    std::string cmd_name = cmd_args[0];
-    pstd::StringToLower(cmd_name);
-    
-    // Extract key based on command type
-    // Most commands have key as the first argument after command name
-    std::string key;
-    if (cmd_args.size() > 1) {
-      // For most commands, key is argv[1]
-      // For special commands like MGET, MSET, we use the first key
-      key = cmd_args[1];
-      has_key = true;
-      
-      // Use simple hash to determine key affinity
-      // Same key will always have same affinity (fast or slow pool)
-      std::hash<std::string> hasher;
-      size_t hash_value = hasher(key);
-      key_affinity_to_slow = (hash_value % 2 == 1);
-    }
-  }
-
-  // Borrowing is enabled, check queue status and decide
+  // Borrowing is enabled, check queue status
   size_t slow_queue_size = SlowCmdThreadPoolCurQueueSize();
   size_t slow_max_queue = SlowCmdThreadPoolMaxQueueSize();
   size_t fast_queue_size = ClientProcessorThreadPoolCurQueueSize();
@@ -833,9 +1106,9 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
   size_t slow_idle_threshold = slow_max_queue * idle_threshold_percent / 100;
   size_t fast_idle_threshold = fast_max_queue * idle_threshold_percent / 100;
 
-  // Decision logic considering both command type and key affinity
+  // Enhanced decision logic considering dynamic classification and improved key affinity
   if (is_slow_cmd) {
-    // This is a slow command
+    // This is a slow command (either statically or dynamically classified)
     if (has_key && !key_affinity_to_slow) {
       // Key affinity is to fast pool, must use fast pool to maintain order
       pika_client_processor_->SchedulePool(func, arg);
@@ -846,8 +1119,12 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
         pika_slow_cmd_thread_pool_->Schedule(func, arg);
       } else {
         // Can borrow from fast pool
+        if (slow_pool_metrics_) {
+          slow_pool_metrics_->borrow_attempts++;
+          slow_pool_metrics_->successful_borrows++;
+        }
         pika_client_processor_->SchedulePool(func, arg);
-        LOG(INFO) << "Slow cmd borrows fast pool (slow_queue: " << slow_queue_size 
+        LOG(INFO) << "Slow cmd " << cmd_name << " borrows fast pool (slow_queue: " << slow_queue_size 
                   << "/" << slow_max_queue << ", fast_queue: " << fast_queue_size 
                   << "/" << fast_max_queue << ")";
       }
@@ -867,8 +1144,12 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
         pika_client_processor_->SchedulePool(func, arg);
       } else {
         // Can borrow from slow pool
+        if (fast_pool_metrics_) {
+          fast_pool_metrics_->borrow_attempts++;
+          fast_pool_metrics_->successful_borrows++;
+        }
         pika_slow_cmd_thread_pool_->Schedule(func, arg);
-        LOG(INFO) << "Fast cmd borrows slow pool (fast_queue: " << fast_queue_size 
+        LOG(INFO) << "Fast cmd " << cmd_name << " borrows slow pool (fast_queue: " << fast_queue_size 
                   << "/" << fast_max_queue << ", slow_queue: " << slow_queue_size 
                   << "/" << slow_max_queue << ")";
       }
@@ -876,6 +1157,12 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
       // Normal case: use fast pool
       pika_client_processor_->SchedulePool(func, arg);
     }
+  }
+  
+  // Periodically adjust borrow thresholds based on load (every 100 commands)
+  static int command_counter = 0;
+  if (++command_counter % 100 == 0) {
+    AdjustBorrowThresholds();
   }
 }
 
@@ -2108,3 +2395,135 @@ void PikaServer::CacheConfigInit(cache::CacheConfig& cache_cfg) {
   cache_cfg.lfu_decay_time = g_pika_conf->cache_lfu_decay_time();
 }
 void PikaServer::SetLogNetActivities(bool value) { pika_dispatch_thread_->SetLogNetActivities(value); }
+
+// 改进的快慢命令分离相关方法实现
+
+void PikaServer::AdjustBorrowThresholds() {
+  // 这个方法可以根据系统负载动态调整借用阈值
+  // 当前使用简单的队列饱和度来调整
+  
+  size_t fast_queue_size = ClientProcessorThreadPoolCurQueueSize();
+  size_t fast_max_queue = ClientProcessorThreadPoolMaxQueueSize();
+  size_t slow_queue_size = SlowCmdThreadPoolCurQueueSize();
+  size_t slow_max_queue = SlowCmdThreadPoolMaxQueueSize();
+  
+  if (fast_max_queue == 0 || slow_max_queue == 0) {
+    return;
+  }
+  
+  // 计算队列饱和度
+  double fast_saturation = static_cast<double>(fast_queue_size) / fast_max_queue;
+  double slow_saturation = static_cast<double>(slow_queue_size) / slow_max_queue;
+  
+  int current_threshold = g_pika_conf->threadpool_borrow_threshold_percent();
+  int new_threshold = current_threshold;
+  
+  // 如果两个线程池都很繁忙（饱和度>0.8），提高借用阈值（更难借用）
+  if (fast_saturation > 0.8 && slow_saturation > 0.8) {
+    new_threshold = std::min(90, current_threshold + 5);
+  }
+  // 如果两个线程池都很空闲（饱和度<0.3），降低借用阈值（更容易借用）
+  else if (fast_saturation < 0.3 && slow_saturation < 0.3) {
+    new_threshold = std::max(30, current_threshold - 5);
+  }
+  
+  if (new_threshold != current_threshold) {
+    g_pika_conf->SetThreadpoolBorrowThresholdPercent(new_threshold);
+    LOG(INFO) << "Adjusted borrow threshold from " << current_threshold 
+              << "% to " << new_threshold << "% (fast_sat: " 
+              << std::fixed << std::setprecision(2) << fast_saturation * 100 
+              << "%, slow_sat: " << slow_saturation * 100 << "%)";
+  }
+}
+
+bool PikaServer::IsDynamicSlowCommand(const std::string& cmd_name) const {
+  if (!cmd_classifier_) {
+    return false;
+  }
+  return cmd_classifier_->IsSlowCommand(cmd_name);
+}
+
+void PikaServer::RecordCommandExecutionTime(const std::string& cmd_name, uint64_t duration_us) {
+  if (cmd_classifier_) {
+    cmd_classifier_->RecordExecutionTime(cmd_name, duration_us);
+  }
+  
+  // 同时记录到线程池指标中
+  // 注意：这里需要知道命令是在哪个线程池执行的，简化起见我们根据是否是慢命令来判断
+  if (IsDynamicSlowCommand(cmd_name) && slow_pool_metrics_) {
+    slow_pool_metrics_->RecordLatency(duration_us);
+    slow_pool_metrics_->tasks_completed++;
+  } else if (fast_pool_metrics_) {
+    fast_pool_metrics_->RecordLatency(duration_us);
+    fast_pool_metrics_->tasks_completed++;
+  }
+}
+
+void PikaServer::SetCommandRateLimit(double rate_per_sec) {
+  if (cmd_rate_limiter_) {
+    cmd_rate_limiter_->SetRate(rate_per_sec);
+    LOG(INFO) << "Command rate limit set to " << rate_per_sec << " commands/sec";
+  }
+}
+
+bool PikaServer::CheckCommandRateLimit() {
+  if (!cmd_rate_limiter_) {
+    return true;  // 如果没有限流器，总是允许
+  }
+  return cmd_rate_limiter_->TryAcquire(1.0);
+}
+
+std::string PikaServer::GetEnhancedThreadPoolMetrics() const {
+  std::stringstream ss;
+  
+  // 基本线程池信息
+  GetThreadPoolInfo(&ss.str());
+  
+  // 增强的指标（Prometheus格式）
+  ss << "\n# Enhanced Thread Pool Metrics\n";
+  
+  if (fast_pool_metrics_) {
+    ss << fast_pool_metrics_->ExportMetrics("fast");
+  }
+  
+  if (slow_pool_metrics_ && g_pika_conf->slow_cmd_pool()) {
+    ss << slow_pool_metrics_->ExportMetrics("slow");
+  }
+  
+  // 命令分类统计
+  if (cmd_classifier_) {
+    ss << "\n# Command Classification\n";
+    auto cmd_avg_times = cmd_classifier_->GetCommandAvgTimes();
+    for (const auto& [cmd_name, avg_time] : cmd_avg_times) {
+      bool is_slow = cmd_classifier_->IsSlowCommand(cmd_name);
+      ss << "command_avg_time{cmd=\"" << cmd_name 
+         << "\",type=\"" << (is_slow ? "slow" : "fast") << "\"} " 
+         << avg_time / 1000.0 << " # milliseconds\n";
+    }
+  }
+  
+  return ss.str();
+}
+
+bool PikaServer::IsKeyAffinityToSlow(const std::string& key) const {
+  if (!key_hash_) {
+    // 如果没有一致性哈希，使用简单的哈希
+    std::hash<std::string> hasher;
+    return (hasher(key) % 2) == 1;
+  }
+  
+  std::string node = key_hash_->GetNode(key);
+  return node == "slow";
+}
+
+void PikaServer::ResetThreadPoolMetrics() {
+  if (fast_pool_metrics_) {
+    fast_pool_metrics_->Reset();
+  }
+  
+  if (slow_pool_metrics_) {
+    slow_pool_metrics_->Reset();
+  }
+  
+  LOG(INFO) << "Thread pool metrics reset";
+}

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -294,8 +294,7 @@ PikaServer::PikaServer()
       cmd_classifier_(new CommandClassifier(50000, 10000, 1000)),
       fast_pool_metrics_(new ThreadPoolMetrics()),
       slow_pool_metrics_(new ThreadPoolMetrics()),
-      cmd_rate_limiter_(new RateLimiter(g_pika_conf->maxclients() * 2)), // 默认速率：最大客户端连接数的2倍
-      key_hash_(new ConsistentHash(100, 1024)) {
+      cmd_rate_limiter_(new RateLimiter(g_pika_conf->maxclients() * 2)){
   // Init server ip host
   if (!ServerInit()) {
     LOG(FATAL) << "ServerInit iotcl error";
@@ -356,6 +355,13 @@ PikaServer::PikaServer()
   bgslots_cleanup_thread_.set_thread_name("PikaServer::bgslots_cleanup_thread_");
   common_bg_thread_.set_thread_name("PikaServer::common_bg_thread_");
   key_scan_thread_.set_thread_name("PikaServer::key_scan_thread_");
+
+  int slot_num = g_pika_conf->default_slot_num();
+  // 这里判断的时候，能否认为没有配置的时候就没有使用sharding模式呢
+  if(slot_num <= 0){
+    slot_num = 1024;
+  }
+  virtual_slot_.resize(slot_num);
 }
 
 PikaServer::~PikaServer() {
@@ -1057,7 +1063,7 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
         key = cmd_args[1];
         has_key = true;
         // Use improved consistent hashing for key affinity
-        key_affinity_to_slow = IsKeyAffinityToSlow(key);
+        // key_affinity_to_slow = IsKeyAffinityToSlow(key);
       }
     }
   }
@@ -2508,16 +2514,6 @@ std::string PikaServer::GetEnhancedThreadPoolMetrics() const {
   return ss.str();
 }
 
-bool PikaServer::IsKeyAffinityToSlow(const std::string& key) const {
-  if (!key_hash_) {
-    std::hash<std::string> hasher;
-    return (hasher(key) % 2) == 1;
-  }
-  
-  std::string node = key_hash_->GetNode(key);
-  return node == "slow";
-}
-
 void PikaServer::ResetThreadPoolMetrics() {
   if (fast_pool_metrics_) {
     fast_pool_metrics_->Reset();
@@ -2528,4 +2524,59 @@ void PikaServer::ResetThreadPoolMetrics() {
   }
   
   LOG(INFO) << "Thread pool metrics reset";
+}
+
+int PikaServer::GetVirtualSlotID(const std::string& key){
+  if (key.empty() || virtual_slots_.empty()) {
+    return -1;
+  }
+  uint32_t crc = pstd::hash::crc32(0, key.data(), key.size());
+  return static_cast<int>(crc % virtual_slots_.size());
+}
+
+void PikaServer::ReleaseVirtualSlotID(int slot_id){
+  if(slot_id < 0 || slot_id >= virtual_slots_.size()){
+    return;
+  }
+  virtual_slots_[slot_id].active_count.fetch_sub(1, std::memory_order_release);
+}
+
+bool PikaServer::IsSlowPoolBusy() {
+  size_t current_size = SlowCmdThreadPoolCurQueueSize();
+  size_t max_size = SlowCmdThreadPoolMaxQueueSize();
+  if (max_size == 0) {
+    return false;
+  }
+  int threadhold = g_pika_conf->threadpool_borrow_threshold_percent();
+  return current_size >= (max_size * threadhold / 100);
+}
+
+bool PikaServer::IsSlowPoolIdle(){
+  size_t current_size = SlowCmdThreadPoolCurQueueSize();
+  size_t max_size = SlowCmdThreadPoolMaxQueueSize();
+  if (max_size == 0) {
+    return true;
+  }
+  int threshold = g_pika_conf->threadpool_idle_threshold_percent();
+  return current_size <= (max_size * threshold / 100);
+}
+
+bool PikaServer::IsFastPoolBusy() {
+  size_t current_size = ClientProcessorThreadPoolCurQueueSize();
+  size_t max_size = ClientProcessorThreadPoolMaxQueueSize();
+  if (max_size == 0) {
+    return false;
+  }
+  int threadhold = g_pika_conf->threadpool_borrow_threshold_percent();
+  return current_size >= (max_size * threadhold / 100);
+}
+
+bool PikaServer::IsFastPoolIdle(){
+  size_t current_size = ClientProcessorThreadPoolCurQueueSize();
+  size_t max_size = ClientProcessorThreadPoolMaxQueueSize();
+  if (max_size == 0) {
+    return true;
+  }
+  int threshold = g_pika_conf->threadpool_idle_threshold_percent();
+  return current_size <= (max_size * threshold / 100);
 }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -770,15 +770,66 @@ void PikaServer::SetFirstMetaSync(bool v) {
 }
 
 void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_cmd, bool is_admin_cmd) {
-  if (is_slow_cmd && g_pika_conf->slow_cmd_pool()) {
-    pika_slow_cmd_thread_pool_->Schedule(func, arg);
-    return;
-  }
+  // Admin commands always go to admin thread pool
   if (is_admin_cmd) {
     pika_admin_cmd_thread_pool_->Schedule(func, arg);
     return;
   }
-  pika_client_processor_->SchedulePool(func, arg);
+
+  // Check if thread pool borrowing is enabled
+  bool borrow_enable = g_pika_conf->threadpool_borrow_enable();
+  bool slow_cmd_pool_enable = g_pika_conf->slow_cmd_pool();
+  
+  if (!borrow_enable || !slow_cmd_pool_enable) {
+    // Original logic: direct routing without borrowing
+    if (is_slow_cmd && slow_cmd_pool_enable) {
+      pika_slow_cmd_thread_pool_->Schedule(func, arg);
+      return;
+    }
+    pika_client_processor_->SchedulePool(func, arg);
+    return;
+  }
+
+  // Borrowing is enabled, check queue status and decide
+  size_t slow_queue_size = SlowCmdThreadPoolCurQueueSize();
+  size_t slow_max_queue = SlowCmdThreadPoolMaxQueueSize();
+  size_t fast_queue_size = ClientProcessorThreadPoolCurQueueSize();
+  size_t fast_max_queue = ClientProcessorThreadPoolMaxQueueSize();
+
+  int borrow_threshold_percent = g_pika_conf->threadpool_borrow_threshold_percent();
+  int idle_threshold_percent = g_pika_conf->threadpool_idle_threshold_percent();
+
+  // Calculate thresholds
+  size_t slow_borrow_threshold = slow_max_queue * borrow_threshold_percent / 100;
+  size_t fast_borrow_threshold = fast_max_queue * borrow_threshold_percent / 100;
+  size_t slow_idle_threshold = slow_max_queue * idle_threshold_percent / 100;
+  size_t fast_idle_threshold = fast_max_queue * idle_threshold_percent / 100;
+
+  if (is_slow_cmd) {
+    // This is a slow command
+    if (slow_queue_size >= slow_borrow_threshold && fast_queue_size <= fast_idle_threshold) {
+      // Slow pool is busy and fast pool is idle, borrow from fast pool
+      pika_client_processor_->SchedulePool(func, arg);
+      LOG(INFO) << "Slow cmd borrows fast pool (slow_queue: " << slow_queue_size 
+                << "/" << slow_max_queue << ", fast_queue: " << fast_queue_size 
+                << "/" << fast_max_queue << ")";
+    } else {
+      // Normal case: use slow pool
+      pika_slow_cmd_thread_pool_->Schedule(func, arg);
+    }
+  } else {
+    // This is a fast command
+    if (fast_queue_size >= fast_borrow_threshold && slow_queue_size <= slow_idle_threshold) {
+      // Fast pool is busy and slow pool is idle, borrow from slow pool
+      pika_slow_cmd_thread_pool_->Schedule(func, arg);
+      LOG(INFO) << "Fast cmd borrows slow pool (fast_queue: " << fast_queue_size 
+                << "/" << fast_max_queue << ", slow_queue: " << slow_queue_size 
+                << "/" << slow_max_queue << ")";
+    } else {
+      // Normal case: use fast pool
+      pika_client_processor_->SchedulePool(func, arg);
+    }
+  }
 }
 
 size_t PikaServer::ClientProcessorThreadPoolCurQueueSize() {

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1022,28 +1022,29 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
     pika_admin_cmd_thread_pool_->Schedule(func, arg);
     return;
   }
+  // 慢池未开启，直接用快池调用
+  if(!g_pika_conf->slow_cmd_pool()) {
+    pika_client_processor_->SchedulePool(func, arg);
+    return;
+  }
   // 这里的速率判断后要做些什么
   // if(cmd_rate_limiter_ && !cmd_rate_limiter_->TryAcquire(1.0)) {
-  //   p
+  //
   // }
 
-  TaskPoolType target_pool = TaskPoolType::kFastCmdPool;
-  bool borrow_enabled = g_pika_conf->threadpool_borrow_enable();
-  if (is_slow_cmd && g_pika_conf->slow_cmd_pool()) {
-    target_pool = TaskPoolType::kSlowCmdPool; // 默认归宿
-
-    if (borrow_enabled && IsSlowPoolBusy() && IsFastPoolIdle()) {
-        target_pool = TaskPoolType::kFastCmdPool;
-        LOG_EVERY_N(INFO, 1000) << "Slow command borrows fast pool (Risk Taken)";
-    }
-  } 
-  else {
-    target_pool = TaskPoolType::kFastCmdPool; // 默认归宿
-    if (borrow_enabled && IsFastPoolBusy() && IsSlowPoolIdle()) {
-        target_pool = TaskPoolType::kSlowCmdPool;
-        LOG_EVERY_N(INFO, 1000) << "Fast command borrows slow pool";
-    }
+  std::string cmd_name;
+  auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
+  if (bg_arg && !bg_arg->redis_cmds.empty() && !bg_arg->redis_cmds[0].empty()) {
+    cmd_name = bg_arg->redis_cmds[0][0];
   }
+
+  TaskPoolType target_pool = DecidePoolType(cmd_name, is_slow_cmd);
+  const char* pool_name = (target_pool == TaskPoolType::kSlowCmdPool) ? "SLOW" : "FAST";
+  const char* cmd_type = is_slow_cmd ? "slow" : "fast";
+    LOG_EVERY_N(INFO, 100) << "[TEST] Command='" << cmd_name 
+                         << "' Type=" << cmd_type
+                         << " -> Pool=" << pool_name;
+
 
   if (target_pool == TaskPoolType::kSlowCmdPool) {
     if (slow_pool_metrics_) {
@@ -1172,6 +1173,18 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
   tmp_stream << "fast_cmd_pool_max_queue_size:" << fast_max_queue << "\r\n";
   tmp_stream << "fast_cmd_pool_usage:" << std::fixed << std::setprecision(2) << fast_usage << "%\r\n";
   
+
+   // 快池借用统计（新增）
+  if (g_pika_server->fast_pool_metrics_) {
+    tmp_stream << "fast_cmd_pool_tasks_scheduled:" 
+       << g_pika_server->fast_pool_metrics_->tasks_scheduled.load() << "\r\n";
+    tmp_stream << "fast_cmd_pool_borrow_attempts:" 
+       << g_pika_server->fast_pool_metrics_->borrow_attempts.load() << "\r\n";
+    tmp_stream << "fast_cmd_pool_successful_borrows:" 
+       << g_pika_server->fast_pool_metrics_->successful_borrows.load() << "\r\n";
+  }
+
+
   // Slow cmd thread pool info
   if (g_pika_conf->slow_cmd_pool()) {
     size_t slow_pool_size = g_pika_conf->slow_cmd_thread_pool_size();
@@ -1188,6 +1201,16 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
     tmp_stream << "slow_cmd_pool_queue_size:0\r\n";
     tmp_stream << "slow_cmd_pool_max_queue_size:0\r\n";
     tmp_stream << "slow_cmd_pool_usage:0.00%\r\n";
+  }
+
+    // 慢池借用统计（新增）
+  if (g_pika_server->slow_pool_metrics_) {
+    tmp_stream << "slow_cmd_pool_tasks_scheduled:" 
+       << g_pika_server->slow_pool_metrics_->tasks_scheduled.load() << "\r\n";
+    tmp_stream << "slow_cmd_pool_borrow_attempts:" 
+       << g_pika_server->slow_pool_metrics_->borrow_attempts.load() << "\r\n";
+    tmp_stream << "slow_cmd_pool_successful_borrows:" 
+       << g_pika_server->slow_pool_metrics_->successful_borrows.load() << "\r\n";
   }
   
   // Admin cmd thread pool info
@@ -2439,6 +2462,9 @@ bool PikaServer::IsFastPoolBusy() {
     return false;
   }
   int threadhold = g_pika_conf->threadpool_borrow_threshold_percent();
+  // [测试日志] 定期打印慢池状态
+  LOG_EVERY_N(INFO, 1000) << "[TEST-POOL] FastPool: " << current_size << "/" << max_size 
+                          << " (" << (max_size > 0 ? current_size * 100 / max_size : 0) << "%)";
   return current_size >= (max_size * threadhold / 100);
 }
 
@@ -2449,6 +2475,9 @@ bool PikaServer::IsFastPoolIdle() {
     return true;
   }
   int threshold = g_pika_conf->threadpool_idle_threshold_percent();
+    // [测试日志] 定期打印快池状态
+  LOG_EVERY_N(INFO, 1000) << "[TEST-POOL] FastPool: " << current_size << "/" << max_size 
+                          << " (" << (max_size > 0 ? current_size * 100 / max_size : 0) << "%)";
   return current_size <= (max_size * threshold / 100);
 }
 
@@ -2459,7 +2488,7 @@ TaskPoolType PikaServer::DecidePoolType(const std::string& cmd_name, bool is_slo
 
   bool borrow_enabled = g_pika_conf->threadpool_borrow_enable();
 
-  // 场景 A: 当前是 慢命令 (Slow Command)
+  // 场景 A: 当前是 慢命令
   if (is_slow_cmd) {
     // 默认归宿：慢池
     TaskPoolType decision = TaskPoolType::kSlowCmdPool;
@@ -2473,12 +2502,24 @@ TaskPoolType PikaServer::DecidePoolType(const std::string& cmd_name, bool is_slo
         slow_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
         slow_pool_metrics_->successful_borrows.fetch_add(1, std::memory_order_relaxed);
       }
-      
       LOG_EVERY_N(INFO, 1000) << "Slow command '" << cmd_name << "' borrows fast pool";
+    
+      // [测试日志] 慢命令借用快池
+      size_t slow_cur = SlowCmdThreadPoolCurQueueSize();
+      size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
+      size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();
+      size_t fast_max = ClientProcessorThreadPoolMaxQueueSize();
+      
+      LOG(WARNING) << "[TEST-BORROW] SLOW->FAST: cmd='" << cmd_name 
+                   << "' slow_queue=" << slow_cur << "/" << slow_max 
+                   << "(" << (slow_max > 0 ? slow_cur * 100 / slow_max : 0) << "%)"
+                   << " fast_queue=" << fast_cur << "/" << fast_max
+                   << "(" << (fast_max > 0 ? fast_cur * 100 / fast_max : 0) << "%)"
+                   << " total_borrows=" << slow_pool_metrics_->successful_borrows.load();
+
     }
     return decision;
-  }
-  else {
+  } else {
     // 默认归宿：快池
     TaskPoolType decision = TaskPoolType::kFastCmdPool;
 
@@ -2494,6 +2535,20 @@ TaskPoolType PikaServer::DecidePoolType(const std::string& cmd_name, bool is_slo
       }
 
       LOG_EVERY_N(INFO, 1000) << "Fast command '" << cmd_name << "' borrows slow pool";
+    
+      // [测试日志] 快命令借用慢池
+      size_t slow_cur = SlowCmdThreadPoolCurQueueSize();
+      size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
+      size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();
+      size_t fast_max = ClientProcessorThreadPoolMaxQueueSize();
+      
+      LOG(INFO) << "[TEST-BORROW] FAST->SLOW: cmd='" << cmd_name 
+                << "' fast_queue=" << fast_cur << "/" << fast_max 
+                << "(" << (fast_max > 0 ? fast_cur * 100 / fast_max : 0) << "%)"
+                << " slow_queue=" << slow_cur << "/" << slow_max
+                << "(" << (slow_max > 0 ? slow_cur * 100 / slow_max : 0) << "%)"
+                << " total_borrows=" << fast_pool_metrics_->successful_borrows.load();
+
     }
     return decision;
   }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -35,106 +35,6 @@ extern std::unique_ptr<net::NetworkStatistic> g_network_statistic;
 // QUEUE_SIZE_THRESHOLD_PERCENTAGE is used to represent a percentage value and should be within the range of 0 to 100.
 const size_t QUEUE_SIZE_THRESHOLD_PERCENTAGE = 75;
 
-// CommandClassifier 实现
-void CommandClassifier::CommandStats::AddTime(uint64_t time, size_t window_size) {
-  total_time += time;
-  count++;
-  
-  if (recent_times.size() < window_size) {
-    recent_times.push_back(time);
-  } else {
-    if (!initialized) {
-      initialized = true;
-    }
-    // 替换最旧的记录
-    total_time -= recent_times[time_index];
-    recent_times[time_index] = time;
-    time_index = (time_index + 1) % window_size;
-  }
-}
-
-double CommandClassifier::CommandStats::GetAverageTime() const {
-  return count > 0 ? static_cast<double>(total_time) / count : 0.0;
-}
-
-double CommandClassifier::CommandStats::GetRecentAverageTime() const {
-  if (!initialized && recent_times.empty()) {
-    return 0.0;
-  }
-  
-  size_t sample_count = initialized ? recent_times.size() : time_index;
-  if (sample_count == 0) {
-    return 0.0;
-  }
-  
-  uint64_t recent_total = 0;
-  for (size_t i = 0; i < sample_count; i++) {
-    recent_total += recent_times[i];
-  }
-  
-  return static_cast<double>(recent_total) / sample_count;
-}
-
-CommandClassifier::CommandClassifier(uint64_t slow_threshold_us, uint64_t fast_threshold_us, size_t window_size)
-    : slow_threshold_us_(slow_threshold_us),
-      fast_threshold_us_(fast_threshold_us),
-      window_size_(window_size) {}
-
-void CommandClassifier::RecordExecutionTime(const std::string& cmd_name, uint64_t duration_us) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  
-  // 更新命令执行时间统计
-  auto& stats = cmd_stats_[cmd_name];
-  stats.AddTime(duration_us, window_size_);
-  
-  // 根据最近平均执行时间分类命令
-  if (stats.initialized || stats.recent_times.size() >= window_size_ / 2) {
-    double recent_avg = stats.GetRecentAverageTime();
-    
-    if (recent_avg > slow_threshold_us_) {
-      // 如果平均时间超过慢命令阈值，标记为慢命令
-      if (slow_commands_.find(cmd_name) == slow_commands_.end()) {
-        LOG(INFO) << "Command '" << cmd_name << "' reclassified as SLOW (avg time: " 
-                  << recent_avg / 1000.0 << "ms)";
-        slow_commands_.insert(cmd_name);
-      }
-    } else if (recent_avg < fast_threshold_us_ && stats.initialized) {
-      // 如果平均时间低于快命令阈值且有足够样本，可能标记为快命令
-      if (slow_commands_.find(cmd_name) != slow_commands_.end()) {
-        LOG(INFO) << "Command '" << cmd_name << "' reclassified as FAST (avg time: " 
-                  << recent_avg / 1000.0 << "ms)";
-        slow_commands_.erase(cmd_name);
-      }
-    }
-  }
-}
-
-bool CommandClassifier::IsSlowCommand(const std::string& cmd_name) const {
-  std::lock_guard<std::mutex> lock(mutex_);
-  return slow_commands_.find(cmd_name) != slow_commands_.end();
-}
-
-void CommandClassifier::MarkAsSlowCommand(const std::string& cmd_name) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  slow_commands_.insert(cmd_name);
-}
-
-void CommandClassifier::MarkAsFastCommand(const std::string& cmd_name) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  slow_commands_.erase(cmd_name);
-}
-
-std::unordered_map<std::string, double> CommandClassifier::GetCommandAvgTimes() const {
-  std::lock_guard<std::mutex> lock(mutex_);
-  std::unordered_map<std::string, double> result;
-  
-  for (const auto& [cmd_name, stats] : cmd_stats_) {
-    result[cmd_name] = stats.GetAverageTime();
-  }
-  
-  return result;
-}
-
 // ThreadPoolMetrics 实现
 void ThreadPoolMetrics::RecordLatency(uint64_t latency_us) {
   if (latency_us < 1000) {
@@ -163,14 +63,8 @@ std::string ThreadPoolMetrics::ExportMetrics(const std::string& pool_name) const
   
   ss << "# TYPE pika_threadpool_tasks_scheduled counter\n"
      << "pika_threadpool_tasks_scheduled{pool=\"" << pool_name << "\"} " << tasks_scheduled.load() << "\n"
-     << "# TYPE pika_threadpool_tasks_completed counter\n"
-     << "pika_threadpool_tasks_completed{pool=\"" << pool_name << "\"} " << tasks_completed.load() << "\n"
-     << "# TYPE pika_threadpool_queue_overflows counter\n"
-     << "pika_threadpool_queue_overflows{pool=\"" << pool_name << "\"} " << queue_overflows.load() << "\n"
      << "# TYPE pika_threadpool_borrow_attempts counter\n"
-     << "pika_threadpool_borrow_attempts{pool=\"" << pool_name << "\"} " << borrow_attempts.load() << "\n"
-     << "# TYPE pika_threadpool_successful_borrows counter\n"
-     << "pika_threadpool_successful_borrows{pool=\"" << pool_name << "\"} " << successful_borrows.load() << "\n";
+     << "pika_threadpool_borrow_attempts{pool=\"" << pool_name << "\"} " << borrow_attempts.load() << "\n";
   
   // 延迟分布
   ss << "# TYPE pika_threadpool_latency_buckets counter\n";
@@ -191,90 +85,11 @@ std::string ThreadPoolMetrics::ExportMetrics(const std::string& pool_name) const
 void ThreadPoolMetrics::Reset() {
   tasks_scheduled.store(0);
   tasks_completed.store(0);
-  queue_overflows.store(0);
   borrow_attempts.store(0);
-  successful_borrows.store(0);
-  
+
   for (auto& bucket : latency_buckets) {
     bucket.store(0);
   }
-}
-
-// RateLimiter 实现
-RateLimiter::RateLimiter(double rate_per_sec, double burst_size)
-    : rate_(rate_per_sec),
-      max_tokens_(burst_size),
-      tokens_(burst_size),
-      last_update_(std::chrono::steady_clock::now()) {}
-
-void RateLimiter::Refill() {
-  auto now = std::chrono::steady_clock::now();
-  double elapsed = std::chrono::duration<double>(now - last_update_).count();
-  double new_tokens = elapsed * rate_;
-  tokens_ = std::min(tokens_ + new_tokens, max_tokens_);
-  last_update_ = now;
-}
-
-bool RateLimiter::TryAcquire(double tokens) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  Refill();
-  
-  if (tokens_ >= tokens) {
-    tokens_ -= tokens;
-    return true;
-  }
-  return false;
-}
-
-void RateLimiter::SetRate(double rate_per_sec) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  Refill();  // 先根据旧速率更新令牌
-  rate_ = rate_per_sec;
-}
-
-// ConsistentHash 实现
-ConsistentHash::ConsistentHash(int num_replicas, int num_buckets)
-    : num_replicas_(num_replicas) {
-  // 添加"fast"和"slow"两个节点
-  AddNode("fast");
-  AddNode("slow");
-}
-
-void ConsistentHash::AddNode(const std::string& node) {
-  for (int i = 0; i < num_replicas_; i++) {
-    std::string key = node + ":" + std::to_string(i);
-    size_t hash = hasher_(key);
-    ring_[hash] = node;
-  }
-}
-
-void ConsistentHash::RemoveNode(const std::string& node) {
-  for (int i = 0; i < num_replicas_; i++) {
-    std::string key = node + ":" + std::to_string(i);
-    size_t hash = hasher_(key);
-    ring_.erase(hash);
-  }
-}
-
-std::string ConsistentHash::GetNode(const std::string& key) const {
-  if (ring_.empty()) {
-    return "fast";  // 默认返回fast
-  }
-  
-  size_t hash = HashKey(key);
-  
-  // 找到第一个大于等于hash的节点
-  auto it = ring_.lower_bound(hash);
-  if (it == ring_.end()) {
-    // 如果没有找到，则环绕到第一个节点
-    return ring_.begin()->second;
-  } else {
-    return it->second;
-  }
-}
-
-size_t ConsistentHash::HashKey(const std::string& key) const {
-  return hasher_(key);
 }
 
 void DoPurgeDir(void* arg) {
@@ -292,10 +107,8 @@ PikaServer::PikaServer()
       last_check_resume_time_({0, 0}),
       repl_state_(PIKA_REPL_NO_CONNECT),
       role_(PIKA_ROLE_SINGLE),
-      cmd_classifier_(new CommandClassifier(50000, 10000, 1000)),
       fast_pool_metrics_(new ThreadPoolMetrics()),
-      slow_pool_metrics_(new ThreadPoolMetrics()),
-      cmd_rate_limiter_(new RateLimiter(g_pika_conf->maxclients() * 2)){
+      slow_pool_metrics_(new ThreadPoolMetrics()){
   // Init server ip host
   if (!ServerInit()) {
     LOG(FATAL) << "ServerInit iotcl error";
@@ -1027,34 +840,18 @@ void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_
     pika_client_processor_->SchedulePool(func, arg);
     return;
   }
-  // 这里的速率判断后要做些什么
-  // if(cmd_rate_limiter_ && !cmd_rate_limiter_->TryAcquire(1.0)) {
-  //
-  // }
 
-  std::string cmd_name;
   auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
-  if (bg_arg && !bg_arg->redis_cmds.empty() && !bg_arg->redis_cmds[0].empty()) {
-    cmd_name = bg_arg->redis_cmds[0][0];
+
+  // 看看是否需要下沉。
+  TaskPoolType target_pool = DecidePoolType(is_slow_cmd);
+  if (bg_arg) {
+    bg_arg->pool_type = target_pool;
   }
 
-  TaskPoolType target_pool = DecidePoolType(cmd_name, is_slow_cmd);
-  const char* pool_name = (target_pool == TaskPoolType::kSlowCmdPool) ? "SLOW" : "FAST";
-  const char* cmd_type = is_slow_cmd ? "slow" : "fast";
-    LOG_EVERY_N(INFO, 100) << "[TEST] Command='" << cmd_name 
-                         << "' Type=" << cmd_type
-                         << " -> Pool=" << pool_name;
-
-
   if (target_pool == TaskPoolType::kSlowCmdPool) {
-    if (slow_pool_metrics_) {
-        slow_pool_metrics_->tasks_scheduled.fetch_add(1, std::memory_order_relaxed);
-    }
     pika_slow_cmd_thread_pool_->Schedule(func, arg);
   } else {
-    if (fast_pool_metrics_) {
-        fast_pool_metrics_->tasks_scheduled.fetch_add(1, std::memory_order_relaxed);
-    }
     pika_client_processor_->SchedulePool(func, arg);
   }
 }
@@ -1090,8 +887,8 @@ size_t PikaServer::SlowCmdThreadPoolMaxQueueSize() {
 }
 
 bool PikaServer::ResizeFastCmdThreadPool(size_t new_size) {
-  if (new_size == 0 || new_size > 1024) {
-    LOG(WARNING) << "Invalid fast cmd thread pool size: " << new_size << ", must be between 1 and 1024";
+  if (new_size == 0 || new_size > 24) {
+    LOG(WARNING) << "Invalid fast cmd thread pool size: " << new_size << ", must be between 1 and 24";
     return false;
   }
 
@@ -1123,7 +920,7 @@ bool PikaServer::ResizeFastCmdThreadPool(size_t new_size) {
 }
 
 bool PikaServer::ResizeSlowCmdThreadPool(size_t new_size) {
-  if (new_size == 0 || new_size > 1024) {
+  if (new_size == 0 || new_size > 24) {
     LOG(WARNING) << "Invalid slow cmd thread pool size: " << new_size << ", must be between 1 and 1024";
     return false;
   }
@@ -1172,18 +969,14 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
   tmp_stream << "fast_cmd_pool_queue_size:" << fast_queue_size << "\r\n";
   tmp_stream << "fast_cmd_pool_max_queue_size:" << fast_max_queue << "\r\n";
   tmp_stream << "fast_cmd_pool_usage:" << std::fixed << std::setprecision(2) << fast_usage << "%\r\n";
-  
 
-   // 快池借用统计（新增）
+   // 快池借用统计
   if (g_pika_server->fast_pool_metrics_) {
     tmp_stream << "fast_cmd_pool_tasks_scheduled:" 
        << g_pika_server->fast_pool_metrics_->tasks_scheduled.load() << "\r\n";
     tmp_stream << "fast_cmd_pool_borrow_attempts:" 
        << g_pika_server->fast_pool_metrics_->borrow_attempts.load() << "\r\n";
-    tmp_stream << "fast_cmd_pool_successful_borrows:" 
-       << g_pika_server->fast_pool_metrics_->successful_borrows.load() << "\r\n";
   }
-
 
   // Slow cmd thread pool info
   if (g_pika_conf->slow_cmd_pool()) {
@@ -1196,23 +989,20 @@ void PikaServer::GetThreadPoolInfo(std::string* info) {
     tmp_stream << "slow_cmd_pool_queue_size:" << slow_queue_size << "\r\n";
     tmp_stream << "slow_cmd_pool_max_queue_size:" << slow_max_queue << "\r\n";
     tmp_stream << "slow_cmd_pool_usage:" << std::fixed << std::setprecision(2) << slow_usage << "%\r\n";
+
+    // 慢池借用统计
+    if (g_pika_server->slow_pool_metrics_) {
+      tmp_stream << "slow_cmd_pool_tasks_scheduled:" 
+        << g_pika_server->slow_pool_metrics_->tasks_scheduled.load() << "\r\n";
+      tmp_stream << "slow_cmd_pool_borrow_attempts:" 
+        << g_pika_server->slow_pool_metrics_->borrow_attempts.load() << "\r\n";
+    }
   } else {
     tmp_stream << "slow_cmd_pool_size:0\r\n";
     tmp_stream << "slow_cmd_pool_queue_size:0\r\n";
     tmp_stream << "slow_cmd_pool_max_queue_size:0\r\n";
     tmp_stream << "slow_cmd_pool_usage:0.00%\r\n";
   }
-
-    // 慢池借用统计（新增）
-  if (g_pika_server->slow_pool_metrics_) {
-    tmp_stream << "slow_cmd_pool_tasks_scheduled:" 
-       << g_pika_server->slow_pool_metrics_->tasks_scheduled.load() << "\r\n";
-    tmp_stream << "slow_cmd_pool_borrow_attempts:" 
-       << g_pika_server->slow_pool_metrics_->borrow_attempts.load() << "\r\n";
-    tmp_stream << "slow_cmd_pool_successful_borrows:" 
-       << g_pika_server->slow_pool_metrics_->successful_borrows.load() << "\r\n";
-  }
-  
   // Admin cmd thread pool info
   size_t admin_pool_size = g_pika_conf->admin_thread_pool_size();
   tmp_stream << "admin_cmd_pool_size:" << admin_pool_size << "\r\n";
@@ -2312,91 +2102,13 @@ void PikaServer::CacheConfigInit(cache::CacheConfig& cache_cfg) {
 void PikaServer::SetLogNetActivities(bool value) { pika_dispatch_thread_->SetLogNetActivities(value); }
 
 // 改进的快慢命令分离相关方法实现
-
-void PikaServer::AdjustBorrowThresholds() {
-  // 这个方法可以根据系统负载动态调整借用阈值
-  // 当前使用简单的队列饱和度来调整
-  
-  size_t fast_queue_size = ClientProcessorThreadPoolCurQueueSize();
-  size_t fast_max_queue = ClientProcessorThreadPoolMaxQueueSize();
-  size_t slow_queue_size = SlowCmdThreadPoolCurQueueSize();
-  size_t slow_max_queue = SlowCmdThreadPoolMaxQueueSize();
-  
-  if (fast_max_queue == 0 || slow_max_queue == 0) {
-    return;
-  }
-  
-  // 计算队列饱和度
-  double fast_saturation = static_cast<double>(fast_queue_size) / fast_max_queue;
-  double slow_saturation = static_cast<double>(slow_queue_size) / slow_max_queue;
-  
-  int current_threshold = g_pika_conf->threadpool_borrow_threshold_percent();
-  int new_threshold = current_threshold;
-  
-  // 如果两个线程池都很繁忙（饱和度>0.8），提高借用阈值（更难借用）
-  if (fast_saturation > 0.8 && slow_saturation > 0.8) {
-    new_threshold = std::min(90, current_threshold + 5);
-  }
-  // 如果两个线程池都很空闲（饱和度<0.3），降低借用阈值（更容易借用）
-  else if (fast_saturation < 0.3 && slow_saturation < 0.3) {
-    new_threshold = std::max(30, current_threshold - 5);
-  }
-  
-  // Note: Currently we don't have a SetThreadpoolBorrowThresholdPercent method in PikaConf
-  // So we just log the recommendation instead of actually changing the threshold
-  if (new_threshold != current_threshold) {
-    LOG(INFO) << "Recommend adjusting borrow threshold from " << current_threshold 
-              << "% to " << new_threshold << "% (fast_sat: " 
-              << std::fixed << std::setprecision(2) << fast_saturation * 100 
-              << "%, slow_sat: " << slow_saturation * 100 << "%)";
-  }
-}
-
-bool PikaServer::IsDynamicSlowCommand(const std::string& cmd_name) const {
-  if (!cmd_classifier_) {
-    return false;
-  }
-  return cmd_classifier_->IsSlowCommand(cmd_name);
-}
-
-void PikaServer::RecordCommandExecutionTime(const std::string& cmd_name, uint64_t duration_us) {
-  if (cmd_classifier_) {
-    cmd_classifier_->RecordExecutionTime(cmd_name, duration_us);
-  }
-  
-  // 同时记录到线程池指标中
-  // 注意：这里需要知道命令是在哪个线程池执行的，简化起见我们根据是否是慢命令来判断
-  if (IsDynamicSlowCommand(cmd_name) && slow_pool_metrics_) {
-    slow_pool_metrics_->RecordLatency(duration_us);
-    slow_pool_metrics_->tasks_completed++;
-  } else if (fast_pool_metrics_) {
-    fast_pool_metrics_->RecordLatency(duration_us);
-    fast_pool_metrics_->tasks_completed++;
-  }
-}
-
-void PikaServer::SetCommandRateLimit(double rate_per_sec) {
-  if (cmd_rate_limiter_) {
-    cmd_rate_limiter_->SetRate(rate_per_sec);
-    LOG(INFO) << "Command rate limit set to " << rate_per_sec << " commands/sec";
-  }
-}
-
-bool PikaServer::CheckCommandRateLimit() {
-  if (!cmd_rate_limiter_) {
-    return true;  // 如果没有限流器，总是允许
-  }
-  return cmd_rate_limiter_->TryAcquire(1.0);
-}
-
-std::string PikaServer::GetEnhancedThreadPoolMetrics() const {
+std::string PikaServer::GetEnhancedThreadPoolMetrics() {
   std::string info;
-  const_cast<PikaServer*>(this)->GetThreadPoolInfo(&info);
+  GetThreadPoolInfo(&info);
   
   std::stringstream ss;
   ss << info;
   
-  // 增强的指标（Prometheus格式）
   ss << "\n# Enhanced Thread Pool Metrics\n";
   
   if (fast_pool_metrics_) {
@@ -2405,18 +2117,6 @@ std::string PikaServer::GetEnhancedThreadPoolMetrics() const {
   
   if (slow_pool_metrics_ && g_pika_conf->slow_cmd_pool()) {
     ss << slow_pool_metrics_->ExportMetrics("slow");
-  }
-  
-  // 命令分类统计
-  if (cmd_classifier_) {
-    ss << "\n# Command Classification\n";
-    auto cmd_avg_times = cmd_classifier_->GetCommandAvgTimes();
-    for (const auto& [cmd_name, avg_time] : cmd_avg_times) {
-      bool is_slow = cmd_classifier_->IsSlowCommand(cmd_name);
-      ss << "command_avg_time{cmd=\"" << cmd_name 
-         << "\",type=\"" << (is_slow ? "slow" : "fast") << "\"} " 
-         << avg_time / 1000.0 << " # milliseconds\n";
-    }
   }
   
   return ss.str();
@@ -2430,8 +2130,6 @@ void PikaServer::ResetThreadPoolMetrics() {
   if (slow_pool_metrics_) {
     slow_pool_metrics_->Reset();
   }
-  
-  LOG(INFO) << "Thread pool metrics reset";
 }
 
 
@@ -2462,9 +2160,6 @@ bool PikaServer::IsFastPoolBusy() {
     return false;
   }
   int threadhold = g_pika_conf->threadpool_borrow_threshold_percent();
-  // [测试日志] 定期打印慢池状态
-  LOG_EVERY_N(INFO, 1000) << "[TEST-POOL] FastPool: " << current_size << "/" << max_size 
-                          << " (" << (max_size > 0 ? current_size * 100 / max_size : 0) << "%)";
   return current_size >= (max_size * threadhold / 100);
 }
 
@@ -2475,23 +2170,19 @@ bool PikaServer::IsFastPoolIdle() {
     return true;
   }
   int threshold = g_pika_conf->threadpool_idle_threshold_percent();
-    // [测试日志] 定期打印快池状态
-  LOG_EVERY_N(INFO, 1000) << "[TEST-POOL] FastPool: " << current_size << "/" << max_size 
-                          << " (" << (max_size > 0 ? current_size * 100 / max_size : 0) << "%)";
   return current_size <= (max_size * threshold / 100);
 }
 
-TaskPoolType PikaServer::DecidePoolType(const std::string& cmd_name, bool is_slow_cmd) {
+TaskPoolType PikaServer::DecidePoolType(bool is_slow_cmd) {
   if (!g_pika_conf->slow_cmd_pool()) {
     return TaskPoolType::kFastCmdPool;
   }
 
   bool borrow_enabled = g_pika_conf->threadpool_borrow_enable();
-
-  // 场景 A: 当前是 慢命令
+  TaskPoolType decision;
   if (is_slow_cmd) {
-    // 默认归宿：慢池
-    TaskPoolType decision = TaskPoolType::kSlowCmdPool;
+    // 默认慢池
+    decision = TaskPoolType::kSlowCmdPool;
 
     // 借用逻辑：慢池忙(Busy) 且 快池闲(Idle) -> 借用快池
     if (borrow_enabled && IsSlowPoolBusy() && IsFastPoolIdle()) {
@@ -2500,56 +2191,48 @@ TaskPoolType PikaServer::DecidePoolType(const std::string& cmd_name, bool is_slo
       // 更新 慢池 的借用指标 (代表慢池向外借力)
       if (slow_pool_metrics_) {
         slow_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
-        slow_pool_metrics_->successful_borrows.fetch_add(1, std::memory_order_relaxed);
       }
-      LOG_EVERY_N(INFO, 1000) << "Slow command '" << cmd_name << "' borrows fast pool";
     
-      // [测试日志] 慢命令借用快池
+      // 慢命令借用快池
       size_t slow_cur = SlowCmdThreadPoolCurQueueSize();
       size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
       size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();
       size_t fast_max = ClientProcessorThreadPoolMaxQueueSize();
       
-      LOG(WARNING) << "[TEST-BORROW] SLOW->FAST: cmd='" << cmd_name 
-                   << "' slow_queue=" << slow_cur << "/" << slow_max 
-                   << "(" << (slow_max > 0 ? slow_cur * 100 / slow_max : 0) << "%)"
-                   << " fast_queue=" << fast_cur << "/" << fast_max
-                   << "(" << (fast_max > 0 ? fast_cur * 100 / fast_max : 0) << "%)"
-                   << " total_borrows=" << slow_pool_metrics_->successful_borrows.load();
-
+      LOG(INFO) << "Slow cmd borrows fast pool (slow_queue: " 
+                << slow_cur << "/" << slow_max 
+                << ", fast_queue: " << fast_cur << "/" << fast_max << ")";
     }
-    return decision;
   } else {
     // 默认归宿：快池
-    TaskPoolType decision = TaskPoolType::kFastCmdPool;
+    decision = TaskPoolType::kFastCmdPool;
 
     // 借用逻辑：快池忙(Busy) 且 慢池闲(Idle) -> 借用慢池
-    // 注意：这里必须要求慢池非常“闲”才借用，防止快命令阻塞慢池中的长任务
     if (borrow_enabled && IsFastPoolBusy() && IsSlowPoolIdle()) {
       decision = TaskPoolType::kSlowCmdPool;
-
-      // 更新 [快池] 的借用指标 (代表快池向外借力)
+      // 更新借用指标 
       if (fast_pool_metrics_) {
         fast_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
-        fast_pool_metrics_->successful_borrows.fetch_add(1, std::memory_order_relaxed);
       }
-
-      LOG_EVERY_N(INFO, 1000) << "Fast command '" << cmd_name << "' borrows slow pool";
-    
-      // [测试日志] 快命令借用慢池
+      // 快命令借用慢池
       size_t slow_cur = SlowCmdThreadPoolCurQueueSize();
       size_t slow_max = SlowCmdThreadPoolMaxQueueSize();
       size_t fast_cur = ClientProcessorThreadPoolCurQueueSize();
       size_t fast_max = ClientProcessorThreadPoolMaxQueueSize();
-      
-      LOG(INFO) << "[TEST-BORROW] FAST->SLOW: cmd='" << cmd_name 
-                << "' fast_queue=" << fast_cur << "/" << fast_max 
-                << "(" << (fast_max > 0 ? fast_cur * 100 / fast_max : 0) << "%)"
-                << " slow_queue=" << slow_cur << "/" << slow_max
-                << "(" << (slow_max > 0 ? slow_cur * 100 / slow_max : 0) << "%)"
-                << " total_borrows=" << fast_pool_metrics_->successful_borrows.load();
 
+      LOG(INFO) << "Fast cmd borrows slow pool (fast_queue: " 
+                << fast_cur << "/" << fast_max 
+                << ", slow_queue: " << slow_cur << "/" << slow_max << ")";
     }
-    return decision;
   }
+  if (decision == TaskPoolType::kFastCmdPool) {
+    if (fast_pool_metrics_) {
+      fast_pool_metrics_->tasks_scheduled.fetch_add(1, std::memory_order_relaxed);
+    }
+  } else {
+    if (slow_pool_metrics_) {
+      slow_pool_metrics_->tasks_scheduled.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+  return decision;
 }

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -25,6 +25,7 @@
 #include "include/pika_monotonic_time.h"
 #include "include/pika_rm.h"
 #include "include/pika_server.h"
+#include "pstd/include/pstd_hash.h"
 
 using pstd::Status;
 extern PikaServer* g_pika_server;
@@ -355,13 +356,6 @@ PikaServer::PikaServer()
   bgslots_cleanup_thread_.set_thread_name("PikaServer::bgslots_cleanup_thread_");
   common_bg_thread_.set_thread_name("PikaServer::common_bg_thread_");
   key_scan_thread_.set_thread_name("PikaServer::key_scan_thread_");
-
-  int slot_num = g_pika_conf->default_slot_num();
-  // 这里判断的时候，能否认为没有配置的时候就没有使用sharding模式呢
-  if(slot_num <= 0){
-    slot_num = 1024;
-  }
-  virtual_slot_.resize(slot_num);
 }
 
 PikaServer::~PikaServer() {
@@ -1024,152 +1018,43 @@ void PikaServer::SetFirstMetaSync(bool v) {
 }
 
 void PikaServer::ScheduleClientPool(net::TaskFunc func, void* arg, bool is_slow_cmd, bool is_admin_cmd) {
-  // Apply rate limiting if enabled (only for non-admin commands)
-  if (!is_admin_cmd && !CheckCommandRateLimit()) {
-    // Rate limit exceeded, handle gracefully
-    auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
-    if (bg_arg) {
-      // Set error response for rate limiting
-      bg_arg->resp_ptr = std::make_shared<std::string>("-ERR Rate limit exceeded, try again later\r\n");
-      bg_arg->conn_ptr->WriteResp(*(bg_arg->resp_ptr));
-      delete bg_arg;
-    }
-    return;
-  }
-
-  // Admin commands always go to admin thread pool
   if (is_admin_cmd) {
-    if (pika_admin_cmd_thread_pool_) {
-      pika_admin_cmd_thread_pool_->Schedule(func, arg);
-    }
+    pika_admin_cmd_thread_pool_->Schedule(func, arg);
     return;
   }
-  
-  // Extract command info for dynamic classification and key affinity
-  auto bg_arg = static_cast<PikaClientConn::BgTaskArg*>(arg);
-  std::string cmd_name;
-  std::string key;
-  bool has_key = false;
-  bool key_affinity_to_slow = false;
-  
-  if (bg_arg && !bg_arg->redis_cmds.empty() && !bg_arg->redis_cmds[0].empty()) {
-    const auto& cmd_args = bg_arg->redis_cmds[0];
-    if (!cmd_args.empty()) {
-      cmd_name = cmd_args[0];
-      pstd::StringToLower(cmd_name);
-      
-      // Extract key for affinity routing
-      if (cmd_args.size() > 1) {
-        key = cmd_args[1];
-        has_key = true;
-        // Use improved consistent hashing for key affinity
-        // key_affinity_to_slow = IsKeyAffinityToSlow(key);
-      }
+  // 这里的速率判断后要做些什么
+  // if(cmd_rate_limiter_ && !cmd_rate_limiter_->TryAcquire(1.0)) {
+  //   p
+  // }
+
+  TaskPoolType target_pool = TaskPoolType::kFastCmdPool;
+  bool borrow_enabled = g_pika_conf->threadpool_borrow_enable();
+  if (is_slow_cmd && g_pika_conf->slow_cmd_pool()) {
+    target_pool = TaskPoolType::kSlowCmdPool; // 默认归宿
+
+    if (borrow_enabled && IsSlowPoolBusy() && IsFastPoolIdle()) {
+        target_pool = TaskPoolType::kFastCmdPool;
+        LOG_EVERY_N(INFO, 1000) << "Slow command borrows fast pool (Risk Taken)";
+    }
+  } 
+  else {
+    target_pool = TaskPoolType::kFastCmdPool; // 默认归宿
+    if (borrow_enabled && IsFastPoolBusy() && IsSlowPoolIdle()) {
+        target_pool = TaskPoolType::kSlowCmdPool;
+        LOG_EVERY_N(INFO, 1000) << "Fast command borrows slow pool";
     }
   }
-  
-  // Check if command is dynamically classified as slow
-  // Override static classification if dynamic classification exists
-  if (!cmd_name.empty() && cmd_classifier_) {
-    bool dynamic_is_slow = IsDynamicSlowCommand(cmd_name);
-    if (dynamic_is_slow) {
-      is_slow_cmd = true;
+
+  if (target_pool == TaskPoolType::kSlowCmdPool) {
+    if (slow_pool_metrics_) {
+        slow_pool_metrics_->tasks_scheduled.fetch_add(1, std::memory_order_relaxed);
     }
-  }
-  
-  // Check if thread pool borrowing is enabled
-  bool borrow_enable = g_pika_conf->threadpool_borrow_enable();
-  bool slow_cmd_pool_enable = g_pika_conf->slow_cmd_pool();
-  
-  // Update metrics before scheduling
-  if (is_slow_cmd && slow_pool_metrics_) {
-    slow_pool_metrics_->tasks_scheduled++;
-  } else if (fast_pool_metrics_) {
-    fast_pool_metrics_->tasks_scheduled++;
-  }
-  
-  // If borrowing or slow pool is disabled, use simple routing
-  if (!borrow_enable || !slow_cmd_pool_enable) {
-    if (is_slow_cmd && slow_cmd_pool_enable) {
-      pika_slow_cmd_thread_pool_->Schedule(func, arg);
-    } else {
-      pika_client_processor_->SchedulePool(func, arg);
-    }
-    return;
-  }
-
-  // Borrowing is enabled, check queue status
-  size_t slow_queue_size = SlowCmdThreadPoolCurQueueSize();
-  size_t slow_max_queue = SlowCmdThreadPoolMaxQueueSize();
-  size_t fast_queue_size = ClientProcessorThreadPoolCurQueueSize();
-  size_t fast_max_queue = ClientProcessorThreadPoolMaxQueueSize();
-
-  int borrow_threshold_percent = g_pika_conf->threadpool_borrow_threshold_percent();
-  int idle_threshold_percent = g_pika_conf->threadpool_idle_threshold_percent();
-
-  // Calculate thresholds
-  size_t slow_borrow_threshold = slow_max_queue * borrow_threshold_percent / 100;
-  size_t fast_borrow_threshold = fast_max_queue * borrow_threshold_percent / 100;
-  size_t slow_idle_threshold = slow_max_queue * idle_threshold_percent / 100;
-  size_t fast_idle_threshold = fast_max_queue * idle_threshold_percent / 100;
-
-  // Enhanced decision logic considering dynamic classification and improved key affinity
-  if (is_slow_cmd) {
-    // This is a slow command (either statically or dynamically classified)
-    if (has_key && !key_affinity_to_slow) {
-      // Key affinity is to fast pool, must use fast pool to maintain order
-      pika_client_processor_->SchedulePool(func, arg);
-    } else if (slow_queue_size >= slow_borrow_threshold && fast_queue_size <= fast_idle_threshold) {
-      // Slow pool is busy and fast pool is idle
-      if (has_key && key_affinity_to_slow) {
-        // Key belongs to slow pool, cannot borrow
-        pika_slow_cmd_thread_pool_->Schedule(func, arg);
-      } else {
-        // Can borrow from fast pool
-        if (slow_pool_metrics_) {
-          slow_pool_metrics_->borrow_attempts++;
-          slow_pool_metrics_->successful_borrows++;
-        }
-        pika_client_processor_->SchedulePool(func, arg);
-        LOG(INFO) << "Slow cmd " << cmd_name << " borrows fast pool (slow_queue: " << slow_queue_size 
-                  << "/" << slow_max_queue << ", fast_queue: " << fast_queue_size 
-                  << "/" << fast_max_queue << ")";
-      }
-    } else {
-      // Normal case: use slow pool
-      pika_slow_cmd_thread_pool_->Schedule(func, arg);
-    }
+    pika_slow_cmd_thread_pool_->Schedule(func, arg);
   } else {
-    // This is a fast command
-    if (has_key && key_affinity_to_slow) {
-      // Key affinity is to slow pool, must use slow pool to maintain order
-      pika_slow_cmd_thread_pool_->Schedule(func, arg);
-    } else if (fast_queue_size >= fast_borrow_threshold && slow_queue_size <= slow_idle_threshold) {
-      // Fast pool is busy and slow pool is idle
-      if (has_key && !key_affinity_to_slow) {
-        // Key belongs to fast pool, cannot borrow
-        pika_client_processor_->SchedulePool(func, arg);
-      } else {
-        // Can borrow from slow pool
-        if (fast_pool_metrics_) {
-          fast_pool_metrics_->borrow_attempts++;
-          fast_pool_metrics_->successful_borrows++;
-        }
-        pika_slow_cmd_thread_pool_->Schedule(func, arg);
-        LOG(INFO) << "Fast cmd " << cmd_name << " borrows slow pool (fast_queue: " << fast_queue_size 
-                  << "/" << fast_max_queue << ", slow_queue: " << slow_queue_size 
-                  << "/" << slow_max_queue << ")";
-      }
-    } else {
-      // Normal case: use fast pool
-      pika_client_processor_->SchedulePool(func, arg);
+    if (fast_pool_metrics_) {
+        fast_pool_metrics_->tasks_scheduled.fetch_add(1, std::memory_order_relaxed);
     }
-  }
-  
-  // Periodically adjust borrow thresholds based on load (every 100 commands)
-  static int command_counter = 0;
-  if (++command_counter % 100 == 0) {
-    AdjustBorrowThresholds();
+    pika_client_processor_->SchedulePool(func, arg);
   }
 }
 
@@ -2526,20 +2411,6 @@ void PikaServer::ResetThreadPoolMetrics() {
   LOG(INFO) << "Thread pool metrics reset";
 }
 
-int PikaServer::GetVirtualSlotID(const std::string& key){
-  if (key.empty() || virtual_slots_.empty()) {
-    return -1;
-  }
-  uint32_t crc = pstd::hash::crc32(0, key.data(), key.size());
-  return static_cast<int>(crc % virtual_slots_.size());
-}
-
-void PikaServer::ReleaseVirtualSlotID(int slot_id){
-  if(slot_id < 0 || slot_id >= virtual_slots_.size()){
-    return;
-  }
-  virtual_slots_[slot_id].active_count.fetch_sub(1, std::memory_order_release);
-}
 
 bool PikaServer::IsSlowPoolBusy() {
   size_t current_size = SlowCmdThreadPoolCurQueueSize();
@@ -2551,7 +2422,7 @@ bool PikaServer::IsSlowPoolBusy() {
   return current_size >= (max_size * threadhold / 100);
 }
 
-bool PikaServer::IsSlowPoolIdle(){
+bool PikaServer::IsSlowPoolIdle() {
   size_t current_size = SlowCmdThreadPoolCurQueueSize();
   size_t max_size = SlowCmdThreadPoolMaxQueueSize();
   if (max_size == 0) {
@@ -2571,7 +2442,7 @@ bool PikaServer::IsFastPoolBusy() {
   return current_size >= (max_size * threadhold / 100);
 }
 
-bool PikaServer::IsFastPoolIdle(){
+bool PikaServer::IsFastPoolIdle() {
   size_t current_size = ClientProcessorThreadPoolCurQueueSize();
   size_t max_size = ClientProcessorThreadPoolMaxQueueSize();
   if (max_size == 0) {
@@ -2579,4 +2450,51 @@ bool PikaServer::IsFastPoolIdle(){
   }
   int threshold = g_pika_conf->threadpool_idle_threshold_percent();
   return current_size <= (max_size * threshold / 100);
+}
+
+TaskPoolType PikaServer::DecidePoolType(const std::string& cmd_name, bool is_slow_cmd) {
+  if (!g_pika_conf->slow_cmd_pool()) {
+    return TaskPoolType::kFastCmdPool;
+  }
+
+  bool borrow_enabled = g_pika_conf->threadpool_borrow_enable();
+
+  // 场景 A: 当前是 慢命令 (Slow Command)
+  if (is_slow_cmd) {
+    // 默认归宿：慢池
+    TaskPoolType decision = TaskPoolType::kSlowCmdPool;
+
+    // 借用逻辑：慢池忙(Busy) 且 快池闲(Idle) -> 借用快池
+    if (borrow_enabled && IsSlowPoolBusy() && IsFastPoolIdle()) {
+      decision = TaskPoolType::kFastCmdPool;
+
+      // 更新 慢池 的借用指标 (代表慢池向外借力)
+      if (slow_pool_metrics_) {
+        slow_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
+        slow_pool_metrics_->successful_borrows.fetch_add(1, std::memory_order_relaxed);
+      }
+      
+      LOG_EVERY_N(INFO, 1000) << "Slow command '" << cmd_name << "' borrows fast pool";
+    }
+    return decision;
+  }
+  else {
+    // 默认归宿：快池
+    TaskPoolType decision = TaskPoolType::kFastCmdPool;
+
+    // 借用逻辑：快池忙(Busy) 且 慢池闲(Idle) -> 借用慢池
+    // 注意：这里必须要求慢池非常“闲”才借用，防止快命令阻塞慢池中的长任务
+    if (borrow_enabled && IsFastPoolBusy() && IsSlowPoolIdle()) {
+      decision = TaskPoolType::kSlowCmdPool;
+
+      // 更新 [快池] 的借用指标 (代表快池向外借力)
+      if (fast_pool_metrics_) {
+        fast_pool_metrics_->borrow_attempts.fetch_add(1, std::memory_order_relaxed);
+        fast_pool_metrics_->successful_borrows.fetch_add(1, std::memory_order_relaxed);
+      }
+
+      LOG_EVERY_N(INFO, 1000) << "Fast command '" << cmd_name << "' borrows slow pool";
+    }
+    return decision;
+  }
 }

--- a/tools/pika_migrate/conf/pika.conf
+++ b/tools/pika_migrate/conf/pika.conf
@@ -132,7 +132,7 @@ masterauth :
 # The [password of user], which is empty by default.
 # [NOTICE] If this user password is the same as admin password (including both being empty),
 # the value of this parameter will be ignored and all users are considered as administrators,
-# in this scenario, users are not subject to the restrictions imposed by the userblacklist.
+# in this scenario, users are not subject to the restrictions imposed by the userb lacklist.
 # PS: "admin password" refers to value of the parameter above: requirepass.
 # userpass :
 
@@ -146,6 +146,7 @@ masterauth :
 # Running Mode of Pika, The current version only supports running in "classic mode".
 # If set to 'classic', Pika will create multiple DBs whose number is the value of configure item "databases".
 instance-mode : classic
+
 
 # The number of databases when Pika runs in classic mode.
 # The default database id is DB 0. You can select a different one on


### PR DESCRIPTION
#3276
## 1. 概况

围绕“命令线程池借用”将命令处理拆分为快/慢线程池，并引入跨池借用机制，同时完善线程池相关的监控输出与在线配置能力，提升负载不均衡下的资源利用率与可观测性。

## 2. 核心功能点

### 2.1 快慢命令线程池分离（Fast / Slow）

命令处理任务在调度阶段会被分配到：

* **快池**：默认处理绝大多数命令
* **慢池**：当开启 `slow-cmd-pool` 且命令被判定为慢命令时使用（`slow-cmd-list`）

### 2.2 跨池借用（Borrow）调度策略

引入借用逻辑：当某池处于忙碌、另一池处于空闲时，允许把任务投递到对方池子以分担压力。

* 快池忙、慢池闲 → **FAST 借用 SLOW**
* 慢池忙、快池闲 → **SLOW 借用 FAST**

决策入口统一在 `PikaServer::DecidePoolType(...)`，路由入口在 `PikaServer::ScheduleClientPool(...)`。
在任务参数中记录 `pool_type`，并在执行入口将其写入连接上下文，使得：

1. 线程池统计（scheduled/active_tasks/latency）按实际执行池归属；
2. 能够针对线程池维度进行观察。

## 3. 忙闲判断指标

使用队列等待时间以及线程池任务队列占比作为判断指标；

**队列等待时间（queue-wait）EMA 指标**

* 排队等待时间：`queue_wait_us = dequeue_ts_ - enqueue_ts_`
* 使用 EMA（指数移动平均）对 `queue-wait` 做平滑计算。

**队列长度占比判断 busy/idle：**

* `threadpool-borrow-threshold-percent`
* `threadpool-idle-threshold-percent`

**活跃任务数占比** (`busy_by_active`)
   - 使用 `active_tasks` 实时追踪线程池正在执行的任务数
   - 当 `active_tasks >= (thread_num * 80%)` 时 → 认为忙碌


###  组合判定规则（用于借用 Busy/Idle）

* **Busy**：`busy = busy_by_queue || busy_by_ema || busy_by_active`
* **Idle**：`idle = idle_by_queue && idle_by_ema`

**Busy 判定：**
只要任一信号表明“忙”，就认为忙。

> `Busy = busy_by_queue || busy_by_ema || busy_by_active` 


**Idle 判定：更保守**
必须两个信号都表明“闲”，才认为该池是空闲，才允许借用。

> `Idle = idle_by_queue && idle_by_ema && idle_by_active`


## 4. 可观测性

**线程池运行信息（`info threadpool`）**
线程池信息输出增强，包含：

* **fast/slow pool**：`size`, `queue_size`, `max_queue_size`, `usage`
* **borrow 相关统计**：`borrow_attempts`
* **调度统计**：`tasks_scheduled`


## 5. 参数动态调整

### 5.1 新增/扩展的 CONFIG GET

支持查询：

* `threadpool-borrow-enable`
* `threadpool-borrow-threshold-percent`
* `threadpool-idle-threshold-percent`

### 5.2 新增/扩展的 CONFIG SET

支持在线设置：

* `thread-pool-size`（快池线程数动态调整，队列为空时允许）
* `slow-cmd-thread-pool-size`（慢池线程数动态调整，队列为空时允许）
* `threadpool-borrow-enable`
* `threadpool-borrow-threshold-percent`
* `threadpool-idle-threshold-percent`

## 6. pika.conf 新增配置项（线程池 EMA 参数）

在配置文件中新增以下参数，用于控制 EMA 与阈值（单位 microseconds）：

* `threadpool-ema-alpha-numerator`
* `threadpool-ema-alpha-denominator`
* `threadpool-fast-busy-threshold`
* `threadpool-fast-idle-threshold`
* `threadpool-slow-busy-threshold`
* `threadpool-slow-idle-threshold`

## 7. 调度链路（从接收请求到入池/借用）

1. 网络线程解析命令后，构造后台任务参数（包含 `redis_cmds`、`pool_type` 等）。
2. 调度入口 `ScheduleClientPool` 调用 `DecidePoolType` 选择目标池：
* 默认 fast/slow 分流
* 满足借用条件时进行跨池投递
