### PR TITLE
fix:When Codis deletes a key, deletion fails for the key in Pika slot…

### DIFF
--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -206,13 +206,26 @@ void DelCmd::DoInitial() {
 }
 
 void DelCmd::Do() {
+  // 先获取所有键的类型
+  std::map<std::string, std::string> key_type_map;
+  for (const auto& key : keys_) {
+    std::string type;
+    int result = GetKeyType(key, type, db_);
+    if (result > 0) {
+      key_type_map[key] = type;
+    }
+  }
+  
+  // 然后删除键
   int64_t count = db_->storage()->Del(keys_);
+  
   if (count >= 0) {
     res_.AppendInteger(count);
     s_ = rocksdb::Status::OK();
-    std::vector<std::string>::const_iterator it;
-    for (it = keys_.begin(); it != keys_.end(); it++) {
-      RemSlotKey(*it, db_);
+    
+    // 使用预先获取的类型信息从 slotKey 中移除
+    for (const auto& [key, type] : key_type_map) {
+      RemSlotKeyByType(type, key, db_);
     }
   } else {
     res_.SetRes(CmdRes::kErrOther, "delete error");

--- a/src/pika_slot_command.cc
+++ b/src/pika_slot_command.cc
@@ -635,7 +635,7 @@ void RemSlotKeyByType(const std::string& type, const std::string& key, const std
   std::vector<std::string> members;
   members.emplace_back(type + key);
   rocksdb::Status s = db->storage()->SRem(slot_key, members, &res);
-  if (!s.ok()) {
+  if (!s.ok() && !s.IsNotFound()) {
     LOG(ERROR) << "srem key[" << key << "] from slotKey[" << slot_key << "] failed, error: " << s.ToString();
     return;
   }
@@ -643,7 +643,7 @@ void RemSlotKeyByType(const std::string& type, const std::string& key, const std
   if (hastag) {
     std::string tag_key = GetSlotsTagKey(crc);
     s = db->storage()->SRem(tag_key, members, &res);
-    if (!s.ok()) {
+    if (!s.ok() && !s.IsNotFound()) {
       LOG(ERROR) << "srem key[" << key << "] from tagKey[" << tag_key << "] failed, error: " << s.ToString();
       return;
     }
@@ -761,17 +761,12 @@ void RemSlotKey(const std::string& key, const std::shared_ptr<DB>& db) {
 int GetKeyType(const std::string& key, std::string& key_type, const std::shared_ptr<DB>& db) {
   enum storage::DataType type;
   rocksdb::Status s = db->storage()->GetType(key, type);
-  if (!s.ok()) {
-    LOG(WARNING) << "Get key type error: " << key << " " << s.ToString();
+  if (!s.ok() || type == storage::DataType::kNones) {
+    LOG(WARNING) << "Get key type error: " << key << " type: " << static_cast<int>(type);
     key_type = "";
     return -1;
   }
   auto key_type_char = storage::DataTypeToTag(type);
-  if (key_type_char == DataTypeToTag(storage::DataType::kNones)) {
-    LOG(WARNING) << "Get key type error: " << key;
-    key_type = "";
-    return -1;
-  }
   key_type = key_type_char;
   return 1;
 }

--- a/src/pstd/CMakeLists.txt
+++ b/src/pstd/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.18)
 set (CMAKE_CXX_STANDARD 17)
 project (pstd)
 
-# 强制使用用户自定的 memcmp
 add_compile_options("-fno-builtin-memcmp -pipe")
 
 

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -1012,6 +1012,9 @@ class Storage {
   int64_t Exists(const std::vector<std::string>& keys);
 
   // Return the key exists type count
+  // Del keys and return deleted keys' types
+  int64_t Del(const std::vector<std::string>& keys, std::vector<std::pair<std::string, std::string>>* key_types);
+
   // return param type_status: return every type status
   int64_t IsExist(const Slice& key, std::map<DataType, Status>* type_status);
 

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -1193,17 +1193,32 @@ int32_t Storage::Expire(const Slice& key, int64_t ttl_millsec) {
 }
 
 
-int64_t Storage::Del(const std::vector<std::string>& keys) {
+int64_t Storage::Del(const std::vector<std::string>& keys, std::vector<std::pair<std::string, std::string>>* key_types) {
   Status s;
   int64_t count = 0;
   for (const auto& key : keys) {
     auto& inst = GetDBInstance(key);
+    // 先获取类型
+    if (key_types != nullptr) {
+      enum DataType type;
+      inst->GetType(key, type);
+      if (type != DataType::kNones) {
+        key_types->emplace_back(key, std::string(1, DataTypeToTag(type)));
+      } else {
+        key_types->emplace_back(key, "");
+      }
+    }
+    // 删除键
     s = inst->Del(key);
     if (s.ok()) {
       count++;
     }
   }
   return count;
+}
+
+int64_t Storage::Del(const std::vector<std::string>& keys) {
+  return Del(keys, nullptr);
 }
 
 int64_t Storage::Exists(const std::vector<std::string>& keys) {


### PR DESCRIPTION
#3224
… key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in slot cleanup operations to gracefully ignore certain storage errors.
  * Enhanced deletion operations with better type detection and validation.

* **Performance Improvements**
  * Optimized deletion process through pre-fetched key type information.

* **Chores**
  * Removed obsolete configuration comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->