### PR TITLE
fix: correct sorted set range cache behavior

### DIFF
--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -538,11 +538,15 @@ void InitCmdTable(CmdTable* cmd_table) {
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrange, std::move(zrevrangeptr)));
   ////ZRangebyscoreCmd
   std::unique_ptr<Cmd> zrangebyscoreptr = std::make_unique<ZRangebyscoreCmd>(
-      kCmdNameZRangebyscore, -4, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsSlow);
+      kCmdNameZRangebyscore, -4,
+      kCmdFlagsRead | kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsReadCache |
+          kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRangebyscore, std::move(zrangebyscoreptr)));
   ////ZRevrangebyscoreCmd
   std::unique_ptr<Cmd> zrevrangebyscoreptr = std::make_unique<ZRevrangebyscoreCmd>(
-      kCmdNameZRevrangebyscore, -4, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsSlow);
+      kCmdNameZRevrangebyscore, -4,
+      kCmdFlagsRead | kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsReadCache |
+          kCmdFlagsSlow);
   cmd_table->insert(
       std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrangebyscore, std::move(zrevrangebyscoreptr)));
   ////ZCountCmd
@@ -574,12 +578,16 @@ void InitCmdTable(CmdTable* cmd_table) {
       std::make_unique<ZScoreCmd>(kCmdNameZScore, 3, kCmdFlagsRead |  kCmdFlagsZset |kCmdFlagsDoThroughDB | kCmdFlagsFast | kCmdFlagsReadCache);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZScore, std::move(zscoreptr)));
   ////ZRangebylexCmd
-  std::unique_ptr<Cmd> zrangebylexptr =
-      std::make_unique<ZRangebylexCmd>(kCmdNameZRangebylex, -4, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsSlow);
+  std::unique_ptr<Cmd> zrangebylexptr = std::make_unique<ZRangebylexCmd>(
+      kCmdNameZRangebylex, -4,
+      kCmdFlagsRead | kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsReadCache |
+          kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRangebylex, std::move(zrangebylexptr)));
   ////ZRevrangebylexCmd
   std::unique_ptr<Cmd> zrevrangebylexptr = std::make_unique<ZRevrangebylexCmd>(
-      kCmdNameZRevrangebylex, -4, kCmdFlagsRead |  kCmdFlagsZset | kCmdFlagsSlow);
+      kCmdNameZRevrangebylex, -4,
+      kCmdFlagsRead | kCmdFlagsZset | kCmdFlagsDoThroughDB | kCmdFlagsUpdateCache | kCmdFlagsReadCache |
+          kCmdFlagsSlow);
   cmd_table->insert(std::pair<std::string, std::unique_ptr<Cmd>>(kCmdNameZRevrangebylex, std::move(zrevrangebylexptr)));
   ////ZLexcountCmd
   std::unique_ptr<Cmd> zlexcountptr =

--- a/src/pika_zset.cc
+++ b/src/pika_zset.cc
@@ -1317,10 +1317,14 @@ void ZRevrangebylexCmd::ReadCache() {
   STAGE_TIMER_GUARD(cache_duration_ms, true);
   auto s = db_->cache()->ZRevrangebylex(key_, min_, max_, &members, db_);
   if (s.ok()) {
-    auto size = count_ < members.size() ? count_ : members.size();
-    res_.AppendArrayLen(static_cast<int64_t >(size));
-    for (int i = 0; i < size; ++i) {
-      res_.AppendString(members[i]);
+    FitLimit(count_, offset_, static_cast<int64_t>(members.size()));
+
+    res_.AppendArrayLen(count_);
+    int64_t index = offset_;
+    int64_t end = offset_ + count_;
+    for (; index < end; index++) {
+      res_.AppendStringLenUint64(members[index].size());
+      res_.AppendContent(members[index]);
     }
   } else if (s.IsNotFound()) {
     res_.SetRes(CmdRes::kCacheMiss);

--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -2,6 +2,7 @@ package pika_integration
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	. "github.com/bsm/ginkgo/v2"
@@ -343,6 +344,35 @@ var _ = Describe("Cache test", func() {
 		Expect(MultiMget.Err()).NotTo(HaveOccurred())
 		Expect(MultiMget.Val()).To(Equal([]interface{}{"a", nil, "c", "d"}))
 	})
+	It("should apply LIMIT offset to cached ZREVRANGEBYLEX results", func() {
+		members := []redis.Z{
+			{Score: 0, Member: "a"},
+			{Score: 0, Member: "b"},
+			{Score: 0, Member: "c"},
+			{Score: 0, Member: "d"},
+			{Score: 0, Member: "e"},
+			{Score: 0, Member: "f"},
+		}
+		Expect(client.ZAdd(ctx, "letters", members...).Err()).NotTo(HaveOccurred())
+
+		result, err := client.Do(ctx, "ZREVRANGEBYLEX", "letters", "+", "-", "LIMIT", 2, 2).StringSlice()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]string{"d", "c"}))
+
+		Eventually(func() bool {
+			info, infoErr := client.Info(ctx, "cache").Result()
+			return infoErr == nil && strings.Contains(info, "cache_keys:1")
+		}, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		result, err = client.Do(ctx, "ZREVRANGEBYLEX", "letters", "+", "-", "LIMIT", 2, 2).StringSlice()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]string{"d", "c"}))
+
+		result, err = client.Do(ctx, "ZREVRANGEBYLEX", "letters", "+", "-", "LIMIT", 4, 2).StringSlice()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]string{"b", "a"}))
+	})
+
 	It("MGET against non-string key", func() {
 		SetMultiKey := client.Set(ctx, "foo{t}", "BAR", 3000*time.Millisecond)
 		Expect(SetMultiKey.Err()).NotTo(HaveOccurred())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached reverse lexicographical sorted-set range results so `LIMIT` offsets and counts are applied consistently.
  * Corrected response formatting for cached `ZREVRANGEBYLEX` results.
  * Improved caching support for sorted-set range-by-score and range-by-lex commands.
  * Ensured repeated queries return the same limited results whether served from storage or cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->