### PR TITLE
fix: When getting the key in the slot where migration failed, codis-p…

### DIFF
--- a/codis/pkg/proxy/backend.go
+++ b/codis/pkg/proxy/backend.go
@@ -269,8 +269,9 @@ func (bc *BackendConn) run() {
 }
 
 var (
-	errRespMasterDown = []byte("MASTERDOWN")
-	errRespLoading    = []byte("LOADING")
+	errRespMasterDown        = []byte("MASTERDOWN")
+	errRespLoading           = []byte("LOADING")
+	errRespSlotMigrateClosed = []byte("ERR please open slotmigrate and reload slot")
 )
 
 func (bc *BackendConn) loopReader(tasks <-chan *Request, c *redis.Conn, round int) (err error) {
@@ -298,6 +299,11 @@ func (bc *BackendConn) loopReader(tasks <-chan *Request, c *redis.Conn, round in
 			case bytes.HasPrefix(resp.Value, errRespLoading):
 				if bc.state.CompareAndSwap(stateConnected, stateDataStale) {
 					log.Warnf("backend conn [%p] to %s, db-%d state = DataStale, caused by 'LOADING'",
+						bc, bc.addr, bc.database)
+				}
+			case bytes.HasPrefix(resp.Value, errRespSlotMigrateClosed):
+				if bc.state.CompareAndSwap(stateConnected, stateDataStale) {
+					log.Warnf("backend conn [%p] to %s, db-%d state = DataStale, caused by 'slotmigrate disabled'",
 						bc, bc.addr, bc.database)
 				}
 			}


### PR DESCRIPTION
#3280
[[…roxy exited abnormally](https://github.com/OpenAtomFoundation/pikiwidb/issues/3205)](https://github.com/OpenAtomFoundation/pikiwidb/issues/3205)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for backend connections to properly detect and log warnings when slot migration is disabled, ensuring correct connection state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->