### PR TITLE
fix: Fix data correctness issues in full replication (rsync)

### DIFF
--- a/include/rsync_client.h
+++ b/include/rsync_client.h
@@ -112,7 +112,11 @@ class RsyncWriter {
  public:
   RsyncWriter(const std::string& filepath) {
     filepath_ = filepath;
-    fd_ = open(filepath.c_str(), O_RDWR | O_APPEND | O_CREAT, 0644);
+    // NOTE: do NOT use O_APPEND here. rsync writes each chunk to an explicit
+    // offset via pwrite(). O_APPEND would force every write to the end of the
+    // file, ignoring the offset, which corrupts the file on retry / resumed
+    // transfer / stale-file scenarios (holes, duplicated or misplaced data).
+    fd_ = open(filepath.c_str(), O_RDWR | O_CREAT, 0644);
   }
   ~RsyncWriter() {}
   Status Write(uint64_t offset, size_t n, const char* data) {
@@ -120,7 +124,7 @@ class RsyncWriter {
     size_t left = n;
     Status s;
     while (left != 0) {
-      ssize_t done = write(fd_, ptr, left);
+      ssize_t done = pwrite(fd_, ptr, left, offset);
       if (done < 0) {
         if (errno == EINTR) {
           continue;

--- a/include/rsync_server.h
+++ b/include/rsync_server.h
@@ -115,6 +115,10 @@ class RsyncReader {
     memcpy(data, block_data_ + offset_in_block, copy_count);
     *bytes_read = copy_count;
     *is_eof = (offset + copy_count == total_size_);
+    // Compute a per-chunk checksum so the client can detect corruption of this
+    // response (e.g. a bit flip that slips past the TCP checksum). Previously
+    // this was left as an empty string, so the client had nothing to verify.
+    *checksum = pstd::md5(std::string(data, copy_count));
     return pstd::Status::OK();
   }
 

--- a/src/rsync_client.cc
+++ b/src/rsync_client.cc
@@ -239,7 +239,22 @@ Status RsyncClient::CopyRemoteFile(const std::string& filename, int index) {
         return s;
       }
 
-      s = writer->Write((uint64_t)offset, ret_count, resp->file_resp().data().c_str());
+      // Verify the per-chunk checksum before writing to disk. Older masters may
+      // return an empty checksum; in that case we keep backward compatibility by
+      // skipping verification. A mismatch means this response was corrupted in
+      // transit, so retry the same offset instead of persisting bad data.
+      const std::string& expected_checksum = resp->file_resp().checksum();
+      if (!expected_checksum.empty()) {
+        std::string actual_checksum = pstd::md5(std::string(resp->file_resp().data().data(), ret_count));
+        if (actual_checksum != expected_checksum) {
+          LOG(WARNING) << "rsync client checksum mismatch, filename: " << filename
+                       << ", offset: " << offset << ", retry";
+          retries++;
+          continue;
+        }
+      }
+
+      s = writer->Write((uint64_t)offset, ret_count, resp->file_resp().data().data());
       if (!s.ok()) {
         LOG(WARNING) << "rsync client write file error";
         break;


### PR DESCRIPTION
fix #3263
本 PR 修复了全量同步链路上两个可能导致从库数据损坏且不被发现的问题。

### 1. 写文件忽略偏移,导致数据错位

`RsyncWriter` 此前以 `O_APPEND` 方式打开文件并使用 `write()`,传入的 `offset` 参数从未真正参与定位,每次写入都被强制追加到文件末尾。在请求重试、断点续传或旧文件残留的场景下,数据会写到错误位置,造成文件空洞、内容重复或错位。

**修复**:移除 `O_APPEND`,将 `write()` 改为 `pwrite()` 按显式偏移写入,保证每个 chunk 落到正确位置。

### 2. rsync 缺少 chunk 级校验,损坏数据静默写入

传输链路两端都没有做 chunk 校验:server 端虽然在响应里预留了 `checksum` 字段,但从未计算(只填了空字符串);client 端也完全没有校验,拿到数据直接写盘。这意味着即使某个 chunk 在传输中被损坏(TCP 校验存在漏检概率),从库也会照单全收。

**修复**:

- server 端在读取 chunk 时计算 MD5 并填入 `checksum` 字段;
- client 端写盘前重算 MD5 并与响应中的 `checksum` 比对,不一致则重试当前偏移,避免损坏数据落盘。

### 兼容性

client 端仅在 `checksum` 非空时才做校验,旧版本 master 返回空校验值时自动跳过,新 client 连接旧 master 不受影响。

### 涉及文件

- `include/rsync_client.h` — `RsyncWriter` 改用 `pwrite` 按偏移写入
- `include/rsync_server.h` — `RsyncReader::Read` 计算 chunk MD5
- `src/rsync_client.cc` — 写盘前校验 chunk checksum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file transfer reliability by writing received data to the correct file position.
  * Added per-chunk integrity checks so corrupted data is detected and retried automatically.
  * Preserved compatibility with older responses that do not include checksum data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->