### PR TITLE
fix: some bugs for v4.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,9 +790,7 @@ message("pika GIT_DATE = ${PIKA_GIT_DATE}")
 message("pika GIT_TAG = ${PIKA_GIT_TAG}")
 message("pika BUILD_DATE = ${PIKA_BUILD_DATE}")
 
-set(PIKA_BUILD_VERSION_CC ${CMAKE_BINARY_DIR}/pika_build_version.cc
-        src/pika_cache_load_thread.cc
-        )
+set(PIKA_BUILD_VERSION_CC ${CMAKE_BINARY_DIR}/pika_build_version.cc)
 message("PIKA_BUILD_VERSION_CC : " ${PIKA_BUILD_VERSION_CC})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/build_version.cc.in ${PIKA_BUILD_VERSION_CC} @ONLY)
 

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -417,7 +417,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHKeys, std::move(hkeysptr)));
   ////HLenCmd
   std::unique_ptr<Cmd> hlenptr =
-      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash  | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
+      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHLen, std::move(hlenptr)));
   ////HMgetCmd
   std::unique_ptr<Cmd> hmgetptr =

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -417,7 +417,7 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHKeys, std::move(hkeysptr)));
   ////HLenCmd
   std::unique_ptr<Cmd> hlenptr =
-      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash | kCmdFlagsUpdateCache | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
+      std::make_unique<HLenCmd>(kCmdNameHLen, 2, kCmdFlagsRead |  kCmdFlagsHash  | kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameHLen, std::move(hlenptr)));
   ////HMgetCmd
   std::unique_ptr<Cmd> hmgetptr =

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -451,7 +451,7 @@ int PikaConf::Load() {
   rate_limiter_auto_tuned_ = at == "yes" || at.empty();
   // if rate limiter autotune enable, `rate_limiter_bandwidth_` will still be respected as an upper-bound.
   if (rate_limiter_auto_tuned_) {
-    rate_limiter_bandwidth_ = 10 * 1024 * 1024 * 1024; // 10GB/s
+    rate_limiter_bandwidth_ = 10LL * 1024 * 1024 * 1024; // 10GB/s
   }
 
   // max_write_buffer_num

--- a/src/storage/include/storage/storage_define.h
+++ b/src/storage/include/storage/storage_define.h
@@ -78,6 +78,7 @@ inline char* EncodeUserKey(const Slice& user_key, char* dst_ptr, size_t nzero) {
   }
   if (pos != user_key.size()) {
     memcpy(dst_ptr, user_data + pos, user_key.size() - pos);
+    dst_ptr += user_key.size() - pos;
   }
 
   memcpy(dst_ptr, kEncodedKeyDelim, 2);


### PR DESCRIPTION
#3275
1. CMakeLists.txt 移除不需要的文件
2.修复\x00 set error
3.fix rate_limiter_bandwidth_ overflow
4.fix ttl error for hlen update cache（后续还要处理其他命令，未完成）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential overflow issue in rate limiter bandwidth calculation on 32-bit systems
  * Fixed user key encoding to correctly process remaining data bytes

* **Performance**
  * Adjusted HLen command caching strategy for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->