### PR TITLE
fix: preserve key casing in slots migration wrapper

### DIFF
--- a/src/pika_slot_command.cc
+++ b/src/pika_slot_command.cc
@@ -1501,7 +1501,6 @@ void SlotsMgrtExecWrapperCmd::DoInitial() {
   }
   auto it = argv_.begin() + 1;
   key_ = *it++;
-  pstd::StringToLower(key_);
   return;
 }
 

--- a/tools/pika_migrate/src/pika_slot_command.cc
+++ b/tools/pika_migrate/src/pika_slot_command.cc
@@ -1501,7 +1501,6 @@ void SlotsMgrtExecWrapperCmd::DoInitial() {
   }
   auto it = argv_.begin() + 1;
   key_ = *it++;
-  pstd::StringToLower(key_);
   return;
 }
 


### PR DESCRIPTION
fix: #3291 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration commands now preserve the key’s original letter casing instead of converting it to lowercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->